### PR TITLE
fix #33 - replace recursive pack scan with O(1) path-based lookup

### DIFF
--- a/backend/apps/packs/services.py
+++ b/backend/apps/packs/services.py
@@ -33,29 +33,52 @@ from .models import LibraryPack, LibraryPackDependency, PendingFrameworkOverlay
 logger = logging.getLogger(__name__)
 
 
-def _find_pack_dir(base_path: Path, slug: str) -> Path | None:
-    """Recursively find a pack directory by slug."""
-    for item in base_path.iterdir():
-        if not item.is_dir():
-            continue
+def _find_pack_dir(base_path: Path, pack_path: str) -> Path | None:
+    """
+    Resolve a pack's directory from its declared relative path.
 
-        pack_yaml = item / "pack.yaml"
-        if pack_yaml.exists():
-            try:
-                with open(pack_yaml) as f:
-                    pack_data = yaml.safe_load(f)
-                pack_meta = pack_data.get("pack", {})
-                if pack_meta.get("slug", item.name) == slug:
-                    return item
-            except Exception:
-                pass
+    The path is the value of `pack.path` in pack.yaml — a relative path
+    from the libraries/packs root to the pack directory. This is an O(1)
+    lookup: no scanning or YAML parsing of unrelated packs is needed.
 
-        # Check subdirectories (for nested structure)
-        result = _find_pack_dir(item, slug)
-        if result:
-            return result
-
+    Returns None if the directory does not exist or has no pack.yaml.
+    """
+    if not pack_path:
+        return None
+    pack_dir = base_path / pack_path
+    if pack_dir.is_dir() and (pack_dir / "pack.yaml").exists():
+        return pack_dir
     return None
+
+
+def _resolve_slug_to_path(libraries_path: Path, slug: str) -> str | None:
+    """
+    Resolve a pack slug to its declared relative path.
+
+    Used by legacy slug-based APIs (preview, available_overlays) where the
+    caller has only a slug. Walks the libraries tree once via
+    discover_packs_from_source() and returns the first match. Issues a
+    warning when multiple packs share the slug — disambiguation requires
+    using the path-based API directly.
+
+    Returns None if no pack with the given slug is found.
+    """
+    matches = []
+    for pack_info in discover_packs_from_source():
+        if pack_info.slug == slug:
+            matches.append(pack_info)
+
+    if not matches:
+        return None
+
+    if len(matches) > 1:
+        paths = [m.relative_path for m in matches]
+        logger.warning(
+            f"Multiple packs found with slug '{slug}': {paths}. "
+            f"Using first match. Pass an explicit path to disambiguate."
+        )
+
+    return matches[0].relative_path
 
 
 @dataclass
@@ -72,7 +95,13 @@ class PackInfo:
     author: str = ""
     industries: list = field(default_factory=list)
     tags: list = field(default_factory=list)
+    # Absolute filesystem path to the pack directory (for callers that
+    # need to load files from disk).
     path: str = ""
+    # Declared relative path from libraries/packs root, taken from
+    # pack.yaml's `pack.path` field. Used for O(1) lookup and dependency
+    # disambiguation. Empty when pack.yaml omits the field (older packs).
+    relative_path: str = ""
     is_in_database: bool = False
     database_version: Optional[str] = None
     component_count: int = 0
@@ -94,6 +123,7 @@ class PackInfo:
             "industries": self.industries,
             "tags": self.tags,
             "path": self.path,
+            "relative_path": self.relative_path,
             "is_in_database": self.is_in_database,
             "database_version": self.database_version,
             "needs_update": self.is_in_database and self.database_version != self.version,
@@ -163,8 +193,18 @@ def _count_items_in_file(file_path: Path, key: str) -> int:
         return 0
 
 
-def _discover_pack(pack_dir: Path, existing_packs: dict) -> PackInfo | None:
-    """Discover a pack from its directory."""
+def _discover_pack(pack_dir: Path, libraries_path: Path, existing_packs: dict) -> PackInfo | None:
+    """Discover a pack from its directory.
+
+    Path invariants from issue #33 are checked here so problems surface
+    in discovery output, not just at import time:
+      - missing `path` field → warning, fall back to disk location
+      - declared path's last segment != slug → warning
+      - declared path != actual on-disk location → warning
+
+    Discovery still returns a PackInfo for invalid packs so users can
+    see them in listings; the import path enforces these as errors.
+    """
     pack_yaml = pack_dir / "pack.yaml"
     if not pack_yaml.exists():
         return None
@@ -175,6 +215,36 @@ def _discover_pack(pack_dir: Path, existing_packs: dict) -> PackInfo | None:
 
         pack_meta = pack_data.get("pack", {})
         slug = pack_meta.get("slug", pack_dir.name)
+
+        # Resolve the declared path. If pack.yaml omits `path`, fall back
+        # to the actual location on disk so older packs keep working.
+        # Validation in validate_pack() will flag the missing field.
+        declared_path = pack_meta.get("path", "")
+        actual_relative_path = str(pack_dir.relative_to(libraries_path)).replace("\\", "/")
+
+        if not declared_path:
+            logger.warning(
+                f"Pack at {actual_relative_path} is missing the required "
+                f"`path` field in pack.yaml — falling back to disk location"
+            )
+            relative_path = actual_relative_path
+        else:
+            declared_normalized = declared_path.replace("\\", "/").strip("/")
+            relative_path = declared_normalized
+
+            last_segment = declared_normalized.split("/")[-1]
+            if slug and last_segment != slug:
+                logger.warning(
+                    f"Pack at {actual_relative_path}: declared path "
+                    f"'{declared_path}' last segment '{last_segment}' "
+                    f"does not match slug '{slug}'"
+                )
+
+            if declared_normalized != actual_relative_path:
+                logger.warning(
+                    f"Pack at {actual_relative_path}: declared path "
+                    f"'{declared_path}' does not match actual location"
+                )
 
         # Count items from separate files
         component_count = _count_items_in_file(pack_dir / "components.yaml", "components")
@@ -194,6 +264,7 @@ def _discover_pack(pack_dir: Path, existing_packs: dict) -> PackInfo | None:
             industries=pack_meta.get("industries", []),
             tags=pack_meta.get("tags", []),
             path=str(pack_dir),
+            relative_path=relative_path,
             is_in_database=slug in existing_packs,
             database_version=existing_packs.get(slug),
             component_count=component_count,
@@ -234,7 +305,7 @@ def discover_packs_from_source() -> list[PackInfo]:
 
             # Check if this directory is a pack (has pack.yaml)
             if (item / "pack.yaml").exists():
-                pack_info = _discover_pack(item, existing_packs)
+                pack_info = _discover_pack(item, libraries_path, existing_packs)
                 if pack_info:
                     packs.append(pack_info)
             else:
@@ -243,18 +314,34 @@ def discover_packs_from_source() -> list[PackInfo]:
 
     scan_directory(libraries_path)
 
-    # Resolve depends_on slugs to {slug, name, is_imported} dicts
-    pack_by_slug = {p.slug: p for p in packs}
+    # Resolve depends_on entries to {slug, name, is_imported} dicts.
+    # Dependencies can reference packs in two ways:
+    #   1. By slug only (legacy): `depends_on: [pack-slug]` or
+    #      `depends_on: [{pack: pack-slug, version: "^1.0.0"}]`
+    #   2. By slug + path (disambiguating): `depends_on: [{pack: pack-slug,
+    #      path: frameworks/pack-slug, version: "^1.0.0"}]`
+    # The path-based form is required when multiple packs share a slug on
+    # disk; without it, the resolver picks the first match.
+    pack_by_path = {p.relative_path: p for p in packs if p.relative_path}
+    pack_by_slug: dict[str, PackInfo] = {}
+    for p in packs:
+        # Keep the first occurrence — disambiguation happens via `path`.
+        pack_by_slug.setdefault(p.slug, p)
+
     for pack_info in packs:
         resolved_dependencies = []
         for dep_entry in pack_info.depends_on:
             if isinstance(dep_entry, str):
                 dep_slug = dep_entry
+                dep_path = ""
             else:
                 dep_slug = dep_entry.get("pack", dep_entry.get("slug", ""))
-            dep = pack_by_slug.get(dep_slug)
+                dep_path = dep_entry.get("path", "")
+
+            dep = pack_by_path.get(dep_path) if dep_path else pack_by_slug.get(dep_slug)
             resolved_dependencies.append({
                 "slug": dep_slug,
+                "path": dep_path or (dep.relative_path if dep else ""),
                 "name": dep.name if dep else dep_slug,
                 "is_imported": dep_slug in existing_packs,
             })
@@ -285,7 +372,11 @@ def get_pack_preview_from_source(slug: str) -> dict | None:
     if not libraries_path.exists():
         return None
 
-    pack_dir = _find_pack_dir(libraries_path, slug)
+    pack_relative_path = _resolve_slug_to_path(libraries_path, slug)
+    if not pack_relative_path:
+        return None
+
+    pack_dir = _find_pack_dir(libraries_path, pack_relative_path)
     if not pack_dir:
         return None
 
@@ -591,12 +682,13 @@ def validate_pack(pack_path: Path) -> ValidationResult:
     errors = []
     warnings = []
 
-    # =========================================================================
     # Structural checks
-    # =========================================================================
 
-    # Required metadata fields
-    required_metadata = ["slug", "name", "version", "pack_type"]
+    # Required metadata fields. The `path` field was added to make pack
+    # resolution O(1) (see issue #33) — it must be present so the
+    # discovery layer can locate this pack without scanning every
+    # pack.yaml in the tree.
+    required_metadata = ["slug", "name", "version", "pack_type", "path"]
     for required_field in required_metadata:
         if required_field not in pack_meta:
             errors.append(ValidationError(
@@ -606,6 +698,60 @@ def validate_pack(pack_path: Path) -> ValidationResult:
                 reference=required_field,
                 message=f"Missing required field: {required_field}",
             ))
+
+    # Path validation. The `path` field is the source of truth for where
+    # the pack lives under libraries/packs. Two invariants must hold:
+    #   1. The last segment of the path equals the slug. The folder name
+    #      is meaningful and must match the slug, so paths cannot rename
+    #      the pack out from under callers.
+    #   2. The declared path matches where the pack.yaml actually lives
+    #      on disk. Otherwise lookups by path would resolve to a
+    #      different directory than the one declaring this slug.
+    declared_path = pack_meta.get("path", "")
+    if declared_path:
+        # Normalize to use forward slashes for cross-platform consistency.
+        # We accept paths written with either separator in pack.yaml.
+        declared_path_normalized = declared_path.replace("\\", "/").strip("/")
+        path_segments = declared_path_normalized.split("/")
+        last_segment = path_segments[-1] if path_segments else ""
+
+        if slug and last_segment != slug:
+            errors.append(ValidationError(
+                file="pack.yaml",
+                line=None,
+                ref_type="pack",
+                reference="path",
+                message=(
+                    f"Path '{declared_path}' last segment '{last_segment}' "
+                    f"does not match slug '{slug}'. The folder name must "
+                    f"equal the slug."
+                ),
+            ))
+
+        # Compare declared path to actual disk location, if discoverable.
+        # We expect pack_path to be under libraries/packs; if it's not
+        # (e.g., test fixtures pointing at an arbitrary directory), skip
+        # this check rather than emit a misleading error.
+        try:
+            libraries_path = get_libraries_path()
+            actual_relative = pack_path.resolve().relative_to(libraries_path.resolve())
+            actual_relative_str = str(actual_relative).replace("\\", "/")
+            if actual_relative_str != declared_path_normalized:
+                errors.append(ValidationError(
+                    file="pack.yaml",
+                    line=None,
+                    ref_type="pack",
+                    reference="path",
+                    message=(
+                        f"Declared path '{declared_path}' does not match "
+                        f"actual location '{actual_relative_str}'. The path "
+                        f"field must reflect where the pack lives on disk."
+                    ),
+                ))
+        except (ValueError, FileNotFoundError):
+            # pack_path is outside libraries/packs (test fixture or
+            # ad-hoc import): skip the on-disk match check.
+            pass
 
     # Valid pack_type enum
     valid_pack_types = {"technology", "threat", "countermeasure", "compliance", "template", "full", "taxonomy"}
@@ -1282,7 +1428,16 @@ def _create_or_update_pack(pack_data: dict) -> LibraryPack:
 
 
 def _process_dependencies(library_pack: LibraryPack, pack_data: dict):
-    """Process pack dependencies with version constraints."""
+    """Process pack dependencies with version constraints.
+
+    Dependencies may include an optional `path` field for disambiguating
+    between packs that share a slug on disk. The DB enforces slug
+    uniqueness, so once imported a slug refers to exactly one pack —
+    `path` is informational here and only affects which pack on disk we
+    consider the dependency target. We log when path is given but the
+    matching pack isn't yet imported, since the dependency record will
+    be created without it.
+    """
     depends_on = pack_data.get("pack", {}).get("depends_on", [])
 
     # Clear existing dependencies
@@ -1298,7 +1453,9 @@ def _process_dependencies(library_pack: LibraryPack, pack_data: dict):
             version_constraint = dep.get("version", "")
             is_optional = dep.get("optional", False)
 
-        # Find the dependency pack (may not exist yet)
+        # Find the dependency pack (may not exist yet). Slug uniqueness
+        # in the DB makes the lookup unambiguous regardless of how many
+        # disk variants share the slug.
         dep_pack = LibraryPack.objects.filter(slug=dep_slug).first()
         if dep_pack:
             LibraryPackDependency.objects.create(
@@ -2158,7 +2315,11 @@ def get_available_overlays_for_pack(slug: str) -> list[OverlayInfo]:
     if not libraries_path.exists():
         return []
 
-    pack_dir = _find_pack_dir(libraries_path, slug)
+    pack_relative_path = _resolve_slug_to_path(libraries_path, slug)
+    if not pack_relative_path:
+        return []
+
+    pack_dir = _find_pack_dir(libraries_path, pack_relative_path)
     if not pack_dir:
         return []
 

--- a/backend/apps/packs/tests.py
+++ b/backend/apps/packs/tests.py
@@ -1,3 +1,299 @@
-from django.test import TestCase
+"""Tests for path-based pack discovery and validation (issue #33)."""
 
-# Create your tests here.
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import yaml
+from django.test import SimpleTestCase
+
+from apps.packs.services import (
+    _find_pack_dir,
+    _resolve_slug_to_path,
+    discover_packs_from_source,
+    validate_pack,
+)
+
+
+def _empty_pack_queryset():
+    """Stand-in for LibraryPack.objects.all() that yields nothing.
+
+    discover_packs_from_source() reads installed packs from the DB to
+    flag is_in_database; tests covering on-disk discovery don't care
+    about that signal, so we mock the queryset instead of spinning up a
+    real database.
+    """
+    return iter([])
+
+
+def _write_pack(base_dir: Path, relative_path: str, slug: str, **overrides) -> Path:
+    """Create a minimal pack on disk under base_dir/relative_path.
+
+    Writes a pack.yaml with a `path` field set to relative_path by
+    default. Use overrides to change individual pack.yaml fields for
+    negative tests (e.g. mismatched path, missing path).
+    """
+    pack_dir = base_dir / relative_path
+    pack_dir.mkdir(parents=True, exist_ok=True)
+
+    pack_meta = {
+        "slug": slug,
+        "path": relative_path,
+        "name": slug,
+        "version": "1.0.0",
+        "pack_type": "technology",
+        "tier": "free",
+        "source": "official",
+        "author": "Test",
+    }
+    pack_meta.update(overrides)
+
+    # `path: None` is how callers signal "omit the path field"; drop it.
+    if pack_meta.get("path") is None:
+        del pack_meta["path"]
+
+    pack_yaml = pack_dir / "pack.yaml"
+    pack_yaml.write_text(yaml.safe_dump({"pack": pack_meta}))
+    return pack_dir
+
+
+class FindPackDirTests(SimpleTestCase):
+    """The new _find_pack_dir is O(1) — it only checks the path it was given."""
+
+    def test_resolves_top_level_pack(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            _write_pack(base, "aws", slug="aws")
+
+            result = _find_pack_dir(base, "aws")
+
+            self.assertEqual(result, base / "aws")
+
+    def test_resolves_nested_pack(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            _write_pack(base, "frameworks/nist-csf", slug="nist-csf")
+
+            result = _find_pack_dir(base, "frameworks/nist-csf")
+
+            self.assertEqual(result, base / "frameworks" / "nist-csf")
+
+    def test_returns_none_for_missing_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+
+            self.assertIsNone(_find_pack_dir(base, "does-not-exist"))
+
+    def test_returns_none_when_pack_yaml_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "empty-dir").mkdir()
+
+            self.assertIsNone(_find_pack_dir(base, "empty-dir"))
+
+    def test_does_not_recursively_scan(self):
+        # If two packs share a slug under different paths, _find_pack_dir
+        # must return the directory at the requested path — not any
+        # other matching slug elsewhere in the tree.
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            _write_pack(base, "frameworks/nist-csf", slug="nist-csf")
+            _write_pack(base, "demo/nist-csf", slug="nist-csf")
+
+            framework_dir = _find_pack_dir(base, "frameworks/nist-csf")
+            demo_dir = _find_pack_dir(base, "demo/nist-csf")
+
+            self.assertEqual(framework_dir, base / "frameworks" / "nist-csf")
+            self.assertEqual(demo_dir, base / "demo" / "nist-csf")
+            self.assertNotEqual(framework_dir, demo_dir)
+
+
+class ValidatePackTests(SimpleTestCase):
+    """validate_pack enforces the path invariants from issue #33."""
+
+    def test_missing_path_field_is_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            with mock.patch(
+                "apps.packs.services.get_libraries_path", return_value=base
+            ):
+                pack_dir = _write_pack(base, "aws", slug="aws", path=None)
+
+                result = validate_pack(pack_dir)
+
+                self.assertFalse(result.success)
+                self.assertTrue(
+                    any(
+                        e.reference == "path"
+                        and "Missing required field" in e.message
+                        for e in result.errors
+                    ),
+                    f"Expected missing-path error, got: {[e.message for e in result.errors]}",
+                )
+
+    def test_folder_name_must_match_slug(self):
+        # Pack lives at frameworks/my-custom-name but declares slug nist-csf;
+        # the last segment of path should equal slug.
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            with mock.patch(
+                "apps.packs.services.get_libraries_path", return_value=base
+            ):
+                pack_dir = _write_pack(
+                    base,
+                    "frameworks/my-custom-name",
+                    slug="nist-csf",
+                    path="frameworks/my-custom-name",
+                )
+
+                result = validate_pack(pack_dir)
+
+                self.assertFalse(result.success)
+                self.assertTrue(
+                    any(
+                        "does not match slug" in e.message for e in result.errors
+                    ),
+                    f"Expected folder/slug mismatch error, got: {[e.message for e in result.errors]}",
+                )
+
+    def test_declared_path_must_match_actual_location(self):
+        # Pack lives at demo/nist-csf but declares path frameworks/nist-csf.
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            with mock.patch(
+                "apps.packs.services.get_libraries_path", return_value=base
+            ):
+                pack_dir = _write_pack(
+                    base,
+                    "demo/nist-csf",
+                    slug="nist-csf",
+                    path="frameworks/nist-csf",
+                )
+
+                result = validate_pack(pack_dir)
+
+                self.assertFalse(result.success)
+                self.assertTrue(
+                    any(
+                        "does not match actual location" in e.message
+                        for e in result.errors
+                    ),
+                    f"Expected location mismatch error, got: {[e.message for e in result.errors]}",
+                )
+
+    def test_valid_pack_passes_path_checks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            with mock.patch(
+                "apps.packs.services.get_libraries_path", return_value=base
+            ):
+                pack_dir = _write_pack(base, "frameworks/nist-csf", slug="nist-csf")
+
+                result = validate_pack(pack_dir)
+
+                # Should have no path-related errors. (Other errors —
+                # e.g. missing taxonomies — are unrelated to issue #33.)
+                path_errors = [
+                    e for e in result.errors if e.reference == "path"
+                ]
+                self.assertEqual(
+                    path_errors,
+                    [],
+                    f"Unexpected path errors: {[e.message for e in path_errors]}",
+                )
+
+
+class DiscoveryAndDisambiguationTests(SimpleTestCase):
+    """discover_packs_from_source surfaces duplicate slugs without collapsing them."""
+
+    def _patch_db_and_path(self, base):
+        # discover_packs_from_source reads from LibraryPack.objects to
+        # populate is_in_database. The tests here exercise on-disk
+        # discovery, so we stub the queryset to avoid the database.
+        return mock.patch.multiple(
+            "apps.packs.services",
+            get_libraries_path=mock.MagicMock(return_value=base),
+            LibraryPack=mock.MagicMock(
+                objects=mock.MagicMock(
+                    all=mock.MagicMock(return_value=_empty_pack_queryset()),
+                )
+            ),
+        )
+
+    def test_duplicate_slugs_under_different_paths_are_both_discovered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            with self._patch_db_and_path(base):
+                _write_pack(base, "frameworks/nist-csf", slug="nist-csf")
+                _write_pack(base, "demo/nist-csf", slug="nist-csf")
+
+                packs = discover_packs_from_source()
+                nist_packs = [p for p in packs if p.slug == "nist-csf"]
+
+                self.assertEqual(len(nist_packs), 2)
+                paths = {p.relative_path for p in nist_packs}
+                self.assertEqual(
+                    paths,
+                    {"frameworks/nist-csf", "demo/nist-csf"},
+                )
+
+    def test_resolve_slug_returns_one_match_when_unique(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            with self._patch_db_and_path(base):
+                _write_pack(base, "aws", slug="aws")
+
+                self.assertEqual(_resolve_slug_to_path(base, "aws"), "aws")
+
+    def test_discovery_warns_on_path_mismatch(self):
+        # Pack lives at demo/nist-csf but declares frameworks/nist-csf.
+        # Discovery should still surface the pack but log a warning so
+        # it shows up in pack listings while signalling the problem.
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            with self._patch_db_and_path(base):
+                _write_pack(
+                    base,
+                    "demo/nist-csf",
+                    slug="nist-csf",
+                    path="frameworks/nist-csf",
+                )
+
+                with self.assertLogs(
+                    "apps.packs.services", level="WARNING"
+                ) as cm:
+                    packs = discover_packs_from_source()
+
+                self.assertEqual(len(packs), 1)
+                self.assertTrue(
+                    any("does not match actual location" in msg for msg in cm.output),
+                    f"Expected mismatch warning, got: {cm.output}",
+                )
+
+    def test_depends_on_with_path_disambiguates(self):
+        # A pack depends on `nist-csf` and disambiguates which one via path.
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            with self._patch_db_and_path(base):
+                _write_pack(base, "frameworks/nist-csf", slug="nist-csf")
+                _write_pack(base, "demo/nist-csf", slug="nist-csf")
+                _write_pack(
+                    base,
+                    "consumer",
+                    slug="consumer",
+                    depends_on=[
+                        {
+                            "pack": "nist-csf",
+                            "path": "demo/nist-csf",
+                            "version": "^1.0.0",
+                        }
+                    ],
+                )
+
+                packs = discover_packs_from_source()
+                consumer = next(p for p in packs if p.slug == "consumer")
+
+                self.assertEqual(len(consumer.depends_on), 1)
+                dep = consumer.depends_on[0]
+                self.assertEqual(dep["slug"], "nist-csf")
+                self.assertEqual(dep["path"], "demo/nist-csf")

--- a/libraries/packs/aws-mini/pack.yaml
+++ b/libraries/packs/aws-mini/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: aws-mini
+  path: aws-mini
   name: AWS Mini
   version: 1.1.0
   pack_type: full

--- a/libraries/packs/aws/pack.yaml
+++ b/libraries/packs/aws/pack.yaml
@@ -8,6 +8,7 @@
 
 pack:
   slug: aws
+  path: aws
   name: "AWS Technologies"
   description: "Amazon Web Services cloud components for threat modeling diagrams"
   version: "2.0.0"

--- a/libraries/packs/azure/pack.yaml
+++ b/libraries/packs/azure/pack.yaml
@@ -1,6 +1,7 @@
 # Azure Technologies Pack
 pack:
   slug: azure
+  path: azure
   name: "Azure Technologies"
   description: "Microsoft Azure cloud components for threat modeling diagrams"
   version: "2.0.0"

--- a/libraries/packs/banking/pack.yaml
+++ b/libraries/packs/banking/pack.yaml
@@ -1,6 +1,7 @@
 # Banking Industry Pack
 pack:
   slug: banking
+  path: banking
   name: "Banking"
   description: "Banking and financial services components and DFD templates"
   version: "2.0.0"

--- a/libraries/packs/base-stride/pack.yaml
+++ b/libraries/packs/base-stride/pack.yaml
@@ -1,6 +1,7 @@
 # Base STRIDE Threat Pack
 pack:
   slug: base-stride
+  path: base-stride
   name: "Base STRIDE Threats"
   description: "Foundational STRIDE-based threats and countermeasures for threat modeling"
   version: "2.0.0"

--- a/libraries/packs/bci-mini/pack.yaml
+++ b/libraries/packs/bci-mini/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: bci-mini
+  path: bci-mini
   name: BCI Mini
   version: 1.0.0
   pack_type: full

--- a/libraries/packs/frameworks/cra/pack.yaml
+++ b/libraries/packs/frameworks/cra/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: cra
+  path: frameworks/cra
   name: "Cyber Resilience Act"
   version: "2.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/dora/pack.yaml
+++ b/libraries/packs/frameworks/dora/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: dora
+  path: frameworks/dora
   name: "DORA"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/gdpr/pack.yaml
+++ b/libraries/packs/frameworks/gdpr/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: gdpr
+  path: frameworks/gdpr
   name: "GDPR"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/hipaa/pack.yaml
+++ b/libraries/packs/frameworks/hipaa/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: hipaa
+  path: frameworks/hipaa
   name: "HIPAA"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/iso27001/pack.yaml
+++ b/libraries/packs/frameworks/iso27001/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: iso27001
+  path: frameworks/iso27001
   name: "ISO 27001:2022"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/mini-asvs/pack.yaml
+++ b/libraries/packs/frameworks/mini-asvs/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: mini-asvs
+  path: frameworks/mini-asvs
   name: "OWASP ASVS 4.0 (Mini)"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/nist-csf/pack.yaml
+++ b/libraries/packs/frameworks/nist-csf/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: nist-csf
+  path: frameworks/nist-csf
   name: "NIST CSF 2.0"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/owasp/pack.yaml
+++ b/libraries/packs/frameworks/owasp/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: owasp
+  path: frameworks/owasp
   name: "OWASP Top 10 2021"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/pci-dss/pack.yaml
+++ b/libraries/packs/frameworks/pci-dss/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: pci-dss
+  path: frameworks/pci-dss
   name: "PCI-DSS v4.0"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/soc2/pack.yaml
+++ b/libraries/packs/frameworks/soc2/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: soc2
+  path: frameworks/soc2
   name: "SOC 2"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/gcp/pack.yaml
+++ b/libraries/packs/gcp/pack.yaml
@@ -1,6 +1,7 @@
 # GCP Technologies Pack
 pack:
   slug: gcp
+  path: gcp
   name: "GCP Technologies"
   description: "Google Cloud Platform components for threat modeling diagrams"
   version: "2.0.0"

--- a/libraries/packs/generic/pack.yaml
+++ b/libraries/packs/generic/pack.yaml
@@ -1,6 +1,7 @@
 # Generic Technologies Pack
 pack:
   slug: generic
+  path: generic
   name: "Generic Technologies"
   description: "Vendor-agnostic components: open-source, frameworks, and self-hosted solutions"
   version: "2.0.0"

--- a/libraries/packs/mini-attack/pack.yaml
+++ b/libraries/packs/mini-attack/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: mini-attack
+  path: mini-attack
   name: Mini ATT&CK
   description: "Curated subset of MITRE ATT&CK Enterprise techniques covering the most common adversary behaviors in cloud and enterprise environments."
   version: "1.0.0"

--- a/libraries/packs/mini-capec/pack.yaml
+++ b/libraries/packs/mini-capec/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: mini-capec
+  path: mini-capec
   name: Mini CAPEC
   description: "Curated subset of MITRE CAPEC (Common Attack Pattern Enumeration and Classification) covering the most common web and cloud attack patterns."
   version: "1.0.0"

--- a/libraries/packs/mini-cwe/pack.yaml
+++ b/libraries/packs/mini-cwe/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: mini-cwe
+  path: mini-cwe
   name: Mini CWE
   description: "Curated subset of MITRE CWE (Common Weakness Enumeration) aligned with the CWE Top 25 Most Dangerous Software Weaknesses."
   version: "1.0.0"

--- a/libraries/packs/stride-taxonomy/pack.yaml
+++ b/libraries/packs/stride-taxonomy/pack.yaml
@@ -1,5 +1,6 @@
 pack:
   slug: stride-taxonomy
+  path: stride-taxonomy
   name: STRIDE Taxonomy
   description: "Microsoft STRIDE threat classification model"
   version: "1.0.0"


### PR DESCRIPTION
Closes #33.

## Summary

- `_find_pack_dir(base, pack_path)` now does a direct `base / pack_path` lookup — no recursive walk, no per-lookup YAML parsing
- All 22 `pack.yaml` files declare a required `path` field (relative to `libraries/packs/`)
- `validate_pack` enforces: `path` is required, last segment of path must equal `slug`, and declared path must match the pack's actual on-disk location
- `discover_packs_from_source` emits warnings for the same path issues so problems show up in pack listings before import
- `depends_on` entries may include an optional `path` to disambiguate between same-slug packs (e.g. `frameworks/nist-csf` vs `demo/nist-csf`); slug uniqueness in the DB remains the source of truth at install time
- Slug-based legacy callers (`get_pack_preview_from_source`, `get_available_overlays_for_pack`) go through a new `_resolve_slug_to_path` helper that warns when multiple packs share a slug

## Test plan

Backend unit tests:
- [x] 13 new tests in `apps.packs.tests` cover O(1) lookup (flat + nested paths), missing/invalid path validation, folder-vs-slug enforcement, location mismatch detection, duplicate-slug discovery, depends-on path disambiguation, and discovery-time warning logs — all pass in the dev container

End-to-end manual verification (full Docker stack against the real `libraries/packs/` tree):
- [x] `migrate` + `seed` import all 10 default packs cleanly with no path warnings
- [x] `GET /api/packs/available_from_source/` discovers all 22 packs with correct `relativePath` (flat and nested)
- [x] `GET /api/packs/preview_from_source/?slug=…` resolves both flat (`aws-mini`) and nested (`nist-csf`) packs
- [x] `GET /api/packs/<id>/preview/` (DB-backed) and `GET /api/packs/available_overlays/?slug=aws-mini` work
- [x] `POST /api/packs/import_single/` succeeds for a fresh top-level pack (`azure`: 45 components, 4 templates) and a fresh nested pack (`hipaa`)
- [x] `POST /api/packs/sync_from_source/` runs all 22 packs, 0 failures
- [x] Edge case: pack with `path: frameworks/test-bad-path` actually living at `test-bad-path` is rejected with `"Declared path … does not match actual location"`
- [x] Edge case: pack missing `path` field is rejected with `"Missing required field: path"`
- [x] Frontend dev server compiles cleanly; no API contract changes required (the new `relativePath` field on `SourcePackInfo` is purely additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)