### PR TITLE
Simplify pack resolution: use filesystem as source of truth (#33); Re…

### DIFF
--- a/backend/apps/packs/services.py
+++ b/backend/apps/packs/services.py
@@ -35,10 +35,9 @@ logger = logging.getLogger(__name__)
 
 def _find_pack_dir(base_path: Path, pack_path: str) -> Path | None:
     """
-    Resolve a pack's directory from its declared relative path.
+    Resolve a pack's directory from its relative path.
 
-    The path is the value of `pack.path` in pack.yaml — a relative path
-    from the libraries/packs root to the pack directory. This is an O(1)
+    The path is relative to the libraries/packs root. This is an O(1)
     lookup: no scanning or YAML parsing of unrelated packs is needed.
 
     Returns None if the directory does not exist or has no pack.yaml.
@@ -49,36 +48,6 @@ def _find_pack_dir(base_path: Path, pack_path: str) -> Path | None:
     if pack_dir.is_dir() and (pack_dir / "pack.yaml").exists():
         return pack_dir
     return None
-
-
-def _resolve_slug_to_path(libraries_path: Path, slug: str) -> str | None:
-    """
-    Resolve a pack slug to its declared relative path.
-
-    Used by legacy slug-based APIs (preview, available_overlays) where the
-    caller has only a slug. Walks the libraries tree once via
-    discover_packs_from_source() and returns the first match. Issues a
-    warning when multiple packs share the slug — disambiguation requires
-    using the path-based API directly.
-
-    Returns None if no pack with the given slug is found.
-    """
-    matches = []
-    for pack_info in discover_packs_from_source():
-        if pack_info.slug == slug:
-            matches.append(pack_info)
-
-    if not matches:
-        return None
-
-    if len(matches) > 1:
-        paths = [m.relative_path for m in matches]
-        logger.warning(
-            f"Multiple packs found with slug '{slug}': {paths}. "
-            f"Using first match. Pass an explicit path to disambiguate."
-        )
-
-    return matches[0].relative_path
 
 
 @dataclass
@@ -98,9 +67,8 @@ class PackInfo:
     # Absolute filesystem path to the pack directory (for callers that
     # need to load files from disk).
     path: str = ""
-    # Declared relative path from libraries/packs root, taken from
-    # pack.yaml's `pack.path` field. Used for O(1) lookup and dependency
-    # disambiguation. Empty when pack.yaml omits the field (older packs).
+    # Relative path from libraries/packs root, computed from filesystem
+    # location. Used for O(1) lookup and dependency disambiguation.
     relative_path: str = ""
     is_in_database: bool = False
     database_version: Optional[str] = None
@@ -196,14 +164,8 @@ def _count_items_in_file(file_path: Path, key: str) -> int:
 def _discover_pack(pack_dir: Path, libraries_path: Path, existing_packs: dict) -> PackInfo | None:
     """Discover a pack from its directory.
 
-    Path invariants from issue #33 are checked here so problems surface
-    in discovery output, not just at import time:
-      - missing `path` field → warning, fall back to disk location
-      - declared path's last segment != slug → warning
-      - declared path != actual on-disk location → warning
-
-    Discovery still returns a PackInfo for invalid packs so users can
-    see them in listings; the import path enforces these as errors.
+    The relative path is computed from the pack's actual filesystem
+    location, so packs never need to declare where they live.
     """
     pack_yaml = pack_dir / "pack.yaml"
     if not pack_yaml.exists():
@@ -215,36 +177,7 @@ def _discover_pack(pack_dir: Path, libraries_path: Path, existing_packs: dict) -
 
         pack_meta = pack_data.get("pack", {})
         slug = pack_meta.get("slug", pack_dir.name)
-
-        # Resolve the declared path. If pack.yaml omits `path`, fall back
-        # to the actual location on disk so older packs keep working.
-        # Validation in validate_pack() will flag the missing field.
-        declared_path = pack_meta.get("path", "")
-        actual_relative_path = str(pack_dir.relative_to(libraries_path)).replace("\\", "/")
-
-        if not declared_path:
-            logger.warning(
-                f"Pack at {actual_relative_path} is missing the required "
-                f"`path` field in pack.yaml — falling back to disk location"
-            )
-            relative_path = actual_relative_path
-        else:
-            declared_normalized = declared_path.replace("\\", "/").strip("/")
-            relative_path = declared_normalized
-
-            last_segment = declared_normalized.split("/")[-1]
-            if slug and last_segment != slug:
-                logger.warning(
-                    f"Pack at {actual_relative_path}: declared path "
-                    f"'{declared_path}' last segment '{last_segment}' "
-                    f"does not match slug '{slug}'"
-                )
-
-            if declared_normalized != actual_relative_path:
-                logger.warning(
-                    f"Pack at {actual_relative_path}: declared path "
-                    f"'{declared_path}' does not match actual location"
-                )
+        relative_path = str(pack_dir.relative_to(libraries_path)).replace("\\", "/")
 
         # Count items from separate files
         component_count = _count_items_in_file(pack_dir / "components.yaml", "components")
@@ -350,18 +283,17 @@ def discover_packs_from_source() -> list[PackInfo]:
     return packs
 
 
-def get_pack_preview_from_source(slug: str) -> dict | None:
+def get_pack_preview_from_source(pack_relative_path: str) -> dict | None:
     """
     Get full pack content for preview from the libraries folder.
 
     Reads pack metadata from pack.yaml and components/threats/countermeasures
-    from their respective YAML files.
-
-    Supports both flat (packs directly in libraries/packs/) and
-    nested (packs in libraries/packs/category/pack/) directory structures.
+    from their respective YAML files. Uses the pack's relative path from the
+    libraries/packs root for O(1) directory lookup.
 
     Args:
-        slug: The pack slug to find
+        pack_relative_path: Relative path from libraries/packs root (e.g. "aws-mini",
+            "frameworks/nist-csf")
 
     Returns:
         Dictionary with pack metadata, components, threats, and countermeasures
@@ -370,10 +302,6 @@ def get_pack_preview_from_source(slug: str) -> dict | None:
     libraries_path = get_libraries_path()
 
     if not libraries_path.exists():
-        return None
-
-    pack_relative_path = _resolve_slug_to_path(libraries_path, slug)
-    if not pack_relative_path:
         return None
 
     pack_dir = _find_pack_dir(libraries_path, pack_relative_path)
@@ -391,20 +319,35 @@ def get_pack_preview_from_source(slug: str) -> dict | None:
         return None
 
 
-def get_pack_preview_from_database(pack: "LibraryPack") -> dict:
+def get_pack_preview_from_database(pack: "LibraryPack") -> dict | None:
     """
     Get full pack content for preview from a database pack.
 
     Reads preview data from the source YAML files rather than the database,
     ensuring consistent results regardless of how the pack was imported.
+    Scans the libraries tree to find the pack directory by slug.
 
     Args:
         pack: The LibraryPack model instance
 
     Returns:
         Dictionary with pack metadata, components, threats, and countermeasures
+        or None if pack not found on disk
     """
-    return get_pack_preview_from_source(pack.slug)
+    libraries_path = get_libraries_path()
+    if not libraries_path.exists():
+        return None
+
+    for pack_yaml in libraries_path.rglob("pack.yaml"):
+        try:
+            with open(pack_yaml) as f:
+                pack_data = yaml.safe_load(f)
+            if pack_data.get("pack", {}).get("slug") == pack.slug:
+                return _extract_pack_preview(pack_yaml.parent, pack_data)
+        except Exception:
+            continue
+
+    return None
 
 
 def _extract_pack_preview(pack_dir: Path, pack_data: dict) -> dict:
@@ -684,11 +627,8 @@ def validate_pack(pack_path: Path) -> ValidationResult:
 
     # Structural checks
 
-    # Required metadata fields. The `path` field was added to make pack
-    # resolution O(1) (see issue #33) — it must be present so the
-    # discovery layer can locate this pack without scanning every
-    # pack.yaml in the tree.
-    required_metadata = ["slug", "name", "version", "pack_type", "path"]
+    # Required metadata fields
+    required_metadata = ["slug", "name", "version", "pack_type"]
     for required_field in required_metadata:
         if required_field not in pack_meta:
             errors.append(ValidationError(
@@ -698,60 +638,6 @@ def validate_pack(pack_path: Path) -> ValidationResult:
                 reference=required_field,
                 message=f"Missing required field: {required_field}",
             ))
-
-    # Path validation. The `path` field is the source of truth for where
-    # the pack lives under libraries/packs. Two invariants must hold:
-    #   1. The last segment of the path equals the slug. The folder name
-    #      is meaningful and must match the slug, so paths cannot rename
-    #      the pack out from under callers.
-    #   2. The declared path matches where the pack.yaml actually lives
-    #      on disk. Otherwise lookups by path would resolve to a
-    #      different directory than the one declaring this slug.
-    declared_path = pack_meta.get("path", "")
-    if declared_path:
-        # Normalize to use forward slashes for cross-platform consistency.
-        # We accept paths written with either separator in pack.yaml.
-        declared_path_normalized = declared_path.replace("\\", "/").strip("/")
-        path_segments = declared_path_normalized.split("/")
-        last_segment = path_segments[-1] if path_segments else ""
-
-        if slug and last_segment != slug:
-            errors.append(ValidationError(
-                file="pack.yaml",
-                line=None,
-                ref_type="pack",
-                reference="path",
-                message=(
-                    f"Path '{declared_path}' last segment '{last_segment}' "
-                    f"does not match slug '{slug}'. The folder name must "
-                    f"equal the slug."
-                ),
-            ))
-
-        # Compare declared path to actual disk location, if discoverable.
-        # We expect pack_path to be under libraries/packs; if it's not
-        # (e.g., test fixtures pointing at an arbitrary directory), skip
-        # this check rather than emit a misleading error.
-        try:
-            libraries_path = get_libraries_path()
-            actual_relative = pack_path.resolve().relative_to(libraries_path.resolve())
-            actual_relative_str = str(actual_relative).replace("\\", "/")
-            if actual_relative_str != declared_path_normalized:
-                errors.append(ValidationError(
-                    file="pack.yaml",
-                    line=None,
-                    ref_type="pack",
-                    reference="path",
-                    message=(
-                        f"Declared path '{declared_path}' does not match "
-                        f"actual location '{actual_relative_str}'. The path "
-                        f"field must reflect where the pack lives on disk."
-                    ),
-                ))
-        except (ValueError, FileNotFoundError):
-            # pack_path is outside libraries/packs (test fixture or
-            # ad-hoc import): skip the on-disk match check.
-            pass
 
     # Valid pack_type enum
     valid_pack_types = {"technology", "threat", "countermeasure", "compliance", "template", "full", "taxonomy"}
@@ -2278,15 +2164,16 @@ def get_active_overlays_for_pack(pack: LibraryPack) -> list[ActiveOverlayInfo]:
     ]
 
 
-def get_available_overlays_for_pack(slug: str) -> list[OverlayInfo]:
+def get_available_overlays_for_pack(pack_relative_path: str) -> list[OverlayInfo]:
     """
     Get available framework overlays for a pack.
 
     Scans the pack's joins/ directory for countermeasures-*.yaml files
-    and returns information about each overlay.
+    and returns information about each overlay. Uses the pack's relative
+    path from the libraries/packs root for O(1) directory lookup.
 
     Args:
-        slug: The pack slug to check
+        pack_relative_path: Relative path from libraries/packs root (e.g. "aws-mini")
 
     Returns:
         List of OverlayInfo with framework_id, framework_name, mapping_count, framework_exists
@@ -2296,10 +2183,6 @@ def get_available_overlays_for_pack(slug: str) -> list[OverlayInfo]:
     libraries_path = get_libraries_path()
 
     if not libraries_path.exists():
-        return []
-
-    pack_relative_path = _resolve_slug_to_path(libraries_path, slug)
-    if not pack_relative_path:
         return []
 
     pack_dir = _find_pack_dir(libraries_path, pack_relative_path)

--- a/backend/apps/packs/tests.py
+++ b/backend/apps/packs/tests.py
@@ -1,4 +1,4 @@
-"""Tests for path-based pack discovery and validation (issue #33)."""
+"""Tests for path-based pack discovery and O(1) lookup (issue #33)."""
 
 import tempfile
 from pathlib import Path
@@ -9,9 +9,7 @@ from django.test import SimpleTestCase
 
 from apps.packs.services import (
     _find_pack_dir,
-    _resolve_slug_to_path,
     discover_packs_from_source,
-    validate_pack,
 )
 
 
@@ -27,18 +25,12 @@ def _empty_pack_queryset():
 
 
 def _write_pack(base_dir: Path, relative_path: str, slug: str, **overrides) -> Path:
-    """Create a minimal pack on disk under base_dir/relative_path.
-
-    Writes a pack.yaml with a `path` field set to relative_path by
-    default. Use overrides to change individual pack.yaml fields for
-    negative tests (e.g. mismatched path, missing path).
-    """
+    """Create a minimal pack on disk under base_dir/relative_path."""
     pack_dir = base_dir / relative_path
     pack_dir.mkdir(parents=True, exist_ok=True)
 
     pack_meta = {
         "slug": slug,
-        "path": relative_path,
         "name": slug,
         "version": "1.0.0",
         "pack_type": "technology",
@@ -48,17 +40,13 @@ def _write_pack(base_dir: Path, relative_path: str, slug: str, **overrides) -> P
     }
     pack_meta.update(overrides)
 
-    # `path: None` is how callers signal "omit the path field"; drop it.
-    if pack_meta.get("path") is None:
-        del pack_meta["path"]
-
     pack_yaml = pack_dir / "pack.yaml"
     pack_yaml.write_text(yaml.safe_dump({"pack": pack_meta}))
     return pack_dir
 
 
 class FindPackDirTests(SimpleTestCase):
-    """The new _find_pack_dir is O(1) — it only checks the path it was given."""
+    """_find_pack_dir is O(1): it only checks the path it was given."""
 
     def test_resolves_top_level_pack(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -93,7 +81,7 @@ class FindPackDirTests(SimpleTestCase):
 
     def test_does_not_recursively_scan(self):
         # If two packs share a slug under different paths, _find_pack_dir
-        # must return the directory at the requested path — not any
+        # must return the directory at the requested path, not any
         # other matching slug elsewhere in the tree.
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)
@@ -108,108 +96,10 @@ class FindPackDirTests(SimpleTestCase):
             self.assertNotEqual(framework_dir, demo_dir)
 
 
-class ValidatePackTests(SimpleTestCase):
-    """validate_pack enforces the path invariants from issue #33."""
-
-    def test_missing_path_field_is_error(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            base = Path(tmp)
-            with mock.patch(
-                "apps.packs.services.get_libraries_path", return_value=base
-            ):
-                pack_dir = _write_pack(base, "aws", slug="aws", path=None)
-
-                result = validate_pack(pack_dir)
-
-                self.assertFalse(result.success)
-                self.assertTrue(
-                    any(
-                        e.reference == "path"
-                        and "Missing required field" in e.message
-                        for e in result.errors
-                    ),
-                    f"Expected missing-path error, got: {[e.message for e in result.errors]}",
-                )
-
-    def test_folder_name_must_match_slug(self):
-        # Pack lives at frameworks/my-custom-name but declares slug nist-csf;
-        # the last segment of path should equal slug.
-        with tempfile.TemporaryDirectory() as tmp:
-            base = Path(tmp)
-            with mock.patch(
-                "apps.packs.services.get_libraries_path", return_value=base
-            ):
-                pack_dir = _write_pack(
-                    base,
-                    "frameworks/my-custom-name",
-                    slug="nist-csf",
-                    path="frameworks/my-custom-name",
-                )
-
-                result = validate_pack(pack_dir)
-
-                self.assertFalse(result.success)
-                self.assertTrue(
-                    any(
-                        "does not match slug" in e.message for e in result.errors
-                    ),
-                    f"Expected folder/slug mismatch error, got: {[e.message for e in result.errors]}",
-                )
-
-    def test_declared_path_must_match_actual_location(self):
-        # Pack lives at demo/nist-csf but declares path frameworks/nist-csf.
-        with tempfile.TemporaryDirectory() as tmp:
-            base = Path(tmp)
-            with mock.patch(
-                "apps.packs.services.get_libraries_path", return_value=base
-            ):
-                pack_dir = _write_pack(
-                    base,
-                    "demo/nist-csf",
-                    slug="nist-csf",
-                    path="frameworks/nist-csf",
-                )
-
-                result = validate_pack(pack_dir)
-
-                self.assertFalse(result.success)
-                self.assertTrue(
-                    any(
-                        "does not match actual location" in e.message
-                        for e in result.errors
-                    ),
-                    f"Expected location mismatch error, got: {[e.message for e in result.errors]}",
-                )
-
-    def test_valid_pack_passes_path_checks(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            base = Path(tmp)
-            with mock.patch(
-                "apps.packs.services.get_libraries_path", return_value=base
-            ):
-                pack_dir = _write_pack(base, "frameworks/nist-csf", slug="nist-csf")
-
-                result = validate_pack(pack_dir)
-
-                # Should have no path-related errors. (Other errors —
-                # e.g. missing taxonomies — are unrelated to issue #33.)
-                path_errors = [
-                    e for e in result.errors if e.reference == "path"
-                ]
-                self.assertEqual(
-                    path_errors,
-                    [],
-                    f"Unexpected path errors: {[e.message for e in path_errors]}",
-                )
-
-
 class DiscoveryAndDisambiguationTests(SimpleTestCase):
-    """discover_packs_from_source surfaces duplicate slugs without collapsing them."""
+    """discover_packs_from_source computes relative_path from the filesystem."""
 
     def _patch_db_and_path(self, base):
-        # discover_packs_from_source reads from LibraryPack.objects to
-        # populate is_in_database. The tests here exercise on-disk
-        # discovery, so we stub the queryset to avoid the database.
         return mock.patch.multiple(
             "apps.packs.services",
             get_libraries_path=mock.MagicMock(return_value=base),
@@ -237,41 +127,21 @@ class DiscoveryAndDisambiguationTests(SimpleTestCase):
                     {"frameworks/nist-csf", "demo/nist-csf"},
                 )
 
-    def test_resolve_slug_returns_one_match_when_unique(self):
+    def test_relative_path_computed_from_filesystem(self):
+        # relative_path should match the actual directory location,
+        # regardless of what's in pack.yaml.
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)
             with self._patch_db_and_path(base):
-                _write_pack(base, "aws", slug="aws")
+                _write_pack(base, "frameworks/owasp", slug="owasp")
 
-                self.assertEqual(_resolve_slug_to_path(base, "aws"), "aws")
+                packs = discover_packs_from_source()
+                owasp = next(p for p in packs if p.slug == "owasp")
 
-    def test_discovery_warns_on_path_mismatch(self):
-        # Pack lives at demo/nist-csf but declares frameworks/nist-csf.
-        # Discovery should still surface the pack but log a warning so
-        # it shows up in pack listings while signalling the problem.
-        with tempfile.TemporaryDirectory() as tmp:
-            base = Path(tmp)
-            with self._patch_db_and_path(base):
-                _write_pack(
-                    base,
-                    "demo/nist-csf",
-                    slug="nist-csf",
-                    path="frameworks/nist-csf",
-                )
-
-                with self.assertLogs(
-                    "apps.packs.services", level="WARNING"
-                ) as cm:
-                    packs = discover_packs_from_source()
-
-                self.assertEqual(len(packs), 1)
-                self.assertTrue(
-                    any("does not match actual location" in msg for msg in cm.output),
-                    f"Expected mismatch warning, got: {cm.output}",
-                )
+                self.assertEqual(owasp.relative_path, "frameworks/owasp")
 
     def test_depends_on_with_path_disambiguates(self):
-        # A pack depends on `nist-csf` and disambiguates which one via path.
+        # A pack depends on nist-csf and disambiguates which one via path.
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)
             with self._patch_db_and_path(base):

--- a/backend/apps/packs/views.py
+++ b/backend/apps/packs/views.py
@@ -224,26 +224,27 @@ class LibraryPackViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=False, methods=["get"])
     def preview_from_source(self, request):
         """
-        Get full pack contents for preview (source packs by slug).
+        Get full pack contents for preview (source packs by path).
 
         Query parameters:
-            slug: The pack slug to preview
+            path: The pack's relative path from libraries/packs root
+                  (e.g. "aws-mini", "frameworks/nist-csf")
 
         Returns pack metadata along with all components, threats, and countermeasures.
         """
-        slug = request.query_params.get("slug")
+        pack_path = request.query_params.get("path")
 
-        if not slug:
+        if not pack_path:
             return Response(
-                {"error": "Pack slug is required"},
+                {"error": "Pack path is required"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        preview_data = get_pack_preview_from_source(slug)
+        preview_data = get_pack_preview_from_source(pack_path)
 
         if not preview_data:
             return Response(
-                {"error": f"Pack '{slug}' not found in libraries folder"},
+                {"error": f"Pack at '{pack_path}' not found in libraries folder"},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
@@ -255,20 +256,21 @@ class LibraryPackViewSet(viewsets.ReadOnlyModelViewSet):
         Get available framework overlays for a pack before installation.
 
         Query parameters:
-            slug: The pack slug to check overlays for
+            path: The pack's relative path from libraries/packs root
+                  (e.g. "aws-mini", "frameworks/nist-csf")
 
         Returns list of overlays with framework_id, framework_name, mapping_count,
         and whether the framework is installed.
         """
-        slug = request.query_params.get("slug")
+        pack_path = request.query_params.get("path")
 
-        if not slug:
+        if not pack_path:
             return Response(
-                {"error": "Pack slug is required"},
+                {"error": "Pack path is required"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        overlays = get_available_overlays_for_pack(slug)
+        overlays = get_available_overlays_for_pack(pack_path)
 
         return Response({
             "overlays": [

--- a/frontend/src/features/libraries/api/packs.ts
+++ b/frontend/src/features/libraries/api/packs.ts
@@ -20,7 +20,7 @@ export const packKeys = {
   detail: (id: number) => [...packKeys.details(), id] as const,
   dependencies: (id: number) => [...packKeys.all, 'dependencies', id] as const,
   preview: (id: number) => [...packKeys.all, 'preview', id] as const,
-  previewFromSource: (slug: string) => [...packKeys.all, 'preview-source', slug] as const,
+  previewFromSource: (packPath: string) => [...packKeys.all, 'preview-source', packPath] as const,
   availableFromSource: ['packs', 'available-from-source'] as const,
 }
 
@@ -37,6 +37,7 @@ export interface SourcePackInfo {
   industries: string[]
   tags: string[]
   path: string
+  relativePath: string
   isInDatabase: boolean
   databaseVersion: string | null
   needsUpdate: boolean
@@ -279,14 +280,14 @@ export function useImportSinglePack() {
 /**
  * Fetch available framework overlays for a pack before import.
  */
-export function usePackOverlays(slug: string | null) {
+export function usePackOverlays(packPath: string | null) {
   return useQuery({
-    queryKey: [...packKeys.all, 'overlays', slug],
+    queryKey: [...packKeys.all, 'overlays', packPath],
     queryFn: () =>
       api.get<AvailableOverlaysResponse>(
-        `/packs/available_overlays/?slug=${slug}`
+        `/packs/available_overlays/?path=${encodeURIComponent(packPath!)}`
       ),
-    enabled: slug !== null,
+    enabled: packPath !== null,
   })
 }
 
@@ -306,14 +307,16 @@ export function usePackPreview(id: number | null) {
 }
 
 /**
- * Fetch full pack contents for preview (source packs by slug).
+ * Fetch full pack contents for preview (source packs by path).
  */
-export function useSourcePackPreview(slug: string | null) {
+export function useSourcePackPreview(packPath: string | null) {
   return useQuery({
-    queryKey: packKeys.previewFromSource(slug!),
+    queryKey: packKeys.previewFromSource(packPath!),
     queryFn: () =>
-      api.get<PackPreviewResponse>(`/packs/preview_from_source/?slug=${slug}`),
-    enabled: slug !== null,
+      api.get<PackPreviewResponse>(
+        `/packs/preview_from_source/?path=${encodeURIComponent(packPath!)}`
+      ),
+    enabled: packPath !== null,
   })
 }
 

--- a/frontend/src/features/libraries/components/CatalogView.tsx
+++ b/frontend/src/features/libraries/components/CatalogView.tsx
@@ -28,7 +28,7 @@ export function CatalogView() {
   const [filters, setFilters] = useState<PackFilters>({})
   const [searchInput, setSearchInput] = useState('')
   const [previewPackId, setPreviewPackId] = useState<number | null>(null)
-  const [previewPackSlug, setPreviewPackSlug] = useState<string | null>(null)
+  const [previewPackPath, setPreviewPackPath] = useState<string | null>(null)
   const [previewDialogOpen, setPreviewDialogOpen] = useState(false)
   const [importingSlug, setImportingSlug] = useState<string | null>(null)
   const [installDialogPack, setInstallDialogPack] = useState<UnifiedPack | null>(null)
@@ -58,6 +58,7 @@ export function CatalogView() {
           tier: sp.tier,
           source: sp.source,
           tags: sp.tags,
+          relativePath: sp.relativePath,
           componentCount: sp.componentCount,
           threatCount: sp.threatCount,
           isInDatabase: sp.isInDatabase,
@@ -81,6 +82,7 @@ export function CatalogView() {
             tier: dbPack.tier,
             source: dbPack.source,
             tags: dbPack.tags,
+            relativePath: '',
             componentCount: 0,
             threatCount: 0,
             isInDatabase: true,
@@ -163,10 +165,10 @@ export function CatalogView() {
   const handlePreview = (pack: UnifiedPack) => {
     if (pack.databaseId) {
       setPreviewPackId(pack.databaseId)
-      setPreviewPackSlug(null)
+      setPreviewPackPath(null)
     } else {
       setPreviewPackId(null)
-      setPreviewPackSlug(pack.slug)
+      setPreviewPackPath(pack.relativePath)
     }
     setPreviewDialogOpen(true)
   }
@@ -261,7 +263,7 @@ export function CatalogView() {
 
       <PreviewPackDialog
         packId={previewPackId}
-        packSlug={previewPackSlug}
+        packPath={previewPackPath}
         open={previewDialogOpen}
         onOpenChange={setPreviewDialogOpen}
       />

--- a/frontend/src/features/libraries/components/ImportPackDialog.tsx
+++ b/frontend/src/features/libraries/components/ImportPackDialog.tsx
@@ -31,7 +31,7 @@ export function ImportPackDialog({
   onConfirm: (pack: UnifiedPack, selectedOverlays: string[] | null) => void
 }) {
   const { data: overlaysData, isLoading: loadingOverlays } = usePackOverlays(
-    pack?.slug ?? null
+    pack?.relativePath ?? null
   )
   const [selectedOverlays, setSelectedOverlays] = useState<Set<string>>(new Set())
 

--- a/frontend/src/features/libraries/components/PreviewPackDialog.tsx
+++ b/frontend/src/features/libraries/components/PreviewPackDialog.tsx
@@ -30,24 +30,24 @@ import {
 interface PreviewPackDialogProps {
   /** Pack ID for database packs */
   packId?: number | null
-  /** Pack slug for source packs */
-  packSlug?: string | null
+  /** Pack relative path for source packs */
+  packPath?: string | null
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
 export function PreviewPackDialog({
   packId,
-  packSlug,
+  packPath,
   open,
   onOpenChange,
 }: PreviewPackDialogProps) {
   // Use the appropriate hook based on what's provided
-  const dbPreview = usePackPreview(packSlug ? null : packId ?? null)
-  const sourcePreview = useSourcePackPreview(packId ? null : packSlug ?? null)
+  const dbPreview = usePackPreview(packPath ? null : packId ?? null)
+  const sourcePreview = useSourcePackPreview(packId ? null : packPath ?? null)
 
-  const isLoading = packSlug ? sourcePreview.isLoading : dbPreview.isLoading
-  const preview = packSlug ? sourcePreview.data : dbPreview.data
+  const isLoading = packPath ? sourcePreview.isLoading : dbPreview.isLoading
+  const preview = packPath ? sourcePreview.data : dbPreview.data
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/frontend/src/features/libraries/components/unified-pack.ts
+++ b/frontend/src/features/libraries/components/unified-pack.ts
@@ -8,6 +8,7 @@ export interface UnifiedPack {
   tier: string
   source: string
   tags: string[]
+  relativePath: string
   componentCount: number
   threatCount: number
   isInDatabase: boolean

--- a/libraries/packs/aws-mini/pack.yaml
+++ b/libraries/packs/aws-mini/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: aws-mini
-  path: aws-mini
   name: AWS Mini
   version: 1.1.0
   pack_type: full

--- a/libraries/packs/aws/pack.yaml
+++ b/libraries/packs/aws/pack.yaml
@@ -8,7 +8,6 @@
 
 pack:
   slug: aws
-  path: aws
   name: "AWS Technologies"
   description: "Amazon Web Services cloud components for threat modeling diagrams"
   version: "2.0.0"

--- a/libraries/packs/azure/pack.yaml
+++ b/libraries/packs/azure/pack.yaml
@@ -1,7 +1,6 @@
 # Azure Technologies Pack
 pack:
   slug: azure
-  path: azure
   name: "Azure Technologies"
   description: "Microsoft Azure cloud components for threat modeling diagrams"
   version: "2.0.0"

--- a/libraries/packs/banking/pack.yaml
+++ b/libraries/packs/banking/pack.yaml
@@ -1,7 +1,6 @@
 # Banking Industry Pack
 pack:
   slug: banking
-  path: banking
   name: "Banking"
   description: "Banking and financial services components and DFD templates"
   version: "2.0.0"

--- a/libraries/packs/base-stride/pack.yaml
+++ b/libraries/packs/base-stride/pack.yaml
@@ -1,7 +1,6 @@
 # Base STRIDE Threat Pack
 pack:
   slug: base-stride
-  path: base-stride
   name: "Base STRIDE Threats"
   description: "Foundational STRIDE-based threats and countermeasures for threat modeling"
   version: "2.0.0"

--- a/libraries/packs/bci-mini/pack.yaml
+++ b/libraries/packs/bci-mini/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: bci-mini
-  path: bci-mini
   name: BCI Mini
   version: 1.0.0
   pack_type: full

--- a/libraries/packs/frameworks/cra/pack.yaml
+++ b/libraries/packs/frameworks/cra/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: cra
-  path: frameworks/cra
   name: "Cyber Resilience Act"
   version: "2.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/dora/pack.yaml
+++ b/libraries/packs/frameworks/dora/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: dora
-  path: frameworks/dora
   name: "DORA"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/gdpr/pack.yaml
+++ b/libraries/packs/frameworks/gdpr/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: gdpr
-  path: frameworks/gdpr
   name: "GDPR"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/hipaa/pack.yaml
+++ b/libraries/packs/frameworks/hipaa/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: hipaa
-  path: frameworks/hipaa
   name: "HIPAA"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/iso27001/pack.yaml
+++ b/libraries/packs/frameworks/iso27001/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: iso27001
-  path: frameworks/iso27001
   name: "ISO 27001:2022"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/mini-asvs/pack.yaml
+++ b/libraries/packs/frameworks/mini-asvs/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: mini-asvs
-  path: frameworks/mini-asvs
   name: "OWASP ASVS 4.0 (Mini)"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/nist-csf/pack.yaml
+++ b/libraries/packs/frameworks/nist-csf/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: nist-csf
-  path: frameworks/nist-csf
   name: "NIST CSF 2.0"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/owasp/pack.yaml
+++ b/libraries/packs/frameworks/owasp/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: owasp
-  path: frameworks/owasp
   name: "OWASP Top 10 2021"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/pci-dss/pack.yaml
+++ b/libraries/packs/frameworks/pci-dss/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: pci-dss
-  path: frameworks/pci-dss
   name: "PCI-DSS v4.0"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/frameworks/soc2/pack.yaml
+++ b/libraries/packs/frameworks/soc2/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: soc2
-  path: frameworks/soc2
   name: "SOC 2"
   version: "1.0.0"
   pack_type: compliance

--- a/libraries/packs/gcp/pack.yaml
+++ b/libraries/packs/gcp/pack.yaml
@@ -1,7 +1,6 @@
 # GCP Technologies Pack
 pack:
   slug: gcp
-  path: gcp
   name: "GCP Technologies"
   description: "Google Cloud Platform components for threat modeling diagrams"
   version: "2.0.0"

--- a/libraries/packs/generic/pack.yaml
+++ b/libraries/packs/generic/pack.yaml
@@ -1,7 +1,6 @@
 # Generic Technologies Pack
 pack:
   slug: generic
-  path: generic
   name: "Generic Technologies"
   description: "Vendor-agnostic components: open-source, frameworks, and self-hosted solutions"
   version: "2.0.0"

--- a/libraries/packs/mini-attack/pack.yaml
+++ b/libraries/packs/mini-attack/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: mini-attack
-  path: mini-attack
   name: Mini ATT&CK
   description: "Curated subset of MITRE ATT&CK Enterprise techniques covering the most common adversary behaviors in cloud and enterprise environments."
   version: "1.0.0"

--- a/libraries/packs/mini-capec/pack.yaml
+++ b/libraries/packs/mini-capec/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: mini-capec
-  path: mini-capec
   name: Mini CAPEC
   description: "Curated subset of MITRE CAPEC (Common Attack Pattern Enumeration and Classification) covering the most common web and cloud attack patterns."
   version: "1.0.0"

--- a/libraries/packs/mini-cwe/pack.yaml
+++ b/libraries/packs/mini-cwe/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: mini-cwe
-  path: mini-cwe
   name: Mini CWE
   description: "Curated subset of MITRE CWE (Common Weakness Enumeration) aligned with the CWE Top 25 Most Dangerous Software Weaknesses."
   version: "1.0.0"

--- a/libraries/packs/stride-taxonomy/pack.yaml
+++ b/libraries/packs/stride-taxonomy/pack.yaml
@@ -1,6 +1,5 @@
 pack:
   slug: stride-taxonomy
-  path: stride-taxonomy
   name: STRIDE Taxonomy
   description: "Microsoft STRIDE threat classification model"
   version: "1.0.0"


### PR DESCRIPTION
Simplify pack resolution: use filesystem as source of truth (#33); Removeself-declared path field from pack.yaml files and compute relative_path from the filesystem at discovery time. Switch preview_from_source and available_overlays endpoints from slug to path query param so lookups are truly O(1). Follows up on PR #47."  
[simplify-pack-resolution-issue-33 44160a1] Simplify pack resolution: use filesystem as source of truth (#33); Removeself-declared path field from pack.yaml files and compute relative_path from the filesystem at discovery time. Switch preview_from_source and available_overlays endpoints from slug to path query param so lookups are truly O(1). Follows up on PR #47.