### PR TITLE
[feat] dfd-editor : threats & countermeasures on canvas + node panel (#2)

### DIFF
--- a/backend/apps/threats/serializers.py
+++ b/backend/apps/threats/serializers.py
@@ -175,6 +175,7 @@ class ComponentInstanceThreatSerializer(serializers.ModelSerializer):
     threat_name_display = serializers.SerializerMethodField()
     taxonomy_entries = serializers.SerializerMethodField()
     component_name = serializers.CharField(source="component.name", read_only=True)
+    countermeasures = serializers.SerializerMethodField()
 
     # Write fields - accept threat_name for custom threats
     threat_name = serializers.CharField(required=False, allow_blank=True, write_only=True)
@@ -197,6 +198,7 @@ class ComponentInstanceThreatSerializer(serializers.ModelSerializer):
             "dismissal_reason",
             "format_metadata",
             "display_order",
+            "countermeasures",
             "created_at",
             "updated_at",
         ]
@@ -207,6 +209,7 @@ class ComponentInstanceThreatSerializer(serializers.ModelSerializer):
             "threat_name_display",
             "taxonomy_entries",
             "component_name",
+            "countermeasures",
         ]
 
     def get_threat_name_display(self, obj):
@@ -227,6 +230,11 @@ class ComponentInstanceThreatSerializer(serializers.ModelSerializer):
                 [j.taxonomy_entry for j in joins], many=True
             ).data
         return obj.taxonomy_snapshot
+
+    def get_countermeasures(self, obj):
+        """Nested countermeasures (resolved at request time; serializer class is defined below)."""
+        qs = obj.countermeasures.all().order_by("display_order", "created_at")
+        return ComponentInstanceCountermeasureSerializer(qs, many=True).data
 
     def create(self, validated_data):
         threat_library = validated_data.get("threat_library")

--- a/backend/apps/threats/views.py
+++ b/backend/apps/threats/views.py
@@ -2,7 +2,7 @@
 Views for threats app.
 """
 
-from django.db.models import Q
+from django.db.models import Prefetch, Q
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, status, viewsets
 from rest_framework.decorators import action
@@ -134,11 +134,18 @@ class ComponentInstanceThreatViewSet(viewsets.ModelViewSet):
         org_ids = self.request.user.organization_memberships.values_list(
             "organization_id", flat=True
         )
+        cm_qs = ComponentInstanceCountermeasure.objects.select_related(
+            "countermeasure_library",
+            "assigned_owner",
+            "verified_by",
+        ).order_by("display_order", "created_at")
         return ComponentInstanceThreat.objects.filter(
             Q(component__orgsystem__organization_id__in=org_ids)
             | Q(component__orgsystem__isnull=True,
                 component__threat_model__organization_id__in=org_ids)
-        ).select_related("component", "threat_library")
+        ).select_related("component", "threat_library").prefetch_related(
+            Prefetch("countermeasures", queryset=cm_qs),
+        )
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     filterset_fields = ["component", "threat_library", "status", "inherent_severity"]
     ordering_fields = ["inherent_severity", "status", "created_at"]
@@ -426,6 +433,7 @@ class ComponentInstanceCountermeasureViewSet(viewsets.ModelViewSet):
             current_status = serializer.instance.status
             _check_platform_status_permission(self.request.user, current_status, new_status)
         instance = serializer.save()
+        recalculate_threat_status(instance.instance_threat)
         recalculate_risks_for_threat(instance.instance_threat, threat_type="component")
 
     @action(detail=False, methods=["post"])

--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useRef, useEffect } from 'react'
+import { useCallback, useState, useRef } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import {
   ReactFlow,
@@ -35,6 +35,7 @@ import { useParentRelationships } from './hooks/useParentRelationships'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useConnectionMode } from './hooks/useConnectionMode'
 import { useBoundaryMode } from './hooks/useBoundaryMode'
+import { ThreatSummaryProvider } from './contexts/ThreatSummaryContext'
 import type { DiagramNode, DiagramEdge, DataFlowEdge, TrustBoundaryEdge } from './types'
 
 function DFDEditorContent() {
@@ -270,9 +271,13 @@ function DFDEditorContent() {
     }
   }, [boundaryMode, cancelBoundaryMode])
 
+  const handleSave = useCallback(async () => {
+    await saveNow()
+  }, [saveNow])
+
   // Keyboard shortcuts
   useKeyboardShortcuts({
-    onSave: saveNow,
+    onSave: handleSave,
     onUndo: undo,
     onDeselect: handleDeselect,
     enabled: true,
@@ -354,6 +359,7 @@ function DFDEditorContent() {
   }
 
   return (
+    <ThreatSummaryProvider threatModelId={threatModelId}>
     <div className="flex flex-col h-[calc(100vh-44px)]">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-2 border-b bg-background">
@@ -424,7 +430,7 @@ function DFDEditorContent() {
 
           <Button
             size="sm"
-            onClick={saveNow}
+            onClick={handleSave}
             disabled={isSaving || !hasUnsavedChanges}
           >
             <Save className="h-4 w-4 mr-2" />
@@ -452,7 +458,7 @@ function DFDEditorContent() {
         onOpenTemplates={() => setShowTemplates(true)}
         onOpenThreatAnalysis={async () => {
           if (hasUnsavedChanges) {
-            await saveNow()
+            await handleSave()
           }
           navigate(`/threat-models/${threatModelId}`)
         }}
@@ -544,6 +550,7 @@ function DFDEditorContent() {
         isDeleting={deleteDFDMutation.isPending}
       />
     </div>
+    </ThreatSummaryProvider>
   )
 }
 

--- a/frontend/src/features/dfd-editor/components/nodes/DataStoreNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/DataStoreNode.tsx
@@ -5,17 +5,18 @@ import { cn } from '@/lib/utils'
 import type { DataStoreNodeData } from '../../types'
 import { DATA_SENSITIVITY_CONFIG } from '../../types'
 import { useTechnologyDisplayName } from '../../api/component-library'
+import { NodeThreatBadge } from './NodeThreatBadge'
 
 type DataStoreNodeType = Node<DataStoreNodeData, 'datastore'>
 
 export const DataStoreNode = memo(function DataStoreNode({
+  id,
   data,
   selected,
 }: NodeProps<DataStoreNodeType>) {
   const isNewlyInserted = data.isNewlyInserted
   const technologyDisplayName = useTechnologyDisplayName(data.technology)
   const [showLockAnimation, setShowLockAnimation] = useState(false)
-
   // Trigger lock animation when lockAnimationKey changes (new timestamp = new animation)
   useEffect(() => {
     if (data.lockAnimationKey) {
@@ -93,6 +94,7 @@ export const DataStoreNode = memo(function DataStoreNode({
                 {DATA_SENSITIVITY_CONFIG[data.dataSensitivity].label}
               </div>
             )}
+            <NodeThreatBadge nodeId={id} className="mt-1.5 text-center" />
           </div>
 
           {/* Bottom ellipse */}

--- a/frontend/src/features/dfd-editor/components/nodes/HumanActorNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/HumanActorNode.tsx
@@ -2,16 +2,17 @@ import { memo, useEffect, useState } from 'react'
 import { Handle, Position, type Node, type NodeProps } from '@xyflow/react'
 import { cn } from '@/lib/utils'
 import type { HumanActorNodeData } from '../../types'
+import { NodeThreatBadge } from './NodeThreatBadge'
 
 type HumanActorNodeType = Node<HumanActorNodeData, 'humanActor'>
 
 export const HumanActorNode = memo(function HumanActorNode({
+  id,
   data,
   selected,
 }: NodeProps<HumanActorNodeType>) {
   const isNewlyInserted = data.isNewlyInserted
   const [showLockAnimation, setShowLockAnimation] = useState(false)
-
   // Trigger lock animation when lockAnimationKey changes (new timestamp = new animation)
   useEffect(() => {
     if (data.lockAnimationKey) {
@@ -66,6 +67,7 @@ export const HumanActorNode = memo(function HumanActorNode({
         <span className="font-medium text-sm text-green-900 text-center">
           {data.label}
         </span>
+        <NodeThreatBadge nodeId={id} className="mt-1 text-center" />
       </div>
     </>
   )

--- a/frontend/src/features/dfd-editor/components/nodes/NodeThreatBadge.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/NodeThreatBadge.tsx
@@ -1,0 +1,42 @@
+import { memo } from 'react'
+import { cn } from '@/lib/utils'
+import { useThreatSummary } from '../../contexts/ThreatSummaryContext'
+
+interface NodeThreatBadgeProps {
+  nodeId: string
+  className?: string
+}
+
+/** Canvas pill: threat workload + native tooltip with worst inherent/residual severities. */
+export const NodeThreatBadge = memo(function NodeThreatBadge({ nodeId, className }: NodeThreatBadgeProps) {
+  const s = useThreatSummary(nodeId)
+  if (!s || s.total <= 0) return null
+
+  const tone =
+    s.exposed > 0 ? 'exposed' : s.addressable > 0 ? 'addressable' : 'mitigated'
+  const label =
+    s.exposed > 0
+      ? `${s.exposed} exposed`
+      : s.addressable > 0
+        ? `${s.addressable} in progress`
+        : `${s.total} mitigated`
+
+  const tipParts = [`${s.total} active threat(s)`, label]
+  if (s.worstInherent) tipParts.push(`Worst inherent: ${s.worstInherent}`)
+  if (s.worstResidual) tipParts.push(`Worst residual: ${s.worstResidual}`)
+
+  return (
+    <div
+      title={tipParts.join(' · ')}
+      className={cn(
+        'text-[10px] px-1.5 py-0.5 rounded font-medium',
+        tone === 'exposed' && 'bg-red-100 text-red-700',
+        tone === 'addressable' && 'bg-yellow-100 text-yellow-700',
+        tone === 'mitigated' && 'bg-green-100 text-green-700',
+        className
+      )}
+    >
+      {label}
+    </div>
+  )
+})

--- a/frontend/src/features/dfd-editor/components/nodes/ProcessNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/ProcessNode.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import type { ProcessNodeData } from '../../types'
 import { DATA_SENSITIVITY_CONFIG } from '../../types'
 import { useTechnologyDisplayName } from '../../api/component-library'
+import { NodeThreatBadge } from './NodeThreatBadge'
 
 type ProcessNodeType = Node<ProcessNodeData, 'process'>
 
@@ -42,7 +43,6 @@ export const ProcessNode = memo(function ProcessNode({
   const technologyDisplayName = useTechnologyDisplayName(data.technology)
   const [showLockAnimation, setShowLockAnimation] = useState(false)
   const [showReceiveAnimation, setShowReceiveAnimation] = useState(false)
-
   // Check if this process has children (makes it a container)
   const isContainer = useStore(
     useCallback(
@@ -128,6 +128,7 @@ export const ProcessNode = memo(function ProcessNode({
                 {DATA_SENSITIVITY_CONFIG[data.dataSensitivity].label}
               </div>
             )}
+            <NodeThreatBadge nodeId={id} className="absolute bottom-1 right-3" />
           </>
         ) : (
           <>
@@ -155,6 +156,7 @@ export const ProcessNode = memo(function ProcessNode({
                 {DATA_SENSITIVITY_CONFIG[data.dataSensitivity].label}
               </div>
             )}
+            <NodeThreatBadge nodeId={id} className="mt-1.5 text-center" />
           </>
         )}
       </div>

--- a/frontend/src/features/dfd-editor/components/nodes/SystemActorNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/SystemActorNode.tsx
@@ -3,16 +3,17 @@ import { Handle, Position, type Node, type NodeProps } from '@xyflow/react'
 import { Server } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { SystemActorNodeData } from '../../types'
+import { NodeThreatBadge } from './NodeThreatBadge'
 
 type SystemActorNodeType = Node<SystemActorNodeData, 'systemActor'>
 
 export const SystemActorNode = memo(function SystemActorNode({
+  id,
   data,
   selected,
 }: NodeProps<SystemActorNodeType>) {
   const isNewlyInserted = data.isNewlyInserted
   const [showLockAnimation, setShowLockAnimation] = useState(false)
-
   // Trigger lock animation when lockAnimationKey changes (new timestamp = new animation)
   useEffect(() => {
     if (data.lockAnimationKey) {
@@ -54,6 +55,7 @@ export const SystemActorNode = memo(function SystemActorNode({
         <span className="font-medium text-sm text-slate-900 text-center">
           {data.label}
         </span>
+        <NodeThreatBadge nodeId={id} className="mt-1 text-center" />
       </div>
     </>
   )

--- a/frontend/src/features/dfd-editor/components/nodes/TrustZoneNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/TrustZoneNode.tsx
@@ -4,16 +4,17 @@ import { Shield } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { TrustZoneNodeData } from '../../types'
 import { getZoneColorConfig } from '../../types'
+import { NodeThreatBadge } from './NodeThreatBadge'
 
 type TrustZoneNodeType = Node<TrustZoneNodeData, 'trustZone'>
 
 export const TrustZoneNode = memo(function TrustZoneNode({
+  id,
   data,
   selected,
 }: NodeProps<TrustZoneNodeType>) {
   const isNewlyInserted = data.isNewlyInserted
   const [showLockAnimation, setShowLockAnimation] = useState(false)
-
   const trustLevel = data.trustLevel ?? 75
   const { color: displayColor, borderColor: displayBorderColor } = getZoneColorConfig(data.zoneColor)
 
@@ -80,6 +81,8 @@ export const TrustZoneNode = memo(function TrustZoneNode({
         >
           TL: {trustLevel}
         </div>
+
+        <NodeThreatBadge nodeId={id} className="absolute bottom-1 right-3" />
       </div>
     </>
   )

--- a/frontend/src/features/dfd-editor/components/panels/NodeEditPanel.tsx
+++ b/frontend/src/features/dfd-editor/components/panels/NodeEditPanel.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { TechnologyCombobox } from '../technology-combobox'
 import { SuggestionCombobox } from '../suggestion-combobox'
+import { NodeThreatSection } from './NodeThreatSection'
 import { useThreatModelSystems, useUpdateComponentSystem } from '@/features/threat-models/api/threat-models'
 import { useDataAssets } from '@/features/threat-models/api/data-assets'
 import {
@@ -804,6 +805,24 @@ export const NodeEditPanel = memo(function NodeEditPanel({
               </div>
             </div>
           </>
+        )}
+
+        {/* Threats & Countermeasures — all analyzable node types */}
+        {['process', 'datastore', 'humanActor', 'systemActor'].includes(node.type as string) && (
+          (node.data as { componentId?: number }).componentId ? (
+            <NodeThreatSection
+              componentId={(node.data as { componentId?: number }).componentId!}
+              componentName={String(node.data.label || '')}
+            />
+          ) : (
+            <>
+              <Separator />
+              <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50 text-xs text-muted-foreground">
+                <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
+                Save the diagram to enable threat analysis for this component.
+              </div>
+            </>
+          )
         )}
 
         {/* Node info */}

--- a/frontend/src/features/dfd-editor/components/panels/NodeThreatSection.tsx
+++ b/frontend/src/features/dfd-editor/components/panels/NodeThreatSection.tsx
@@ -1,0 +1,306 @@
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { Shield, Plus, Zap, ChevronDown, ChevronUp, AlertTriangle, Link2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+import { AddThreatDialog } from '../threat-analysis/AddThreatDialog'
+import { AddCountermeasureDialog } from '../threat-analysis/AddCountermeasureDialog'
+import { useComponentThreats, useGenerateThreats } from '@/features/threat-models/api/threats'
+import type { ComponentInstanceCountermeasure, GenerateThreatsResponse } from '@/features/threat-models/api/threats'
+import { THREAT_STATUS_CONFIG, COUNTERMEASURE_STATUS_CONFIG } from '../../types/threat-analysis'
+import type { ThreatStatus, CountermeasureStatus } from '../../types/threat-analysis'
+
+interface NodeThreatSectionProps {
+  componentId: number
+  componentName: string
+}
+
+function toThreatStatus(s: string): ThreatStatus {
+  if (s === 'mitigated') return 'mitigated'
+  if (s === 'addressable') return 'addressable'
+  return 'exposed'
+}
+
+function formatSeverityLabel(value: string | undefined | null): string {
+  const v = String(value ?? '').trim().toLowerCase()
+  if (!v) return 'Not assessed'
+  return v
+}
+
+function sortedCountermeasures(list: ComponentInstanceCountermeasure[] | undefined) {
+  if (!list?.length) return []
+  return [...list].sort(
+    (a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0) || a.id - b.id
+  )
+}
+
+function CountermeasureRow({
+  cm,
+}: {
+  cm: ComponentInstanceCountermeasure
+}) {
+  const status = cm.status as CountermeasureStatus
+  const cfg = COUNTERMEASURE_STATUS_CONFIG[status] ?? COUNTERMEASURE_STATUS_CONFIG.gap
+  const name =
+    cm.countermeasureNameDisplay?.trim() ||
+    cm.countermeasureName?.trim() ||
+    'Countermeasure'
+
+  return (
+    <div
+      className={cn(
+        'rounded border px-2 py-1.5 text-[11px] space-y-1',
+        cm.isInherited ? 'border-blue-200 bg-blue-50/50' : 'border-border bg-muted/30'
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="font-medium leading-snug text-foreground line-clamp-2">{name}</span>
+        <div className="flex items-center gap-1 shrink-0">
+          <span className="w-2 h-2 rounded-full" style={{ backgroundColor: cfg.color }} />
+          <span className="text-[9px] font-medium capitalize text-foreground">{cfg.label}</span>
+        </div>
+      </div>
+      {cm.assignedOwnerEmail && (
+        <p className="text-muted-foreground">
+          Owner: <span className="text-foreground">{cm.assignedOwnerEmail}</span>
+        </p>
+      )}
+      {cm.isInherited && (cm.inheritedFromZoneName || cm.inheritedFromComponentName) && (
+        <p className="flex items-center gap-1 text-blue-800/90">
+          <Link2 className="h-3 w-3 shrink-0" />
+          <span>
+            Inherited
+            {cm.inheritedFromZoneName ? ` from zone “${cm.inheritedFromZoneName}”` : ''}
+            {cm.inheritedFromComponentName && !cm.inheritedFromZoneName
+              ? ` from “${cm.inheritedFromComponentName}”`
+              : ''}
+          </span>
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function NodeThreatSection({ componentId, componentName }: NodeThreatSectionProps) {
+  const [expanded, setExpanded] = useState(true)
+  const [addThreatOpen, setAddThreatOpen] = useState(false)
+  const [addCountermeasureFor, setAddCountermeasureFor] = useState<{
+    threatId: number
+    threatName: string
+    threatLibraryId?: number | null
+  } | null>(null)
+
+  const { data: threats = [], isLoading } = useComponentThreats(componentId)
+  const generateMutation = useGenerateThreats()
+
+  const activeThreats = useMemo(() => threats.filter((t) => !t.isDismissed), [threats])
+  const exposedCount = activeThreats.filter((t) => t.status === 'exposed').length
+
+  return (
+    <>
+      <Separator />
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label
+            className="flex items-center gap-1.5 cursor-pointer"
+            onClick={() => setExpanded((v) => !v)}
+          >
+            <Shield className="h-3.5 w-3.5 text-red-500" />
+            Threats
+            {activeThreats.length > 0 && (
+              <Badge
+                variant="outline"
+                className={cn(
+                  'h-5 px-1.5 text-[10px]',
+                  exposedCount > 0 ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'
+                )}
+              >
+                {activeThreats.length}
+              </Badge>
+            )}
+          </Label>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              title="Generate threats from library"
+              disabled={generateMutation.isPending}
+              onClick={() =>
+                generateMutation.mutate(componentId, {
+                  onSuccess: (result: GenerateThreatsResponse) => {
+                    if (result.createdCount > 0) {
+                      toast.success(
+                        `Generated ${result.createdCount} new threat${result.createdCount !== 1 ? 's' : ''}`
+                      )
+                    } else {
+                      toast.info(`No new threats — ${result.existingCount} already up to date`)
+                    }
+                  },
+                  onError: () => {
+                    toast.error('Failed to generate threats')
+                  },
+                })
+              }
+            >
+              <Zap className="h-3 w-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              title="Add threat"
+              onClick={() => setAddThreatOpen(true)}
+            >
+              <Plus className="h-3 w-3" />
+            </Button>
+            <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => setExpanded((v) => !v)}>
+              {expanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            </Button>
+          </div>
+        </div>
+
+        {expanded && (
+          <div className="space-y-2">
+            {isLoading && <p className="text-xs text-muted-foreground py-1">Loading threats...</p>}
+
+            {!isLoading && activeThreats.length === 0 && (
+              <div className="rounded-lg border border-dashed border-border px-3 py-4 text-center space-y-1">
+                <p className="text-xs text-muted-foreground">No threats yet.</p>
+                <p className="text-[11px] text-muted-foreground/70">
+                  Click <Zap className="inline h-3 w-3" /> to generate from library or{' '}
+                  <button
+                    className="underline underline-offset-2 hover:text-foreground"
+                    onClick={() => setAddThreatOpen(true)}
+                  >
+                    add manually
+                  </button>
+                  .
+                </p>
+              </div>
+            )}
+
+            {activeThreats.map((threat) => {
+              const status = toThreatStatus(threat.status)
+              const statusConfig = THREAT_STATUS_CONFIG[status]
+              const displayName =
+                threat.threatNameDisplay || threat.threatName || 'Unnamed threat'
+              const cms = sortedCountermeasures(threat.countermeasures)
+
+              const statusColors: Record<string, string> = {
+                exposed: 'border-red-200 bg-red-50/60',
+                addressable: 'border-yellow-200 bg-yellow-50/60',
+                mitigated: 'border-green-200 bg-green-50/60',
+              }
+
+              return (
+                <div
+                  key={threat.id}
+                  className={cn(
+                    'rounded-lg border px-3 py-2.5 space-y-2',
+                    statusColors[status] ?? 'border-border bg-muted/40'
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex items-center gap-1.5 min-w-0 flex-1">
+                      {status === 'exposed' && (
+                        <AlertTriangle className="h-3.5 w-3.5 text-red-500 flex-shrink-0 mt-px" />
+                      )}
+                      <span className="font-medium text-sm leading-snug line-clamp-2">{displayName}</span>
+                    </div>
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        'text-[10px] h-5 px-2 flex-shrink-0 capitalize font-medium',
+                        statusConfig.bgColor
+                      )}
+                    >
+                      {statusConfig.label}
+                    </Badge>
+                  </div>
+
+                  <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+                    <span className="capitalize">
+                      Inherent:{' '}
+                      <span className="text-foreground font-medium">
+                        {formatSeverityLabel(threat.inherentSeverity)}
+                      </span>
+                    </span>
+                    <span className="capitalize">
+                      Residual:{' '}
+                      <span
+                        className={cn(
+                          'font-medium',
+                          String(threat.residualSeverity ?? '').trim()
+                            ? 'text-foreground'
+                            : 'text-muted-foreground italic'
+                        )}
+                      >
+                        {formatSeverityLabel(threat.residualSeverity)}
+                      </span>
+                    </span>
+                  </div>
+
+                  {cms.length > 0 && (
+                    <div className="space-y-1.5 pt-1">
+                      <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                        Countermeasures
+                      </p>
+                      <div className="space-y-1.5">
+                        {cms.map((cm) => (
+                          <CountermeasureRow key={cm.id} cm={cm} />
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="flex justify-end pt-0.5">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-6 text-[11px] px-2 gap-1"
+                      onClick={() =>
+                        setAddCountermeasureFor({
+                          threatId: threat.id,
+                          threatName: displayName,
+                          threatLibraryId: threat.threatLibrary ?? null,
+                        })
+                      }
+                    >
+                      <Plus className="h-3 w-3" />
+                      Add countermeasure
+                    </Button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      <AddThreatDialog
+        open={addThreatOpen}
+        onOpenChange={setAddThreatOpen}
+        targetId={componentId}
+        targetType="component"
+        targetName={componentName}
+      />
+
+      {addCountermeasureFor && (
+        <AddCountermeasureDialog
+          open={!!addCountermeasureFor}
+          onOpenChange={(open) => {
+            if (!open) setAddCountermeasureFor(null)
+          }}
+          threatId={addCountermeasureFor.threatId}
+          threatType="component"
+          threatName={addCountermeasureFor.threatName}
+          threatLibraryId={addCountermeasureFor.threatLibraryId}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/features/dfd-editor/contexts/ThreatSummaryContext.tsx
+++ b/frontend/src/features/dfd-editor/contexts/ThreatSummaryContext.tsx
@@ -1,0 +1,96 @@
+import { createContext, useContext, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+import { deriveThreatStatus, worseSeverity } from '../types/threat-analysis'
+import type { ThreatModelThreatsResponse } from '@/features/threat-models/api/threats'
+import { transformBackendThreatsToComponentThreats } from '@/features/threat-models/api/threats'
+
+export interface NodeThreatSummary {
+  total: number
+  exposed: number
+  addressable: number
+  mitigated: number
+  /** Highest inherent severity across active threats on this node (for tooltips). */
+  worstInherent?: string
+  /** Highest residual severity across active threats on this node (for tooltips). */
+  worstResidual?: string
+}
+
+type ThreatSummaryMap = Map<string, NodeThreatSummary>
+
+interface ThreatSummaryContextValue {
+  summaryMap: ThreatSummaryMap
+  threatModelId: string | undefined
+}
+
+const ThreatSummaryContext = createContext<ThreatSummaryContextValue>({
+  summaryMap: new Map(),
+  threatModelId: undefined,
+})
+
+export function ThreatSummaryProvider({
+  threatModelId,
+  children,
+}: {
+  threatModelId: string | undefined
+  children: React.ReactNode
+}) {
+  const { data } = useQuery({
+    queryKey: ['threat-model-threats', threatModelId],
+    queryFn: threatModelId
+      ? async () => {
+          const response = await api.get<ThreatModelThreatsResponse>(
+            `/threat-models/${threatModelId}/threats/`
+          )
+          return {
+            ...response,
+            componentThreats: transformBackendThreatsToComponentThreats(response.threats),
+          }
+        }
+      : undefined,
+    enabled: !!threatModelId,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+  })
+
+  const summaryMap = useMemo<ThreatSummaryMap>(() => {
+    const map = new Map<string, NodeThreatSummary>()
+    if (!data?.componentThreats) return map
+
+    for (const threat of data.componentThreats) {
+      if (threat.dismissed) continue
+      const nodeId = threat.componentId
+      if (!nodeId) continue
+
+      const existing = map.get(nodeId) ?? {
+        total: 0,
+        exposed: 0,
+        addressable: 0,
+        mitigated: 0,
+        worstInherent: undefined as string | undefined,
+        worstResidual: undefined as string | undefined,
+      }
+      const status = deriveThreatStatus(threat.countermeasures)
+      map.set(nodeId, {
+        total: existing.total + 1,
+        exposed: existing.exposed + (status === 'exposed' ? 1 : 0),
+        addressable: existing.addressable + (status === 'addressable' ? 1 : 0),
+        mitigated: existing.mitigated + (status === 'mitigated' ? 1 : 0),
+        worstInherent: worseSeverity(existing.worstInherent, threat.inherentSeverity),
+        worstResidual: worseSeverity(existing.worstResidual, threat.residualSeverity),
+      })
+    }
+    return map
+  }, [data?.componentThreats])
+
+  return (
+    <ThreatSummaryContext.Provider value={{ summaryMap, threatModelId }}>
+      {children}
+    </ThreatSummaryContext.Provider>
+  )
+}
+
+export function useThreatSummary(nodeId: string): NodeThreatSummary | null {
+  const { summaryMap } = useContext(ThreatSummaryContext)
+  return summaryMap.get(nodeId) ?? null
+}

--- a/frontend/src/features/dfd-editor/hooks/useDiagramState.ts
+++ b/frontend/src/features/dfd-editor/hooks/useDiagramState.ts
@@ -29,7 +29,7 @@ interface UseDiagramStateReturn {
   setEdges: React.Dispatch<React.SetStateAction<DiagramEdge[]>>
   onNodesChange: (changes: NodeChange<DiagramNode>[]) => void
   onEdgesChange: (changes: EdgeChange<DiagramEdge>[]) => void
-  saveNow: () => Promise<void>
+  saveNow: () => Promise<Diagram>
   updateTitle: (title: string) => Promise<void>
   // Undo feature - remove this line to disable undo functionality
   undo: () => void
@@ -261,7 +261,8 @@ export function useDiagramState({
 
   // Save now function
   const saveNow = useCallback(async () => {
-    await saveMutation.mutateAsync({ nodes, edges })
+    const result = await saveMutation.mutateAsync({ nodes, edges })
+    return result
   }, [nodes, edges, saveMutation])
 
   // Update title function

--- a/frontend/src/features/dfd-editor/types/threat-analysis.ts
+++ b/frontend/src/features/dfd-editor/types/threat-analysis.ts
@@ -156,6 +156,7 @@ export interface ComponentThreat {
   taxonomyEntries?: TaxonomyEntry[]
   // Severity scoring metadata
   inherentSeverity?: string
+  residualSeverity?: string
   severityScoringMetadata?: Record<string, unknown>
   // Display order for drag-and-drop reordering
   displayOrder?: number
@@ -204,6 +205,24 @@ export function deriveThreatStatus(countermeasures: ComponentThreatCountermeasur
 
   // All are 'platform' or 'verified' (no gaps, no planned, no waived)
   return 'mitigated'
+}
+
+const SEVERITY_RANK: Record<string, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+}
+
+/** Return the higher (worse) of two severity labels for rollup on the canvas. */
+export function worseSeverity(a: string | undefined, b: string | undefined): string | undefined {
+  const ra = SEVERITY_RANK[String(a ?? '').toLowerCase()] ?? 0
+  const rb = SEVERITY_RANK[String(b ?? '').toLowerCase()] ?? 0
+  const ta = String(a ?? '').trim()
+  const tb = String(b ?? '').trim()
+  if (!ta) return tb || undefined
+  if (!tb) return ta
+  return rb >= ra ? tb : ta
 }
 
 /**

--- a/frontend/src/features/threat-models/api/threats.ts
+++ b/frontend/src/features/threat-models/api/threats.ts
@@ -15,8 +15,9 @@ export interface ComponentInstanceThreat {
   id: number
   component: number
   componentName: string
-  threatLibrary: number
+  threatLibrary: number | null
   threatName: string
+  threatNameDisplay?: string  // read field from serializer (threat_name_display)
   taxonomyEntries?: TaxonomyEntry[]
   inherentSeverity: string
   residualSeverity: string
@@ -27,6 +28,8 @@ export interface ComponentInstanceThreat {
   formatMetadata: Record<string, unknown>
   createdAt: string
   updatedAt: string
+  /** Populated on list/detail when nested serialization is enabled */
+  countermeasures?: ComponentInstanceCountermeasure[]
 }
 
 export interface CountermeasureLibraryItem {
@@ -54,6 +57,11 @@ export interface ComponentInstanceCountermeasure {
   instanceThreat: number
   countermeasureLibrary: number
   countermeasureName: string
+  countermeasureNameDisplay?: string | null
+  countermeasureDescription?: string
+  controlType?: string
+  controlTypeDisplay?: string
+  effectiveness?: number | null
   status: BackendCountermeasureStatus
   priority: string
   verifiedBy: number | null
@@ -63,6 +71,7 @@ export interface ComponentInstanceCountermeasure {
   assignedOwner: number | null
   assignedOwnerEmail: string | null
   formatMetadata: Record<string, unknown>
+  displayOrder?: number
   isInherited?: boolean
   inheritedFromComponentName?: string
   inheritedFromZoneName?: string
@@ -703,6 +712,7 @@ export function transformBackendThreatsToComponentThreats(
       taxonomyEntries: bt.taxonomyEntries,
       // Severity scoring metadata
       inherentSeverity: bt.inherentSeverity,
+      residualSeverity: bt.residualSeverity,
       severityScoringMetadata: bt.severityScoringMetadata,
       // Display order for drag-and-drop reordering
       displayOrder: bt.displayOrder ?? 0,


### PR DESCRIPTION
Closes #2

### Summary
Surfaced threat-model data in the DFD editor so users can see workload and mitigate threats without leaving the diagram.

The node inspect panel lists threats with severity, nested countermeasures (status, owner, zone inheritance), and actions aligned with Threat Analysis (generate, add threat, add countermeasure). Canvas nodes show aggregate pills with hover text for counts and rolled-up severities.

Backend returns nested countermeasures on `GET .../component-threats/` with prefetch; countermeasure `PATCH` recalculates threat status when status changes.

https://github.com/user-attachments/assets/483ea2ff-c70e-4554-9b3a-4f4ddf1c1bcf

### What Changed

#### Frontend
- **ThreatSummaryProvider + useThreatSummary**: One query (`threat-model-threats`), rollup map by canvas node id (`staleTime: 0`, refetch on focus).
- **NodeThreatSection**: Displays threats (inherent + residual), countermeasure list (gap/planned/verified/waived/platform), owner email, inherited-from (zone/component), and generate/add actions.
- **NodeThreatBadge**: Added to Process, Data Store, Human Actor, System Actor, and Trust Zone nodes. Tooltip includes worst inherent/residual severity where data exists.
- `saveNow()` now returns the diagram.
- Diagram / API typing refinements (`threatNameDisplay`, `threatLibrary` nullable, nested CM types).
- Added `worseSeverity` helper for rollup.
- `transformBackendThreatsToComponentThreats` includes `residualSeverity`.
- Removed non-functional component conflict/restore flow (never worked after orphan delete). Dropped `RestoreComponentDialog` and related `PATCH componentConflicts` behavior.

#### Backend
- **ComponentInstanceThreatSerializer**: Now includes nested read-only countermeasures. Optimized list/detail prefetch.
- **ComponentInstanceCountermeasureViewSet.perform_update**: Calls `recalculate_threat_status` after updates so verified/platform countermeasures correctly move threats to mitigated.
- Diagrams sync: Stripped dead restore/conflict pre-pass.

### Known Limitations / Documented Caveats (I am confused about these so please review and suggest a follow up if needed)
- Residual severity on `ComponentInstanceThreat` is optional in the schema and is **not** auto-derived from countermeasures. Auto-generated threats often leave it blank until set elsewhere (e.g. severity workflow). UI shows **“Not assessed”** when unset.
- Data-flow threats are not shown as badges on edges (aggregation is keyed by component node ids).
- Trust zone pills appear only when threats resolve to that zone’s canvas node id (rare compared to component-keyed threats).
- Residual is not computed from CM state in this PR — uses stored value only.

**Node deletion behavior (explicit):**  
Deleting an analyzable node from the diagram and saving the primary DFD triggers orphan cleanup → `OrgsystemComponent` deletion → CASCADE removes that instance’s threats/countermeasures. Re-analysis creates a new component row when the node is re-added.

### How to Test
- **Primary DFD**: Add/sync nodes → confirm pills and tooltips match workspace counts/severities.
- **Panel**: Check severities (residual unset → “Not assessed”), CM rows (status dot, owner, inherited line), generate/add threat/add CM actions + toasts + refetch.
- **Workspace ⇄ Editor**: Toggle CM status (e.g. to verified) → badge and panel should update after invalidate/refetch.
- Verify `GET .../component-threats/?component=` includes `countermeasures` array.
- Save diagram → confirm no `componentConflicts` in PATCH body/response.