### PR TITLE
fix: generate threats for existing components/flows on

### DIFF
--- a/backend/apps/diagrams/services.py
+++ b/backend/apps/diagrams/services.py
@@ -120,17 +120,41 @@ def _cleanup_orphaned_records(old_canvas_data, new_canvas_data, threat_model):
 
     # 2. DataFlows (FK source/dest component -> CASCADE, delete before components)
     if orphaned_dataflow_ids:
+        # Capture affected risk IDs before CASCADE wipes RiskThreat links
+        affected_risk_ids = list(
+            RiskThreat.objects.filter(
+                flow_threat__data_flow_id__in=orphaned_dataflow_ids
+            ).values_list("risk_id", flat=True).distinct()
+        )
+
         count, _ = DataFlow.objects.filter(id__in=orphaned_dataflow_ids).delete()
         deleted_counts["dataflows"] = count
+
+        # Recalculate risks that lost threat links
+        for risk in Risk.objects.filter(id__in=affected_risk_ids):
+            recalculate_risk(risk)
 
     # 3. Components (CASCADE -> ComponentInstanceThreat -> ComponentInstanceCountermeasure)
     # Scope to this threat model to prevent cross-model deletion from corrupted canvas data
     if orphaned_component_ids:
+        # Capture affected risk IDs before CASCADE wipes RiskThreat links
+        affected_risk_ids = list(
+            RiskThreat.objects.filter(
+                Q(component_threat__component_id__in=orphaned_component_ids)
+                | Q(flow_threat__data_flow__source_component_id__in=orphaned_component_ids)
+                | Q(flow_threat__data_flow__dest_component_id__in=orphaned_component_ids)
+            ).values_list("risk_id", flat=True).distinct()
+        )
+
         count, _ = OrgsystemComponent.objects.filter(
             id__in=orphaned_component_ids,
             threat_model=threat_model,
         ).delete()
         deleted_counts["components"] = count
+
+        # Recalculate risks that lost threat links
+        for risk in Risk.objects.filter(id__in=affected_risk_ids):
+            recalculate_risk(risk)
 
     # 4. Trust zones
     if orphaned_zone_ids:
@@ -209,7 +233,7 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
     created_count = 0
     threats_generated = 0
     node_component_map = {}
-    new_components = []
+    all_synced_components = []
 
     with transaction.atomic():
         # Sync trust zone nodes first (zones must exist before component assignment)
@@ -315,7 +339,7 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                             data_sensitivity_level=node_data.get("data_sensitivity", "") if node_type in ("process", "datastore") else "",
                         )
                         created_count += 1
-                        new_components.append(component)
+                        all_synced_components.append(component)
                     else:
                         # No library change (or first assignment): update in place
                         component.name = label
@@ -336,10 +360,7 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                             component.threat_model = threat_model
                         component.save()
                         synced_count += 1
-
-                        # Generate threats if library was just assigned (null to non-null)
-                        if library_changed and new_library_id is not None:
-                            new_components.append(component)
+                        all_synced_components.append(component)
 
                 except OrgsystemComponent.DoesNotExist:
                     # Component was deleted, create new one
@@ -359,7 +380,7 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                         data_sensitivity_level=node_data.get("data_sensitivity", "") if node_type in ("process", "datastore") else "",
                     )
                     created_count += 1
-                    new_components.append(component)
+                    all_synced_components.append(component)
             else:
                 # Create new component with no system assigned
                 # component_library may be None for actors without technology
@@ -379,7 +400,7 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                     data_sensitivity_level=node_data.get("data_sensitivity", "") if node_type in ("process", "datastore") else "",
                 )
                 created_count += 1
-                new_components.append(component)
+                all_synced_components.append(component)
                 synced_count += 1
 
             node_component_map[node_id] = component.id
@@ -443,8 +464,8 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                 parent_component_id=parent_component_db_id,
             )
 
-        # Auto-generate threats for new components
-        for component in new_components:
+        # Auto-generate threats for all synced components (idempotent via get_or_create)
+        for component in all_synced_components:
             if component.component_library:
                 generated = _generate_threats_for_component(component)
                 threats_generated += generated
@@ -691,7 +712,7 @@ def _sync_edges_to_dataflows(dfd, edges, node_component_map):
     synced_count = 0
     created_count = 0
     threats_generated = 0
-    new_flows = []
+    all_synced_flows = []
     edge_dataflow_map = {}
 
     for edge in edges:
@@ -738,6 +759,7 @@ def _sync_edges_to_dataflows(dfd, edges, node_component_map):
                 dataflow.dest_component_id = target_component_id
                 dataflow.save()
                 synced_count += 1
+                all_synced_flows.append(dataflow)
             except DataFlow.DoesNotExist:
                 # DataFlow was deleted, create new one
                 dataflow = DataFlow.objects.create(
@@ -753,7 +775,8 @@ def _sync_edges_to_dataflows(dfd, edges, node_component_map):
                     data_classification=data_classification,
                 )
                 created_count += 1
-                new_flows.append(dataflow)
+                synced_count += 1
+                all_synced_flows.append(dataflow)
         else:
             # Create new DataFlow
             dataflow = DataFlow.objects.create(
@@ -769,7 +792,7 @@ def _sync_edges_to_dataflows(dfd, edges, node_component_map):
                 data_classification=data_classification,
             )
             created_count += 1
-            new_flows.append(dataflow)
+            all_synced_flows.append(dataflow)
             synced_count += 1
 
         edge_dataflow_map[edge_id] = dataflow.id
@@ -777,8 +800,8 @@ def _sync_edges_to_dataflows(dfd, edges, node_component_map):
     # Update canvas_data with dataflow_ids
     _update_canvas_with_dataflow_ids(dfd, edge_dataflow_map)
 
-    # Generate threats for new data flows
-    for dataflow in new_flows:
+    # Generate threats for all synced data flows (idempotent via get_or_create)
+    for dataflow in all_synced_flows:
         generated = _generate_threats_for_dataflow(dataflow)
         threats_generated += generated
 


### PR DESCRIPTION
  re-sync and recalculate risks on orphan deletion (#52)
  
  Fixes issue #52 
  
  
  More details:
  1. Threat generation on DataFlow re-sync — existing DataFlows now get threat generation on every sync, not just on first creation. New flow-tagged threats from pack updates are materialized on existing flows. 
2. Threat generation on Component re-sync — same fix on the component side. Existing components now pick up new ComponentLibraryThreat records from pack updates even when their library FK hasn't changed. 
3. Missing synced_count in DataFlow DoesNotExist fallback — the fallback create path (when a stored dataflow_id points to a deleted record) wasn't incrementing synced_count, making the returned stats inaccurate. 
4. Risk recalculation on orphaned DataFlow deletion — when DataFlows are removed from the canvas, risks linked to their flow threats now get recalculated so scores don't go stale. 
5. Risk recalculation on orphaned Component deletion — same fix for components removed from the canvas.