### PR TITLE
fix issue #26

### DIFF
--- a/backend/apps/packs/services.py
+++ b/backend/apps/packs/services.py
@@ -918,6 +918,109 @@ def validate_pack(pack_path: Path) -> ValidationResult:
                     message=f"Failed to parse: {e}",
                 ))
 
+        # Validate threat-taxonomy joins
+        # Build pool of known taxonomy slugs
+        known_taxonomy_slugs = set()
+
+        # From this pack's own taxonomy.yaml
+        if taxonomy_file.exists():
+            try:
+                with open(taxonomy_file) as f:
+                    own_tax_data = yaml.safe_load(f) or {}
+                for t in own_tax_data.get("taxonomies", []):
+                    if t.get("slug"):
+                        known_taxonomy_slugs.add(t["slug"])
+            except Exception:
+                pass
+
+        # From dependency packs' taxonomy.yaml files
+        dep_entries = pack_meta.get("depends_on", [])
+        if dep_entries:
+            libraries_path = get_libraries_path()
+            for dep_entry in dep_entries:
+                if isinstance(dep_entry, str):
+                    dep_slug = dep_entry
+                    dep_path = dep_entry
+                else:
+                    dep_slug = dep_entry.get("pack", dep_entry.get("slug", ""))
+                    dep_path = dep_entry.get("path", dep_slug)
+
+                dep_dir = _find_pack_dir(libraries_path, dep_path)
+                if not dep_dir and dep_path != dep_slug:
+                    dep_dir = _find_pack_dir(libraries_path, dep_slug)
+                if not dep_dir:
+                    # Fallback: search for pack with matching slug
+                    for nested_pack_yaml in libraries_path.glob("**/pack.yaml"):
+                        try:
+                            with open(nested_pack_yaml) as f:
+                                nested_pack_data = yaml.safe_load(f) or {}
+                            if nested_pack_data.get("pack", {}).get("slug") == dep_slug:
+                                dep_dir = nested_pack_yaml.parent
+                                break
+                        except Exception:
+                            continue
+
+                if dep_dir:
+                    dep_tax_file = dep_dir / "taxonomy.yaml"
+                    if dep_tax_file.exists():
+                        try:
+                            with open(dep_tax_file) as f:
+                                dep_tax_data = yaml.safe_load(f) or {}
+                            for t in dep_tax_data.get("taxonomies", []):
+                                if t.get("slug"):
+                                    known_taxonomy_slugs.add(t["slug"])
+                        except Exception:
+                            pass
+
+        # Fallback: also check database for already-imported taxonomies
+        db_taxonomy_slugs = set(
+            ExternalTaxonomy.objects.values_list("slug", flat=True)
+        )
+        known_taxonomy_slugs |= db_taxonomy_slugs
+
+        for join_file in joins_dir.glob("threats-*.yaml"):
+            if join_file.name == "threats-countermeasures.yaml":
+                continue
+            try:
+                with open(join_file) as f:
+                    join_data = yaml.safe_load(f) or {}
+                taxonomy_ref = join_data.get("taxonomy", "")
+                if taxonomy_ref and taxonomy_ref not in known_taxonomy_slugs:
+                    errors.append(ValidationError(
+                        file=f"joins/{join_file.name}",
+                        line=None,
+                        ref_type="taxonomy",
+                        reference=taxonomy_ref,
+                        message=(
+                            f"Taxonomy '{taxonomy_ref}' not found. "
+                            f"Note: taxonomy slugs come from taxonomy.yaml, "
+                            f"not from the pack slug. "
+                            f"Available taxonomies: {sorted(known_taxonomy_slugs)}"
+                        ),
+                    ))
+
+                # Also validate threat references in mappings
+                for mapping in join_data.get("mappings", []):
+                    threat_ref = mapping.get("threat", "")
+                    if (threat_ref and "/" not in threat_ref
+                            and threat_ref not in pack_threats):
+                        if not _resolve_threat_reference_exists(slug, threat_ref):
+                            errors.append(ValidationError(
+                                file=f"joins/{join_file.name}",
+                                line=None,
+                                ref_type="threat",
+                                reference=threat_ref,
+                                message=f"Threat '{threat_ref}' not found in pack or database",
+                            ))
+            except Exception as e:
+                errors.append(ValidationError(
+                    file=f"joins/{join_file.name}",
+                    line=None,
+                    ref_type="join",
+                    reference="",
+                    message=f"Failed to parse: {e}",
+                ))
+
     # Validate DFD templates
     templates_dir = pack_path / "dfd-templates"
 
@@ -1420,6 +1523,14 @@ def _load_threat_taxonomy_joins(library_pack: LibraryPack, file_path: Path) -> i
         logger.warning(f"No taxonomy specified in {file_path}")
         return 0
 
+    if not ExternalTaxonomy.objects.filter(slug=taxonomy_slug).exists():
+        logger.error(
+            f"Taxonomy '{taxonomy_slug}' does not exist — "
+            f"check that this matches the slug in taxonomy.yaml, not the pack slug. "
+            f"File: {file_path.name}"
+        )
+        return 0
+
     count = 0
     for mapping in data.get("mappings", []):
         threat_ref = mapping.get("threat", "")
@@ -1444,8 +1555,9 @@ def _load_threat_taxonomy_joins(library_pack: LibraryPack, file_path: Path) -> i
                 count += 1
             except TaxonomyEntry.DoesNotExist:
                 logger.warning(
-                    f"Taxonomy entry {taxonomy_slug}:{external_id} not found — "
-                    f"import the taxonomy pack first"
+                    f"Taxonomy entry {taxonomy_slug}:{external_id} not found. "
+                    f"Check that '{taxonomy_slug}' matches the slug in taxonomy.yaml "
+                    f"(not the pack slug). Import the taxonomy pack first if not yet imported."
                 )
 
     return count

--- a/backend/apps/packs/tests.py
+++ b/backend/apps/packs/tests.py
@@ -1,4 +1,5 @@
-"""Tests for path-based pack discovery and O(1) lookup (issue #33)."""
+"""Tests for path-based pack discovery, O(1) lookup (issue #33),
+and taxonomy reference validation (issue #26)."""
 
 import tempfile
 from pathlib import Path
@@ -10,6 +11,7 @@ from django.test import SimpleTestCase
 from apps.packs.services import (
     _find_pack_dir,
     discover_packs_from_source,
+    validate_pack,
 )
 
 
@@ -167,3 +169,88 @@ class DiscoveryAndDisambiguationTests(SimpleTestCase):
                 dep = consumer.depends_on[0]
                 self.assertEqual(dep["slug"], "nist-csf")
                 self.assertEqual(dep["path"], "demo/nist-csf")
+
+
+class TaxonomyReferenceValidationTests(SimpleTestCase):
+    """validate_pack catches bad taxonomy slugs in joins/threats-*.yaml (#26)."""
+
+    @mock.patch("apps.packs.services.ExternalTaxonomy")
+    def test_validate_rejects_unknown_taxonomy_reference(self, mock_taxonomy_model):
+        mock_taxonomy_model.objects.values_list.return_value = []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_dir = _write_pack(Path(tmp), "bad-pack", slug="bad-pack")
+
+            joins_dir = pack_dir / "joins"
+            joins_dir.mkdir()
+            join_data = {"taxonomy": "nonexistent-taxonomy", "mappings": []}
+            (joins_dir / "threats-foo.yaml").write_text(yaml.safe_dump(join_data))
+
+            result = validate_pack(pack_dir)
+
+            taxonomy_errors = [e for e in result.errors if e.ref_type == "taxonomy"]
+            self.assertEqual(len(taxonomy_errors), 1)
+            self.assertEqual(taxonomy_errors[0].reference, "nonexistent-taxonomy")
+            self.assertIn("taxonomy.yaml", taxonomy_errors[0].message)
+            self.assertIn("not from the pack slug", taxonomy_errors[0].message)
+
+    @mock.patch("apps.packs.services.ExternalTaxonomy")
+    def test_validate_accepts_valid_taxonomy_reference(self, mock_taxonomy_model):
+        mock_taxonomy_model.objects.values_list.return_value = []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pack_dir = _write_pack(Path(tmp), "good-pack", slug="good-pack")
+
+            # Pack defines its own taxonomy
+            tax_data = {
+                "taxonomies": [{"slug": "cwe", "name": "CWE", "entries": []}]
+            }
+            (pack_dir / "taxonomy.yaml").write_text(yaml.safe_dump(tax_data))
+
+            joins_dir = pack_dir / "joins"
+            joins_dir.mkdir()
+            join_data = {"taxonomy": "cwe", "mappings": []}
+            (joins_dir / "threats-cwe.yaml").write_text(yaml.safe_dump(join_data))
+
+            result = validate_pack(pack_dir)
+
+            taxonomy_errors = [e for e in result.errors if e.ref_type == "taxonomy"]
+            self.assertEqual(len(taxonomy_errors), 0)
+
+    @mock.patch("apps.packs.services.ExternalTaxonomy")
+    @mock.patch("apps.packs.services.get_libraries_path")
+    def test_validate_accepts_taxonomy_from_dependency(
+        self, mock_get_libraries_path, mock_taxonomy_model
+    ):
+        mock_taxonomy_model.objects.values_list.return_value = []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            mock_get_libraries_path.return_value = base
+
+            # Dependency pack provides the taxonomy
+            dep_dir = _write_pack(
+                base, "cwe-taxonomy", slug="cwe-taxonomy", pack_type="taxonomy"
+            )
+            tax_data = {
+                "taxonomies": [{"slug": "cwe", "name": "CWE", "entries": []}]
+            }
+            (dep_dir / "taxonomy.yaml").write_text(yaml.safe_dump(tax_data))
+
+            # Downstream pack references the dependency's taxonomy
+            pack_dir = _write_pack(
+                base,
+                "mini-cwe",
+                slug="mini-cwe",
+                pack_type="threat",
+                depends_on=["cwe-taxonomy"],
+            )
+            joins_dir = pack_dir / "joins"
+            joins_dir.mkdir()
+            join_data = {"taxonomy": "cwe", "mappings": []}
+            (joins_dir / "threats-cwe.yaml").write_text(yaml.safe_dump(join_data))
+
+            result = validate_pack(pack_dir)
+
+            taxonomy_errors = [e for e in result.errors if e.ref_type == "taxonomy"]
+            self.assertEqual(len(taxonomy_errors), 0)


### PR DESCRIPTION
Add taxonomy slug validation to validate_pack() so mismatched references                                                   
  in joins/threats-*.yaml are caught at validation time instead of silently                                                  
  producing zero taxonomy tags. Improve runtime warning in                                                                   
  _load_threat_taxonomy_joins() to explain the pack-slug vs taxonomy-slug                                                    
  distinction and fail early when the taxonomy doesn't exist.                  
  
  Fixes issue #26 