### PR TITLE
Fix #24: return success=False when pack version mismatch is detected …

### DIFF
--- a/backend/apps/packs/services.py
+++ b/backend/apps/packs/services.py
@@ -1216,6 +1216,14 @@ def _import_pack(
         )
 
         if has_active_items:
+            if version != existing.version:
+                return ImportResult(
+                    success=False,
+                    pack_slug=slug,
+                    pack_name=name,
+                    version=existing.version,
+                    message=f"Pack '{slug}' has a newer version on disk (v{version} != v{existing.version}). Use force=True to upgrade.",
+                )
             return ImportResult(
                 success=True,
                 pack_slug=slug,


### PR DESCRIPTION
…sync_all_packs_from_source no longer silently reports success when an on-disk pack has a different version than the DB.