### PR TITLE
Fix component category enums, unify control_type values across stack,…

### DIFF
--- a/backend/apps/packs/services.py
+++ b/backend/apps/packs/services.py
@@ -865,7 +865,7 @@ def validate_pack(pack_path: Path) -> ValidationResult:
             pass
 
     # Countermeasures must have 'id', check for duplicates, and validate control_type/cost enums
-    valid_control_types = {"preventive", "detective", "corrective", "procedural"}
+    valid_control_types = {"preventive", "detective", "corrective", "deterrent", "recovery", "compensating", "procedural"}
     valid_costs = {"low", "medium", "high"}
     cm_file = pack_path / "countermeasures.yaml"
     if cm_file.exists():

--- a/docs/concepts/library-packs.md
+++ b/docs/concepts/library-packs.md
@@ -91,7 +91,7 @@ Here's how the YAML maps to what you see in the UI when previewing a pack:
 components:
   - id: s3
     name: Amazon S3
-    category: datastore          # process | datastore | human_actor | system_actor
+    category: datastore          # process | datastore | external_human_actor | external_system_actor
     type: Object Storage
     provider: aws
     description: |
@@ -116,7 +116,7 @@ countermeasures:
     name: S3 Block Public Access
     description: |
       Enable S3 Block Public Access at account and bucket level.
-    control_type: preventive     # preventive | detective | corrective
+    control_type: preventive     # preventive | detective | corrective | deterrent | recovery | compensating | procedural
     cost: low                    # low | medium | high
 ```
 

--- a/docs/contributing/creating-library-packs.md
+++ b/docs/contributing/creating-library-packs.md
@@ -185,7 +185,7 @@ Use these conventions:
 - All IDs: lowercase with hyphens (e.g., "s3-public-exposure")
 - Threat descriptions: explain what the threat is and how it occurs
 - Countermeasure descriptions: explain what the control does and how it helps
-- control_type: preventive, detective, corrective, or procedural
+- control_type: preventive, detective, corrective, deterrent, recovery, compensating, or procedural
 - cost: low, medium, or high
 - applies_to in component-threat joins: "component", "flow", or "both"
 
@@ -291,9 +291,9 @@ This endpoint requires **Security Team** role. It checks structural issues (meta
 |---|---|---|
 | Framework uses `id` instead of `slug` | "Framework uses 'id' instead of 'slug'" | Rename `id:` to `slug:` in the frameworks section of pack.yaml |
 | Taxonomy uses `id` instead of `slug` | "Taxonomy uses 'id' instead of 'slug'" | Rename `id:` to `slug:` in taxonomy.yaml |
-| Invalid `control_type` | "Unknown control_type" | Use `preventive`, `detective`, `corrective`, or `procedural` |
+| Invalid `control_type` | "Unknown control_type" | Use `preventive`, `detective`, `corrective`, `deterrent`, `recovery`, `compensating`, or `procedural` |
 | Invalid `cost` | "Unknown cost" | Use `low`, `medium`, or `high` |
-| Invalid `category` | "Unknown category" | Use `process`, `datastore`, `external`, `human_actor`, or `system_actor` |
+| Invalid `category` | "Unknown category" | Use `process`, `datastore`, `external_human_actor`, or `external_system_actor` |
 | Missing `pack_type` | "Missing required field: pack_type" | Add `pack_type` to the `pack:` section |
 | Missing component `id` | "Component at index N has no 'id' field" | Add `id:` to the component entry |
 

--- a/frontend/src/features/dfd-editor/components/threat-analysis/AddCountermeasureDialog.tsx
+++ b/frontend/src/features/dfd-editor/components/threat-analysis/AddCountermeasureDialog.tsx
@@ -35,6 +35,7 @@ const CONTROL_TYPES = [
   { value: 'deterrent', label: 'Deterrent' },
   { value: 'recovery', label: 'Recovery' },
   { value: 'compensating', label: 'Compensating' },
+  { value: 'procedural', label: 'Procedural' },
 ]
 
 interface AddCountermeasureDialogProps {

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -148,7 +148,7 @@ components:
 |---|---|---|
 | `id` | yes | Unique within pack. Lowercase + hyphens. |
 | `name` | yes | Display name. |
-| `category` | yes | `process`, `datastore`, `human_actor`, `system_actor` |
+| `category` | yes | `process`, `datastore`, `external_human_actor`, `external_system_actor` |
 | `type` | yes | Free-text component type (e.g. "Object Storage", "NoSQL Database"). |
 | `provider` | no | Provider name (e.g. `aws`, `azure`, `gcp`). |
 | `description` | no | Multi-line description. |
@@ -214,7 +214,7 @@ countermeasures:
 | `id` | yes | Unique within pack. |
 | `name` | yes | Display name. |
 | `description` | yes | What the control does and how it helps. |
-| `control_type` | yes | `preventive`, `detective`, `corrective`, or `procedural` |
+| `control_type` | yes | `preventive`, `detective`, `corrective`, `deterrent`, `recovery`, `compensating`, or `procedural` |
 | `cost` | yes | `low`, `medium`, or `high` |
 | `default_status` | no | `gap` (default) or `platform`. Platform countermeasures are treated as infrastructure-level controls managed by the security team. See [Platform Controls](../docs/concepts/platform-controls.md). |
 
@@ -634,7 +634,7 @@ Before submitting a pack, verify:
 - [ ] `pack.yaml` has all required fields (`slug`, `name`, `version`, `pack_type`, `description`)
 - [ ] All `id` / `slug` values are unique within their file
 - [ ] All `id` values are lowercase alphanumeric with hyphens (`^[a-z0-9]+(-[a-z0-9]+)*$`)
-- [ ] All `control_type` values are `preventive`, `detective`, `corrective`, or `procedural`
+- [ ] All `control_type` values are `preventive`, `detective`, `corrective`, `deterrent`, `recovery`, `compensating`, or `procedural`
 - [ ] All `cost` values are `low`, `medium`, or `high`
 - [ ] All references in join files point to ids that exist in the pack (or in declared dependencies)
 - [ ] All threat refs in `threats-{taxonomy}.yaml` join files resolve to valid threat IDs

--- a/libraries/packs/mini-cwe/taxonomy.yaml
+++ b/libraries/packs/mini-cwe/taxonomy.yaml
@@ -64,3 +64,59 @@ taxonomies:
         title: Improper Input Validation
         description: "The application does not validate or incorrectly validates input that can affect the control flow or data flow."
         reference_url: "https://cwe.mitre.org/data/definitions/20.html"
+      - external_id: CWE-16
+        title: Configuration
+        description: "Weaknesses in this category are typically introduced during the configuration of the software."
+        reference_url: "https://cwe.mitre.org/data/definitions/16.html"
+      - external_id: CWE-284
+        title: Improper Access Control
+        description: "The product does not restrict or incorrectly restricts access to a resource from an unauthorized actor."
+        reference_url: "https://cwe.mitre.org/data/definitions/284.html"
+      - external_id: CWE-294
+        title: Authentication Bypass by Capture-replay
+        description: "A capture-replay flaw exists when the design of the product makes it possible for a malicious user to sniff network traffic and bypass authentication by replaying it."
+        reference_url: "https://cwe.mitre.org/data/definitions/294.html"
+      - external_id: CWE-295
+        title: Improper Certificate Validation
+        description: "The product does not validate, or incorrectly validates, a certificate."
+        reference_url: "https://cwe.mitre.org/data/definitions/295.html"
+      - external_id: CWE-300
+        title: Channel Accessible by Non-Endpoint
+        description: "The product does not adequately verify the identity of actors at both ends of a communication channel, or does not adequately ensure the integrity of the channel, allowing an entity to act as a man-in-the-middle."
+        reference_url: "https://cwe.mitre.org/data/definitions/300.html"
+      - external_id: CWE-311
+        title: Missing Encryption of Sensitive Data
+        description: "The product does not encrypt sensitive or critical information before storage or transmission."
+        reference_url: "https://cwe.mitre.org/data/definitions/311.html"
+      - external_id: CWE-319
+        title: Cleartext Transmission of Sensitive Information
+        description: "The product transmits sensitive or security-critical data in cleartext in a communication channel that can be sniffed by unauthorized actors."
+        reference_url: "https://cwe.mitre.org/data/definitions/319.html"
+      - external_id: CWE-345
+        title: Insufficient Verification of Data Authenticity
+        description: "The product does not sufficiently verify the origin or authenticity of data, in a way that causes it to accept invalid data."
+        reference_url: "https://cwe.mitre.org/data/definitions/345.html"
+      - external_id: CWE-400
+        title: Uncontrolled Resource Consumption
+        description: "The product does not properly control the allocation and maintenance of a limited resource, thereby enabling an actor to influence the amount of resources consumed, eventually leading to exhaustion."
+        reference_url: "https://cwe.mitre.org/data/definitions/400.html"
+      - external_id: CWE-426
+        title: Untrusted Search Path
+        description: "The product searches for critical resources using an externally-supplied search path that can point to resources that are not under the product's direct control."
+        reference_url: "https://cwe.mitre.org/data/definitions/426.html"
+      - external_id: CWE-441
+        title: Unintended Proxy or Intermediary
+        description: "The product receives a request, message, or directive from an upstream component, but the product does not sufficiently preserve the original source of the request before forwarding it to an external actor."
+        reference_url: "https://cwe.mitre.org/data/definitions/441.html"
+      - external_id: CWE-494
+        title: Download of Code Without Integrity Check
+        description: "The product downloads source code or an executable from a remote location and executes the code without sufficiently verifying the origin and integrity of the code."
+        reference_url: "https://cwe.mitre.org/data/definitions/494.html"
+      - external_id: CWE-693
+        title: Protection Mechanism Failure
+        description: "The product does not use or incorrectly uses a protection mechanism that provides sufficient defense against directed attacks."
+        reference_url: "https://cwe.mitre.org/data/definitions/693.html"
+      - external_id: CWE-770
+        title: Allocation of Resources Without Limits or Throttling
+        description: "The product allocates a reusable resource or group of resources on behalf of an actor without imposing any restrictions on the size or number of resources that can be allocated."
+        reference_url: "https://cwe.mitre.org/data/definitions/770.html"


### PR DESCRIPTION
                                                                                                               
  - Update docs to use external_human_actor/external_system_actor (matching backend model)
  - Align all 7 control_type values (preventive, detective, corrective, deterrent, recovery,                                          
    compensating, procedural) across frontend, backend validator, and docs
  - Add 14 ICS-relevant CWE entries to mini-cwe taxonomy for OT/ICS pack compatibility
