### PR TITLE
fix: New elements appear in the middle of the screen

### DIFF
--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -9,6 +9,7 @@ import {
   useReactFlow,
   useViewport,
   type Connection,
+  type XYPosition,
   addEdge,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
@@ -127,6 +128,15 @@ function DFDEditorContent() {
     },
     [setConnectionMode, setBoundaryMode]
   )
+
+  const getCanvasCenterPosition = useCallback((): XYPosition => {
+    const bounds = reactFlowWrapper.current?.getBoundingClientRect()
+
+    return screenToFlowPosition({
+      x: bounds ? bounds.left + bounds.width / 2 : window.innerWidth / 2,
+      y: bounds ? bounds.top + bounds.height / 2 : window.innerHeight / 2,
+    })
+  }, [screenToFlowPosition])
 
   // Handle node click - delegates to mode hooks then falls through to selection
   const handleNodeClick = useCallback(
@@ -449,6 +459,7 @@ function DFDEditorContent() {
         onConnectionModeChange={handleConnectionModeChange}
         boundaryMode={boundaryMode}
         onBoundaryModeChange={handleBoundaryModeChange}
+        getCanvasCenterPosition={getCanvasCenterPosition}
         onOpenTemplates={() => setShowTemplates(true)}
         onOpenThreatAnalysis={async () => {
           if (hasUnsavedChanges) {

--- a/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
+++ b/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import { useReactFlow } from '@xyflow/react'
+import { useReactFlow, type XYPosition } from '@xyflow/react'
 import { User, Server, Cog, Database, Shield, Box, ArrowRight, LayoutTemplate, ShieldAlert, ShieldCheck } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
@@ -17,6 +17,7 @@ interface DiagramToolbarProps {
   onConnectionModeChange: (enabled: boolean) => void
   boundaryMode: boolean
   onBoundaryModeChange: (enabled: boolean) => void
+  getCanvasCenterPosition: () => XYPosition
   onOpenTemplates: () => void
   onOpenThreatAnalysis: () => void
 }
@@ -74,22 +75,33 @@ const nodeButtons: ToolbarButtonConfig[] = [
   },
 ]
 
+const DEFAULT_NODE_SIZES: Record<DiagramNodeType, { width: number; height: number }> = {
+  humanActor: { width: 100, height: 100 },
+  systemActor: { width: 100, height: 90 },
+  process: { width: 120, height: 60 },
+  datastore: { width: 120, height: 80 },
+  trustZone: { width: 300, height: 200 },
+  systemScope: { width: 300, height: 200 },
+}
+
 export const DiagramToolbar = memo(function DiagramToolbar({
   connectionMode,
   onConnectionModeChange,
   boundaryMode,
   onBoundaryModeChange,
+  getCanvasCenterPosition,
   onOpenTemplates,
   onOpenThreatAnalysis,
 }: DiagramToolbarProps) {
   const { addNodes, getNodes } = useReactFlow()
 
   const handleAddNode = (type: DiagramNodeType) => {
-    const nodes = getNodes()
-
-    // Calculate position for new node (offset from existing nodes)
-    const baseX = 100 + (nodes.length % 5) * 150
-    const baseY = 100 + Math.floor(nodes.length / 5) * 150
+    const center = getCanvasCenterPosition()
+    const nodeSize = DEFAULT_NODE_SIZES[type]
+    const position = {
+      x: center.x - nodeSize.width / 2,
+      y: center.y - nodeSize.height / 2,
+    }
 
     // Generate unique ID
     const id = `${type}-${Date.now()}`
@@ -112,7 +124,7 @@ export const DiagramToolbar = memo(function DiagramToolbar({
     addNodes({
       id,
       type,
-      position: { x: baseX, y: baseY },
+      position,
       data: { ...defaultData[type], isNewlyInserted: true },
       style: defaultStyle,
     })


### PR DESCRIPTION
## Summary
- Places toolbar added DFD nodes at the center of the currently visible canvas
- Uses React Flow screen to flow coordinate conversion so pan/zoom are respected

https://github.com/user-attachments/assets/e5d42091-db1d-447f-9748-6cfc714b363b

Fixes #80 