### PR TITLE
fix: validate owning_team belongs to same org on threat model creation

### DIFF
--- a/backend/apps/threat_models/serializers.py
+++ b/backend/apps/threat_models/serializers.py
@@ -835,6 +835,13 @@ class ThreatModelCreateSerializer(serializers.ModelSerializer):
             if user_team_memberships.count() == 1:
                 validated_data["owning_team"] = user_team_memberships.first().team
 
+        # Validate owning_team belongs to the same organization
+        owning_team = validated_data.get("owning_team")
+        if owning_team and owning_team.organization_id != validated_data["organization"].id:
+            raise serializers.ValidationError(
+                {"owning_team": "Team does not belong to the selected organization."}
+            )
+
         # Initialize workspace_data — only progressChecklist remains here;
         # status, description, scope_locked, assets, out_of_scope_items
         # are now managed via dedicated model fields and API endpoints.


### PR DESCRIPTION
## Summary                              
                                                                                                     
  - Adds validation in `ThreatModelCreateSerializer` to reject threat model creation when            
  `owning_team` belongs to a different organization                                                  
  - Prevents orphaned threat models that become invisible in the UI due to cross-org team assignment 
                                                                                                     
  ## Context                                                                                         
                                                                                                     
  When a user belongs to multiple organizations, `currentTeam` in WorkspaceContext (persisted via    
  localStorage) can point to a team from org A while the threat model gets auto-assigned to org B.
  The backend had no validation to catch this mismatch, resulting in threat models that exist in the
  database but are invisible to all users.