### PR TITLE
fix: validate owning_team org match on threat model update

### DIFF
--- a/backend/apps/threat_models/serializers.py
+++ b/backend/apps/threat_models/serializers.py
@@ -218,6 +218,14 @@ class ThreatModelSerializer(ThreatModelFieldsMixin, serializers.ModelSerializer)
         ]
         read_only_fields = ["id", "created_at", "updated_at", "created_by_email", "owner", "organization_name", "owning_team_name", "business_unit_name"]
 
+    def validate_owning_team(self, value):
+        """Validate owning_team belongs to the same organization as the threat model."""
+        if value and self.instance and value.organization_id != self.instance.organization_id:
+            raise serializers.ValidationError(
+                "Team does not belong to the selected organization."
+            )
+        return value
+
     def validate_assumptions(self, value):
         """Validate assumptions list structure."""
         if not isinstance(value, list):


### PR DESCRIPTION
  ## Summary                        
                                                                                                     
  - Adds field-level validation on `ThreatModelSerializer` to reject `PATCH` requests where          
  `owning_team` belongs to a different organization than the threat model                            
  - Prevents tenant isolation violations where a user with access to multiple orgs could reassign a  
  threat model to a team in a different organization via direct API call

  ## Context

  The previous PR (#112 ) added this validation for threat model **creation**. This PR closes the same
   gap on the **update** path. While there is currently no frontend UI to change a threat model's
  owning team, the API accepts it — making this a defense-in-depth fix for multi-tenant safety.