### PR TITLE
feat(reports): add CSV and Word export to report view

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "dependencies": {
         "@dnd-kit/helpers": "^0.3.2",
         "@dnd-kit/react": "^0.3.2",
@@ -31,6 +31,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
+        "docx": "^9.0.3",
         "lucide-react": "^0.561.0",
         "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
@@ -6016,6 +6017,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6192,6 +6199,56 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/docx": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.7.1.tgz",
+      "integrity": "sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/docx/node_modules/@types/node": {
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/docx/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/docx/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -6631,6 +6688,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -6657,6 +6724,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -6685,6 +6758,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6707,6 +6786,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6792,6 +6877,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6814,6 +6911,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -7129,6 +7235,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -7242,6 +7354,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7333,6 +7451,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7698,6 +7822,21 @@
         }
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -7753,6 +7892,21 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7773,6 +7927,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {
@@ -7816,6 +7976,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -8072,6 +8241,12 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
@@ -8171,6 +8346,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "docx": "^9.0.3",
     "lucide-react": "^0.561.0",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",

--- a/frontend/src/features/reports/ReportView.tsx
+++ b/frontend/src/features/reports/ReportView.tsx
@@ -1,6 +1,14 @@
 import { useState } from 'react'
+import { toast } from 'sonner'
 import { Card, CardContent } from '@/components/ui/card'
-import { Loader2, BarChart3, Code, Shield, FileText } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Button } from '@/components/ui/button'
+import { Loader2, BarChart3, Code, Shield, FileText, Download, ChevronDown } from 'lucide-react'
 import { useReport } from '@/features/reports/api/reports'
 import type { ReportType, ReportData } from '@/features/reports/types/report'
 import { getSectionsForType } from './reportConfig'
@@ -20,6 +28,13 @@ import { AssumptionsReviewSection } from './sections/AssumptionsReviewSection'
 import { FindingsSection } from './sections/FindingsSection'
 import { ProgressChecklistSection } from './sections/ProgressChecklistSection'
 import { ComplianceDriftBanner } from '@/features/compliance/components/ComplianceDriftBanner'
+import {
+  exportThreatsCSV,
+  exportCountermeasuresCSV,
+  exportRisksCSV,
+  exportComplianceCSV,
+} from './utils/csvExport'
+import { exportWordDoc } from './utils/wordExport'
 
 interface ReportViewProps {
   threatModelId: string
@@ -106,12 +121,10 @@ function renderSection(sectionId: string, depth: string, data: ReportData) {
 export function ReportView({ threatModelId }: ReportViewProps) {
   const [reportType, setReportType] = useState<ReportType>('executive')
   const { data, isLoading, error } = useReport(threatModelId)
-
   const sections = getSectionsForType(reportType)
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      {/* Report type selector */}
       <div className="shrink-0 p-4 border-b">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
           {REPORT_TYPES.map((rt) => (
@@ -140,7 +153,7 @@ export function ReportView({ threatModelId }: ReportViewProps) {
         <ComplianceDriftBanner threatModelId={threatModelId} />
       )}
 
-      {/* Report content */}
+
       <div className="flex-1 overflow-y-auto p-4">
         {isLoading && (
           <div className="flex items-center justify-center py-12">
@@ -148,7 +161,6 @@ export function ReportView({ threatModelId }: ReportViewProps) {
             <span className="ml-2 text-muted-foreground">Loading report data...</span>
           </div>
         )}
-
         {error && (
           <div className="text-center py-12">
             <p className="text-destructive">Failed to load report data.</p>
@@ -157,10 +169,8 @@ export function ReportView({ threatModelId }: ReportViewProps) {
             </p>
           </div>
         )}
-
         {data && (
           <div className="space-y-4 max-w-5xl mx-auto">
-            {/* Report header */}
             <div className="flex items-center justify-between">
               <div>
                 <h2 className="text-lg font-semibold">{data.metadata.name}</h2>
@@ -170,9 +180,46 @@ export function ReportView({ threatModelId }: ReportViewProps) {
                   </span>
                 </div>
               </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" className="gap-1.5">
+                    <Download className="h-4 w-4" />
+                    Export CSV
+                    <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => exportThreatsCSV(data, data.metadata.name)}>
+                    Threats
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => exportCountermeasuresCSV(data, data.metadata.name)}>
+                    Countermeasures
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => exportRisksCSV(data, data.metadata.name)}>
+                    Risks
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => exportComplianceCSV(data, data.metadata.name)}>
+                    Compliance Coverage
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={async () => {
+                      try {
+                        await exportWordDoc(data, data.metadata.name)
+                      } catch (err) {
+                        toast.error(
+                          err instanceof Error
+                            ? "Failed to export Word report: " + err.message
+                            : "Failed to export Word report"
+                        )
+                      }
+                    }}
+                  >
+                    Full Report (Word)
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
 
-            {/* Sections */}
             {sections.map((section) => (
               <div key={section.id}>
                 {renderSection(section.id, section.depth, data)}

--- a/frontend/src/features/reports/utils/csvExport.ts
+++ b/frontend/src/features/reports/utils/csvExport.ts
@@ -1,0 +1,126 @@
+import type { ReportData, ReportThreat } from '../types/report'
+
+function downloadCsv(filename: string, headers: string[], rows: string[][]): void {
+  const csvContent = [
+    headers.join(','),
+    ...rows.map(row =>
+      row.map(cell => `"${String(cell ?? '').replace(/"/g, '""')}"`).join(',')
+    ),
+  ].join('\n')
+
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
+}
+
+type ThreatWithContext = { threat: ReportThreat; context: string }
+
+function flattenThreats(data: ReportData): ThreatWithContext[] {
+  const out: ThreatWithContext[] = []
+  for (const [context, threats] of Object.entries(data.threatAnalysis.componentThreats)) {
+    for (const threat of threats) out.push({ threat, context })
+  }
+  for (const [context, threats] of Object.entries(data.threatAnalysis.dataFlowThreats)) {
+    for (const threat of threats) out.push({ threat, context })
+  }
+  return out
+}
+
+export function exportThreatsCSV(data: ReportData, modelName: string): void {
+  const headers = [
+    'Threat Name',
+    'Description',
+    'STRIDE Category',
+    'Inherent Severity',
+    'Residual Severity',
+    'Status',
+    'Component / Data Flow',
+  ]
+  const rows = flattenThreats(data).map(({ threat, context }) => [
+    threat.threatName,
+    threat.threatDescription,
+    threat.strideCategory ?? '',
+    threat.inherentSeverity,
+    threat.residualSeverity,
+    threat.status,
+    context,
+  ])
+  downloadCsv(`${slugify(modelName)}-threats.csv`, headers, rows)
+}
+
+export function exportCountermeasuresCSV(data: ReportData, modelName: string): void {
+  const headers = [
+    'Countermeasure',
+    'Control Type',
+    'Status',
+    'Priority',
+    'Assigned Owner',
+    'Inherited',
+    'Inherited From',
+    'Associated Threat',
+    'Component / Data Flow',
+  ]
+  const rows: string[][] = []
+  for (const { threat, context } of flattenThreats(data)) {
+    for (const cm of threat.countermeasures) {
+      rows.push([
+        cm.countermeasureName,
+        cm.controlType,
+        cm.status,
+        cm.priority,
+        cm.assignedOwnerEmail ?? '',
+        cm.isInherited ? 'Yes' : 'No',
+        cm.inheritedFromComponentName ?? cm.inheritedFromZoneName ?? '',
+        threat.threatName,
+        context,
+      ])
+    }
+  }
+  downloadCsv(`${slugify(modelName)}-countermeasures.csv`, headers, rows)
+}
+
+export function exportRisksCSV(data: ReportData, modelName: string): void {
+  const headers = [
+    'Risk Name',
+    'Description',
+    'Inherent Score',
+    'Inherent Level',
+    'Residual Score',
+    'Residual Level',
+    'Owner',
+  ]
+  const rows = data.risks.map(risk => [
+    risk.name,
+    risk.description,
+    String(risk.inherentScore),
+    risk.inherentLevel,
+    String(risk.residualScore),
+    risk.residualLevel,
+    risk.ownerEmail ?? '',
+  ])
+  downloadCsv(`${slugify(modelName)}-risks.csv`, headers, rows)
+}
+
+export function exportComplianceCSV(data: ReportData, modelName: string): void {
+  const headers = [
+    'Framework',
+    'Total Requirements',
+    'Covered',
+    'Coverage %',
+  ]
+  const rows = data.compliance.frameworks.map(fw => [
+    fw.name,
+    String(fw.totalRequirements),
+    String(fw.coveredRequirements),
+    `${fw.coveragePercentage.toFixed(1)}%`,
+  ])
+  downloadCsv(`${slugify(modelName)}-compliance.csv`, headers, rows)
+}

--- a/frontend/src/features/reports/utils/wordExport.ts
+++ b/frontend/src/features/reports/utils/wordExport.ts
@@ -1,0 +1,700 @@
+import {
+  Document,
+  Packer,
+  Paragraph,
+  Table,
+  TableRow,
+  TableCell,
+  TextRun,
+  HeadingLevel,
+  AlignmentType,
+  BorderStyle,
+  WidthType,
+  ShadingType,
+  PageBreak,
+  LevelFormat,
+} from 'docx'
+import type { ReportData, ReportThreat } from '../types/report'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// US Letter, 1" margins — content width 9360 DXA
+const CONTENT_WIDTH = 9360
+const CELL_BORDER = { style: BorderStyle.SINGLE, size: 1, color: 'CCCCCC' }
+const CELL_BORDERS = {
+  top: CELL_BORDER,
+  bottom: CELL_BORDER,
+  left: CELL_BORDER,
+  right: CELL_BORDER,
+}
+const CELL_MARGINS = { top: 80, bottom: 80, left: 120, right: 120 }
+const HEADER_FILL = { fill: 'D5E8F0', type: ShadingType.CLEAR }
+
+// ---------------------------------------------------------------------------
+// Download helper
+// ---------------------------------------------------------------------------
+
+async function downloadDocx(doc: Document, filename: string): Promise<void> {
+  const blob = await Packer.toBlob(doc)
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
+}
+
+// ---------------------------------------------------------------------------
+// Primitive builders
+// ---------------------------------------------------------------------------
+
+function h1(text: string): Paragraph {
+  return new Paragraph({ heading: HeadingLevel.HEADING_1, children: [new TextRun(text)] })
+}
+
+function h2(text: string): Paragraph {
+  return new Paragraph({ heading: HeadingLevel.HEADING_2, children: [new TextRun(text)] })
+}
+
+function h3(text: string): Paragraph {
+  return new Paragraph({ heading: HeadingLevel.HEADING_3, children: [new TextRun(text)] })
+}
+
+function para(text: string, options?: { bold?: boolean; italic?: boolean; size?: number }): Paragraph {
+  return new Paragraph({
+    children: [
+      new TextRun({
+        text,
+        bold: options?.bold,
+        italics: options?.italic,
+        size: options?.size,
+      }),
+    ],
+  })
+}
+
+function placeholder(text: string): Paragraph {
+  return new Paragraph({
+    children: [
+      new TextRun({
+        text: `[${text}]`,
+        italics: true,
+        color: '888888',
+      }),
+    ],
+  })
+}
+
+function spacer(): Paragraph {
+  return new Paragraph({ children: [new TextRun('')] })
+}
+
+function pageBreak(): Paragraph {
+  return new Paragraph({ children: [new PageBreak()] })
+}
+
+// ---------------------------------------------------------------------------
+// Table builders
+// ---------------------------------------------------------------------------
+
+function headerCell(text: string, width: number): TableCell {
+  return new TableCell({
+    borders: CELL_BORDERS,
+    width: { size: width, type: WidthType.DXA },
+    shading: HEADER_FILL,
+    margins: CELL_MARGINS,
+    children: [
+      new Paragraph({
+        children: [new TextRun({ text, bold: true })],
+      }),
+    ],
+  })
+}
+
+function dataCell(text: string, width: number): TableCell {
+  return new TableCell({
+    borders: CELL_BORDERS,
+    width: { size: width, type: WidthType.DXA },
+    margins: CELL_MARGINS,
+    children: [new Paragraph({ children: [new TextRun(text ?? '')] })],
+  })
+}
+
+function buildTable(
+  columnWidths: number[],
+  headers: string[],
+  rows: string[][],
+): Table {
+  return new Table({
+    width: { size: CONTENT_WIDTH, type: WidthType.DXA },
+    columnWidths,
+    rows: [
+      new TableRow({
+        tableHeader: true,
+        children: headers.map((h, i) => headerCell(h, columnWidths[i])),
+      }),
+      ...rows.map(
+        (row) =>
+          new TableRow({
+            children: row.map((cell, i) => dataCell(cell, columnWidths[i])),
+          }),
+      ),
+    ],
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Flatten helpers (mirrors csvExport.ts)
+// ---------------------------------------------------------------------------
+
+type ThreatWithContext = { threat: ReportThreat; context: string }
+
+function flattenThreats(data: ReportData): ThreatWithContext[] {
+  const out: ThreatWithContext[] = []
+  for (const [context, threats] of Object.entries(data.threatAnalysis.componentThreats)) {
+    for (const threat of threats) out.push({ threat, context })
+  }
+  for (const [context, threats] of Object.entries(data.threatAnalysis.dataFlowThreats)) {
+    for (const threat of threats) out.push({ threat, context })
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Section builders
+// ---------------------------------------------------------------------------
+
+function buildMetadataSection(data: ReportData): (Paragraph | Table)[] {
+  const m = data.metadata
+  const rows = [
+    ['Threat Model Name', m.name],
+    ['Criticality', m.criticality],
+    ['Risk Scoring Method', m.riskScoringMethod],
+    ['Owning Team', m.owningTeam ?? '—'],
+    ['Created By', m.createdBy ?? '—'],
+    ['Created', m.createdAt ?? '—'],
+    ['Last Updated', m.updatedAt ?? '—'],
+    ['Frameworks', m.frameworks.map((f) => f.name).join(', ') || '—'],
+  ]
+
+  return [
+    h1('1. Document Information'),
+    spacer(),
+    buildTable([3000, 6360], ['Field', 'Value'], rows),
+    spacer(),
+  ]
+}
+
+function buildSummarySection(data: ReportData): (Paragraph | Table)[] {
+  const s = data.summaryMetrics
+  const statusRows = Object.entries(s.threatsByStatus).map(([k, v]) => [k, String(v)])
+  const cmRows = Object.entries(s.countermeasuresByStatus).map(([k, v]) => [k, String(v)])
+  const riskRows = Object.entries(s.risksByLevel).map(([k, v]) => [k, String(v)])
+
+  return [
+    h1('2. Executive Summary'),
+    spacer(),
+    h2('2.1 Summary Metrics'),
+    spacer(),
+    buildTable(
+      [4680, 4680],
+      ['Metric', 'Count'],
+      [
+        ['Total Active Threats', String(s.totalActiveThreats)],
+        ['Total Dismissed Threats', String(s.totalDismissedThreats)],
+        ['Total Countermeasures', String(s.totalCountermeasures)],
+        ['Open Gaps', String(s.totalGaps)],
+        ['Waived Countermeasures', String(s.totalWaived)],
+        ['Inherited Countermeasures', String(s.totalInherited)],
+        ['Total Risks', String(s.totalRisks)],
+      ],
+    ),
+    spacer(),
+    h2('2.2 Threat Status Breakdown'),
+    spacer(),
+    buildTable([4680, 4680], ['Status', 'Count'], statusRows),
+    spacer(),
+    h2('2.3 Countermeasure Status Breakdown'),
+    spacer(),
+    buildTable([4680, 4680], ['Status', 'Count'], cmRows),
+    spacer(),
+    ...(riskRows.length > 0
+      ? [
+          h2('2.4 Risk Level Breakdown') as Paragraph | Table,
+          spacer(),
+          buildTable([4680, 4680], ['Level', 'Count'], riskRows),
+          spacer(),
+        ]
+      : []),
+    h2('2.5 STRIDE Distribution'),
+    spacer(),
+    buildTable(
+      [4680, 4680],
+      ['STRIDE Category', 'Count'],
+      Object.entries(data.threatAnalysis.strideSummary).map(([k, v]) => [k, String(v)]),
+    ),
+    spacer(),
+  ]
+}
+
+function buildScopeSection(data: ReportData): (Paragraph | Table)[] {
+  const scope = data.scope
+  const children: (Paragraph | Table)[] = [
+    h1('3. Scope'),
+    spacer(),
+    h2('3.1 Scope Description'),
+    para(scope.description || '—'),
+    spacer(),
+  ]
+
+  if (scope.assumptions.length > 0) {
+    children.push(
+      h2('3.2 Assumptions'),
+      spacer(),
+      buildTable(
+        [4500, 1800, 3060],
+        ['Assumption', 'Validity', 'Topics'],
+        scope.assumptions.map((a) => [
+          a.description,
+          a.validity,
+          a.topics.join(', '),
+        ]),
+      ),
+      spacer(),
+    )
+  }
+
+  if (scope.outOfScopeItems.length > 0) {
+    children.push(
+      h2('3.3 Out of Scope'),
+      spacer(),
+      buildTable(
+        [3120, 6240],
+        ['Item', 'Reason'],
+        scope.outOfScopeItems.map((i) => [i.name, i.reason]),
+      ),
+      spacer(),
+    )
+  }
+
+  return children
+}
+
+function buildArchitectureSection(data: ReportData): (Paragraph | Table)[] {
+  const arch = data.architecture
+  const children: (Paragraph | Table)[] = [h1('4. System Architecture'), spacer()]
+
+  // DFD inventory table
+  if (arch.dfds.length > 0) {
+    children.push(
+      h2('4.1 Data Flow Diagrams'),
+      spacer(),
+      buildTable(
+        [3240, 1800, 720, 720, 2880],
+        ['Diagram Name', 'Type', 'Nodes', 'Edges', 'Notes'],
+        arch.dfds.map((dfd) => [
+          dfd.name,
+          dfd.diagramType,
+          String(dfd.nodeCount),
+          String(dfd.edgeCount),
+          dfd.isPrimary ? 'Primary DFD' : 'Reference DFD',
+        ]),
+      ),
+      spacer(),
+    )
+
+    // Per-DFD placeholder + node inventory
+    arch.dfds.forEach((dfd, idx) => {
+      children.push(
+        h3(`Figure ${idx + 1}: ${dfd.name}${dfd.isPrimary ? ' (Primary)' : ''}`),
+        placeholder(`Insert DFD diagram screenshot here — ${dfd.name}`),
+        spacer(),
+      )
+
+      // If canvasData has nodes, extract a component inventory
+      const nodes = (dfd.canvasData as any)?.nodes
+      if (Array.isArray(nodes) && nodes.length > 0) {
+        const nodeRows = nodes
+          .filter((n: any) => n?.data)
+          .map((n: any) => [
+            n.data?.label ?? n.data?.name ?? n.id ?? '—',
+            n.type ?? '—',
+          ])
+        if (nodeRows.length > 0) {
+          children.push(
+            para('Component nodes in this diagram:', { italic: true }),
+            buildTable([4680, 4680], ['Node Label', 'Type'], nodeRows),
+            spacer(),
+          )
+        }
+      }
+    })
+  }
+
+  // Trust Zones
+  if (arch.trustZones.length > 0) {
+    children.push(
+      h2('4.2 Trust Zones'),
+      spacer(),
+      buildTable(
+        [2400, 1200, 5760],
+        ['Zone Name', 'Trust Level', 'Description'],
+        arch.trustZones.map((z) => [z.name, String(z.trustLevel), z.description]),
+      ),
+      spacer(),
+    )
+  }
+
+  // Trust Boundaries
+  if (arch.trustBoundaries.length > 0) {
+    children.push(
+      h2('4.3 Trust Boundaries'),
+      spacer(),
+      buildTable(
+        [3120, 3120, 3120],
+        ['Boundary', 'Zone A', 'Zone B'],
+        arch.trustBoundaries.map((b) => [b.label, b.zoneA, b.zoneB]),
+      ),
+      spacer(),
+    )
+  }
+
+  // Reference Images
+  if (arch.referenceImages.length > 0) {
+    children.push(
+      h2('4.4 Reference Images'),
+      spacer(),
+      buildTable(
+        [4680, 4680],
+        ['Filename', 'Description'],
+        arch.referenceImages.map((img) => [img.filename, img.description]),
+      ),
+      spacer(),
+    )
+  }
+
+  return children
+}
+
+function buildDataAssetsSection(data: ReportData): (Paragraph | Table)[] {
+  if (data.dataAssets.length === 0) return []
+
+  return [
+    h1('5. Data Assets'),
+    spacer(),
+    buildTable(
+      [1800, 1440, 1260, 1260, 1260, 2340],
+      ['Name', 'Classification', 'Confidentiality', 'Integrity', 'Availability', 'Description'],
+      data.dataAssets.map((a) => [
+        a.name,
+        a.classification,
+        a.confidentiality,
+        a.integrity,
+        a.availability,
+        a.description,
+      ]),
+    ),
+    spacer(),
+  ]
+}
+
+function buildComponentsSection(data: ReportData): (Paragraph | Table)[] {
+  const c = data.components
+  const allComponents = [
+    ...c.processes.map((p) => ({ ...p, _type: 'Process' })),
+    ...c.dataStores.map((p) => ({ ...p, _type: 'Data Store' })),
+    ...c.humanActors.map((p) => ({ ...p, _type: 'Human Actor' })),
+    ...c.systemActors.map((p) => ({ ...p, _type: 'System Actor' })),
+  ]
+
+  if (allComponents.length === 0) return []
+
+  return [
+    h1('6. Component Inventory'),
+    spacer(),
+    buildTable(
+      [2400, 1440, 1440, 1440, 2640],
+      ['Name', 'Type', 'Category', 'Trust Zone', 'Description'],
+      allComponents.map((c) => [
+        c.name,
+        c._type,
+        c.category,
+        c.trustZone ?? '—',
+        c.description,
+      ]),
+    ),
+    spacer(),
+  ]
+}
+
+function buildThreatAnalysisSection(data: ReportData): (Paragraph | Table)[] {
+  const allThreats = flattenThreats(data)
+  if (allThreats.length === 0) return []
+
+  const children: (Paragraph | Table)[] = [
+    h1('7. Threat Analysis'),
+    spacer(),
+    para(
+      `This section documents ${allThreats.length} identified threats across all system components and data flows.`,
+    ),
+    spacer(),
+    buildTable(
+      [3240, 2160, 960, 960, 960, 1080],
+      ['Threat Name', 'Component / Data Flow', 'STRIDE', 'Inherent Severity', 'Status', 'CMs'],
+      allThreats.map(({ threat, context }) => [
+        threat.threatName,
+        context,
+        threat.strideCategory ?? '—',
+        threat.inherentSeverity,
+        threat.status,
+        String(threat.countermeasures.length),
+      ]),
+    ),
+    spacer(),
+  ]
+
+  // Dismissed threats
+  if (data.threatAnalysis.dismissedThreats.length > 0) {
+    children.push(
+      h2('7.1 Dismissed Threats'),
+      spacer(),
+      buildTable(
+        [3240, 2880, 3240],
+        ['Threat Name', 'Component / Data Flow', 'Dismissal Reason'],
+        data.threatAnalysis.dismissedThreats.map((t) => [
+          t.threatName,
+          t.componentName ?? t.flowLabel ?? '—',
+          t.dismissalReason,
+        ]),
+      ),
+      spacer(),
+    )
+  }
+
+  return children
+}
+
+function buildCountermeasuresSection(data: ReportData): (Paragraph | Table)[] {
+  const allThreats = flattenThreats(data)
+  const rows: string[][] = []
+
+  for (const { threat, context } of allThreats) {
+    for (const cm of threat.countermeasures) {
+      rows.push([
+        cm.countermeasureName,
+        cm.controlType,
+        cm.status,
+        cm.priority,
+        cm.isInherited
+          ? `Yes — ${cm.inheritedFromComponentName ?? cm.inheritedFromZoneName ?? ''}`
+          : 'No',
+        threat.threatName,
+        context,
+      ])
+    }
+  }
+
+  if (rows.length === 0) return []
+
+  const children: (Paragraph | Table)[] = [
+    h1('8. Countermeasures'),
+    spacer(),
+    buildTable(
+      [2160, 1080, 900, 780, 1440, 1440, 1560],
+      ['Countermeasure', 'Control Type', 'Status', 'Priority', 'Inherited', 'Associated Threat', 'Component'],
+      rows,
+    ),
+    spacer(),
+  ]
+
+  // Gaps
+  if (data.countermeasureSummary.gaps.length > 0) {
+    children.push(
+      h2('8.1 Open Gaps'),
+      spacer(),
+      buildTable(
+        [3240, 2160, 1440, 2520],
+        ['Countermeasure', 'Component / Data Flow', 'Priority', 'Assigned Owner'],
+        data.countermeasureSummary.gaps.map((g) => [
+          g.countermeasureName,
+          g.componentName ?? g.flowLabel ?? '—',
+          g.priority,
+          g.assignedOwnerEmail ?? 'Unassigned',
+        ]),
+      ),
+      spacer(),
+    )
+  }
+
+  return children
+}
+
+function buildRisksSection(data: ReportData): (Paragraph | Table)[] {
+  if (data.risks.length === 0) return []
+
+  return [
+    h1('9. Risk Register'),
+    spacer(),
+    buildTable(
+      [2160, 1200, 1200, 1200, 1200, 2400],
+      ['Risk Name', 'Inherent Score', 'Inherent Level', 'Residual Score', 'Residual Level', 'Owner'],
+      data.risks.map((r) => [
+        r.name,
+        String(r.inherentScore),
+        r.inherentLevel,
+        String(r.residualScore),
+        r.residualLevel,
+        r.ownerEmail ?? 'Unassigned',
+      ]),
+    ),
+    spacer(),
+  ]
+}
+
+function buildComplianceSection(data: ReportData): (Paragraph | Table)[] {
+  if (data.compliance.frameworks.length === 0) return []
+
+  return [
+    h1('10. Compliance Coverage'),
+    spacer(),
+    buildTable(
+      [3240, 1680, 1680, 2760],
+      ['Framework', 'Total Requirements', 'Covered', 'Coverage %'],
+      data.compliance.frameworks.map((fw) => [
+        fw.name,
+        String(fw.totalRequirements),
+        String(fw.coveredRequirements),
+        `${fw.coveragePercentage.toFixed(1)}%`,
+      ]),
+    ),
+    spacer(),
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function exportWordDoc(data: ReportData, modelName: string): Promise<void> {
+  const children: (Paragraph | Table)[] = [
+    // Title page
+    new Paragraph({
+      heading: HeadingLevel.TITLE,
+      children: [new TextRun({ text: modelName })],
+    }),
+    new Paragraph({
+      children: [
+        new TextRun({
+          text: 'Cybersecurity Threat Model — Full Report',
+          size: 28,
+          color: '444444',
+        }),
+      ],
+    }),
+    new Paragraph({
+      children: [
+        new TextRun({
+          text: `Generated: ${new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`,
+          size: 24,
+          color: '888888',
+        }),
+      ],
+    }),
+    spacer(),
+    placeholder('This document is auto-generated. Review all sections and insert DFD diagrams before submission.'),
+    pageBreak(),
+
+    // Sections
+    ...buildMetadataSection(data),
+    pageBreak(),
+    ...buildSummarySection(data),
+    pageBreak(),
+    ...buildScopeSection(data),
+    pageBreak(),
+    ...buildArchitectureSection(data),
+    pageBreak(),
+    ...buildDataAssetsSection(data),
+    pageBreak(),
+    ...buildComponentsSection(data),
+    pageBreak(),
+    ...buildThreatAnalysisSection(data),
+    pageBreak(),
+    ...buildCountermeasuresSection(data),
+    pageBreak(),
+    ...buildRisksSection(data),
+    pageBreak(),
+    ...buildComplianceSection(data),
+  ]
+
+  const doc = new Document({
+    styles: {
+      default: {
+        document: { run: { font: 'Arial', size: 22 } }, // 11pt
+      },
+      paragraphStyles: [
+        {
+          id: 'Heading1',
+          name: 'Heading 1',
+          basedOn: 'Normal',
+          next: 'Normal',
+          quickFormat: true,
+          run: { size: 32, bold: true, font: 'Arial', color: '1F3864' },
+          paragraph: { spacing: { before: 360, after: 120 }, outlineLevel: 0 },
+        },
+        {
+          id: 'Heading2',
+          name: 'Heading 2',
+          basedOn: 'Normal',
+          next: 'Normal',
+          quickFormat: true,
+          run: { size: 26, bold: true, font: 'Arial', color: '2E74B5' },
+          paragraph: { spacing: { before: 240, after: 80 }, outlineLevel: 1 },
+        },
+        {
+          id: 'Heading3',
+          name: 'Heading 3',
+          basedOn: 'Normal',
+          next: 'Normal',
+          quickFormat: true,
+          run: { size: 24, bold: true, font: 'Arial', color: '444444' },
+          paragraph: { spacing: { before: 180, after: 60 }, outlineLevel: 2 },
+        },
+      ],
+    },
+    numbering: {
+      config: [
+        {
+          reference: 'bullets',
+          levels: [
+            {
+              level: 0,
+              format: LevelFormat.BULLET,
+              text: '\u2022',
+              alignment: AlignmentType.LEFT,
+              style: { paragraph: { indent: { left: 720, hanging: 360 } } },
+            },
+          ],
+        },
+      ],
+    },
+    sections: [
+      {
+        properties: {
+          page: {
+            size: { width: 12240, height: 15840 },
+            margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 },
+          },
+        },
+        children,
+      },
+    ],
+  })
+
+  await downloadDocx(doc, `${slugify(modelName)}-threat-model-report.docx`)
+}


### PR DESCRIPTION
Implements client-side export from the Reports tab as outlined in #8.

This is a rebased + review-addressed version of #43 (closed). The CLA is now signed.

CSV export (four sections via dropdown):
- Threats: name, description, STRIDE, severity, status, component
- Countermeasures: name, control type, status, priority, inherited, associated threat, component
- Risks: name, scores, levels, owner
- Compliance Coverage: framework, total, covered, coverage %

Word export (Full Report .docx):
- 10 sections covering metadata, summary metrics, scope, architecture, data assets, components, threat analysis, countermeasures, risks, and compliance coverage
- Architecture section includes DFD inventory table and per-diagram component node extraction from canvas data, with labeled placeholders for diagram screenshots

Addresses review feedback from #43 (@vikram-s-narayan):
- `docx` ^9.0.3 declared as a frontend dependency in `package.json` (was missing)
- `exportWordDoc` onClick wrapped in `try/catch` with `toast.error` on failure

Note: server-side PDF, DOCX, and Markdown remain out of scope per #8.

Closes #8