### PR TITLE
  feat(pentests): add Scope sub-tab to Pentests workspace tab

### DIFF
--- a/backend/apps/threat_models/report_service.py
+++ b/backend/apps/threat_models/report_service.py
@@ -297,6 +297,23 @@ def _get_stride_category(threat_library):
     return "unknown"
 
 
+def _get_taxonomy_entries(threat_library, taxonomy_snapshot=None):
+    """Return all taxonomy entries for a threat, falling back to snapshot."""
+    if threat_library:
+        entries = []
+        for join in threat_library.taxonomy_entries.all():
+            entry = join.taxonomy_entry
+            if entry.taxonomy:
+                entries.append({
+                    "taxonomy_slug": entry.taxonomy.slug,
+                    "external_id": entry.external_id,
+                    "title": entry.title,
+                    "reference_url": entry.reference_url or "",
+                })
+        return entries
+    return taxonomy_snapshot or []
+
+
 def _serialize_countermeasure(cm):
     """Serialize a countermeasure (component or flow) to dict."""
     return {
@@ -380,6 +397,9 @@ def _build_threat_analysis(component_ids, dataflow_ids):
                 threat.threat_library.description if threat.threat_library else None
             ) or threat.threat_description,
             "stride_category": _get_stride_category(threat.threat_library),
+            "taxonomy_entries": _get_taxonomy_entries(
+                threat.threat_library, threat.taxonomy_snapshot
+            ),
             "inherent_severity": threat.inherent_severity,
             "residual_severity": threat.residual_severity,
             "status": threat.status,
@@ -404,6 +424,9 @@ def _build_threat_analysis(component_ids, dataflow_ids):
                 threat.threat_library.description if threat.threat_library else None
             ) or threat.threat_description,
             "stride_category": _get_stride_category(threat.threat_library),
+            "taxonomy_entries": _get_taxonomy_entries(
+                threat.threat_library, threat.taxonomy_snapshot
+            ),
             "inherent_severity": threat.inherent_severity,
             "residual_severity": threat.residual_severity,
             "status": threat.status,

--- a/frontend/src/features/pentests/PentestView.tsx
+++ b/frontend/src/features/pentests/PentestView.tsx
@@ -1,0 +1,154 @@
+import { useMemo } from 'react'
+import { Loader2, Crosshair, Construction } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useReport } from '@/features/reports/api/reports'
+import {
+  computeScopeMetrics,
+  buildTrustZoneGroups,
+  buildSeverityPrioritySummary,
+  buildComponentTestGroups,
+  buildScopeDefinition,
+  buildDataAssetsAtRisk,
+  buildComplianceSummary,
+  buildRiskCrossReferences,
+} from './utils/scopeTransformers'
+import { PentestMetricsRow } from './sections/PentestMetricsRow'
+import { PentestScopeDefinition } from './sections/PentestScopeDefinition'
+import { AttackSurfaceMap } from './sections/AttackSurfaceMap'
+import { TestingPrioritySummary } from './sections/TestingPrioritySummary'
+import { TestCasesByComponent } from './sections/TestCasesByComponent'
+import { DataAssetsAtRisk } from './sections/DataAssetsAtRisk'
+import { ComplianceTestRequirements } from './sections/ComplianceTestRequirements'
+import { RiskCrossReference } from './sections/RiskCrossReference'
+
+interface PentestViewProps {
+  threatModelId: string
+}
+
+export function PentestView({ threatModelId }: PentestViewProps) {
+  const { data: reportData, isLoading, isError } = useReport(threatModelId)
+
+  // Transform report data into shapes needed by each section
+  const scopeMetrics = useMemo(
+    () => (reportData ? computeScopeMetrics(reportData) : null),
+    [reportData]
+  )
+  const trustZoneGroups = useMemo(
+    () => (reportData ? buildTrustZoneGroups(reportData) : []),
+    [reportData]
+  )
+  const severityPriority = useMemo(
+    () => (reportData ? buildSeverityPrioritySummary(reportData) : []),
+    [reportData]
+  )
+  const componentTestGroups = useMemo(
+    () => (reportData ? buildComponentTestGroups(reportData) : []),
+    [reportData]
+  )
+  const scopeDefinition = useMemo(
+    () => (reportData ? buildScopeDefinition(reportData) : null),
+    [reportData]
+  )
+  const dataAssets = useMemo(
+    () => (reportData ? buildDataAssetsAtRisk(reportData) : []),
+    [reportData]
+  )
+  const complianceFrameworks = useMemo(
+    () => (reportData ? buildComplianceSummary(reportData) : []),
+    [reportData]
+  )
+  const riskCrossReferences = useMemo(
+    () => (reportData ? buildRiskCrossReferences(reportData) : []),
+    [reportData]
+  )
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (isError || !reportData) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <p className="text-muted-foreground">Failed to load pentest scope data.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      <Tabs defaultValue="scope" className="flex-1 flex flex-col min-h-0">
+        <div className="px-6 border-b bg-muted/20">
+          <TabsList className="h-10 bg-transparent p-0 gap-4">
+            <TabsTrigger
+              value="scope"
+              className="h-10 px-3 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none gap-1.5 text-sm"
+            >
+              <Crosshair className="h-3.5 w-3.5" />
+              Scope
+            </TabsTrigger>
+            <TabsTrigger
+              value="reconcile"
+              className="h-10 px-3 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none gap-1.5 text-sm"
+            >
+              <Construction className="h-3.5 w-3.5" />
+              Reconcile
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        {/* Scope sub-tab */}
+        <TabsContent value="scope" className="flex-1 overflow-y-auto m-0">
+          <div className="max-w-5xl mx-auto p-6 space-y-4">
+            {/* Header */}
+            <div className="mb-2">
+              <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 text-[11px] font-semibold uppercase tracking-wide mb-2">
+                <Crosshair className="h-3 w-3" />
+                Pentest Scope
+              </div>
+              <h2 className="text-xl font-bold tracking-tight">{reportData.metadata.name}</h2>
+              <p className="text-sm text-muted-foreground mt-1">
+                Penetration testing scope derived from threat model analysis.
+                {scopeMetrics && (
+                  <> Covers {scopeMetrics.totalComponents} components and {scopeMetrics.totalTestCases} identified threats.</>
+                )}
+              </p>
+            </div>
+
+            {/* Metrics */}
+            {scopeMetrics && <PentestMetricsRow metrics={scopeMetrics} />}
+
+            {/* Sections */}
+            {scopeDefinition && <PentestScopeDefinition scope={scopeDefinition} />}
+            <DataAssetsAtRisk assets={dataAssets} />
+            <AttackSurfaceMap zoneGroups={trustZoneGroups} />
+            <TestingPrioritySummary rows={severityPriority} />
+            <TestCasesByComponent groups={componentTestGroups} />
+            <ComplianceTestRequirements frameworks={complianceFrameworks} />
+            <RiskCrossReference risks={riskCrossReferences} />
+          </div>
+        </TabsContent>
+
+        {/* Reconcile sub-tab (placeholder) */}
+        <TabsContent value="reconcile" className="flex-1 overflow-y-auto m-0">
+          <div className="flex items-center justify-center h-full min-h-[400px]">
+            <Card className="max-w-md">
+              <CardContent className="flex flex-col items-center text-center py-10 px-8">
+                <Construction className="h-12 w-12 text-muted-foreground mb-4" />
+                <h3 className="text-lg font-semibold mb-2">Reconcile</h3>
+                <p className="text-sm text-muted-foreground">
+                  Compare pentest findings against your threat model to identify gaps and validate coverage.
+                  This feature is coming soon.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/frontend/src/features/pentests/sections/AttackSurfaceMap.tsx
+++ b/frontend/src/features/pentests/sections/AttackSurfaceMap.tsx
@@ -1,0 +1,109 @@
+import { Globe, Shield, Database, Server, HardDrive, User, Monitor, ArrowRight, Lock, LockOpen } from 'lucide-react'
+import { ReportSection } from '@/features/reports/ReportSection'
+import type { TrustZoneGroup } from '../utils/scopeTransformers'
+
+interface AttackSurfaceMapProps {
+  zoneGroups: TrustZoneGroup[]
+}
+
+const ZONE_STYLES: Record<number, { borderColor: string; labelColor: string; icon: React.ReactNode }> = {}
+
+function getZoneStyle(trustLevel: number) {
+  if (trustLevel <= 1) {
+    return { borderColor: 'border-red-500/25', labelColor: 'text-red-500', icon: <Globe className="h-3.5 w-3.5" /> }
+  }
+  if (trustLevel <= 3) {
+    return { borderColor: 'border-orange-500/25', labelColor: 'text-orange-500', icon: <Shield className="h-3.5 w-3.5" /> }
+  }
+  if (trustLevel <= 5) {
+    return { borderColor: 'border-blue-500/25', labelColor: 'text-blue-500', icon: <Database className="h-3.5 w-3.5" /> }
+  }
+  return { borderColor: 'border-muted-foreground/25', labelColor: 'text-muted-foreground', icon: <Shield className="h-3.5 w-3.5" /> }
+}
+
+function getCategoryIcon(category: string) {
+  switch (category) {
+    case 'process': return <Server className="h-3.5 w-3.5 text-muted-foreground" />
+    case 'datastore': return <Database className="h-3.5 w-3.5 text-muted-foreground" />
+    case 'external_human_actor': return <User className="h-3.5 w-3.5 text-muted-foreground" />
+    case 'external_system_actor': return <Monitor className="h-3.5 w-3.5 text-muted-foreground" />
+    default: return <Server className="h-3.5 w-3.5 text-muted-foreground" />
+  }
+}
+
+export function AttackSurfaceMap({ zoneGroups }: AttackSurfaceMapProps) {
+  if (zoneGroups.length === 0) {
+    return (
+      <ReportSection title="Attack Surface Map">
+        <p className="text-sm text-muted-foreground italic">No trust zones defined in the threat model.</p>
+      </ReportSection>
+    )
+  }
+
+  return (
+    <ReportSection title="Attack Surface Map">
+      <div className="flex flex-col gap-3">
+        {zoneGroups.map((zone) => {
+          const style = getZoneStyle(zone.trustLevel)
+          return (
+            <div
+              key={zone.zoneName}
+              className={`relative rounded-lg border border-dashed p-4 pt-5 ${style.borderColor}`}
+            >
+              {/* Zone label */}
+              <div className={`absolute -top-2.5 left-4 bg-background px-2 text-xs font-semibold uppercase tracking-wide flex items-center gap-1.5 ${style.labelColor}`}>
+                {style.icon}
+                {zone.zoneName}
+              </div>
+
+              {/* Components */}
+              <div className="flex flex-wrap gap-2">
+                {zone.components.map((comp) => (
+                  <div
+                    key={comp.id}
+                    className="flex items-center gap-2 rounded-md border bg-muted/50 px-3 py-2 text-xs font-medium"
+                  >
+                    {getCategoryIcon(comp.category)}
+                    <span>{comp.name}</span>
+                    {comp.componentType && (
+                      <span className="text-muted-foreground">{comp.componentType}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              {/* Boundary crossings */}
+              {zone.boundaryCrossings.length > 0 && (
+                <div className="mt-3 pt-3 border-t border-dashed">
+                  <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                    Boundary Crossings
+                  </p>
+                  <div className="space-y-1">
+                    {zone.boundaryCrossings.map((flow) => (
+                      <div key={flow.id} className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono">
+                        <ArrowRight className="h-3 w-3 shrink-0" />
+                        <span>{flow.source ?? '?'}</span>
+                        <ArrowRight className="h-3 w-3 shrink-0" />
+                        <span>{flow.destination ?? '?'}</span>
+                        {flow.protocol && (
+                          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium">
+                            {flow.protocol}
+                          </span>
+                        )}
+                        {flow.encrypted ? (
+                          <Lock className="h-3 w-3 text-green-500" />
+                        ) : (
+                          <LockOpen className="h-3 w-3 text-red-500" />
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </ReportSection>
+  )
+}

--- a/frontend/src/features/pentests/sections/ComplianceTestRequirements.tsx
+++ b/frontend/src/features/pentests/sections/ComplianceTestRequirements.tsx
@@ -1,0 +1,71 @@
+import { Progress } from '@/components/ui/progress'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ReportSection } from '@/features/reports/ReportSection'
+import type { ComplianceFrameworkSummary } from '../utils/scopeTransformers'
+
+interface ComplianceTestRequirementsProps {
+  frameworks: ComplianceFrameworkSummary[]
+}
+
+function coverageColorClass(percentage: number): string {
+  if (percentage >= 80) return 'text-green-500'
+  if (percentage >= 50) return 'text-yellow-500'
+  return 'text-red-500'
+}
+
+export function ComplianceTestRequirements({ frameworks }: ComplianceTestRequirementsProps) {
+  if (frameworks.length === 0) {
+    return (
+      <ReportSection title="Compliance-Driven Test Requirements">
+        <p className="text-sm text-muted-foreground italic">No compliance frameworks linked to this threat model.</p>
+      </ReportSection>
+    )
+  }
+
+  return (
+    <ReportSection title="Compliance-Driven Test Requirements">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Framework</TableHead>
+            <TableHead className="w-[100px] text-center">Requirements</TableHead>
+            <TableHead className="w-[100px] text-center">Covered</TableHead>
+            <TableHead className="w-[180px]">Coverage</TableHead>
+            <TableHead className="w-[100px] text-center">Satisfied</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {frameworks.map((fw) => (
+            <TableRow key={fw.slug}>
+              <TableCell className="font-medium">{fw.name}</TableCell>
+              <TableCell className="text-center">{fw.totalRequirements}</TableCell>
+              <TableCell className="text-center">{fw.coveredRequirements}</TableCell>
+              <TableCell>
+                <div className="flex items-center gap-2">
+                  <Progress value={fw.coveragePercentage} className="w-24 h-1.5" />
+                  <span className={`text-xs font-semibold ${coverageColorClass(fw.coveragePercentage)}`}>
+                    {fw.coveragePercentage}%
+                  </span>
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center justify-center gap-2">
+                  <span className={`text-xs font-semibold ${coverageColorClass(fw.satisfactionPercentage)}`}>
+                    {fw.satisfiedRequirements} ({fw.satisfactionPercentage}%)
+                  </span>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </ReportSection>
+  )
+}

--- a/frontend/src/features/pentests/sections/DataAssetsAtRisk.tsx
+++ b/frontend/src/features/pentests/sections/DataAssetsAtRisk.tsx
@@ -1,0 +1,97 @@
+import { Badge } from '@/components/ui/badge'
+import { Check, X } from 'lucide-react'
+import { ReportSection } from '@/features/reports/ReportSection'
+import type { DataAssetRisk } from '../utils/scopeTransformers'
+
+interface DataAssetsAtRiskProps {
+  assets: DataAssetRisk[]
+}
+
+const CLASSIFICATION_CLASSES: Record<string, string> = {
+  restricted: 'bg-red-100 text-red-700 border-red-200 dark:bg-red-950 dark:text-red-400 dark:border-red-900',
+  confidential: 'bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-950 dark:text-orange-400 dark:border-orange-900',
+  sensitive: 'bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-950 dark:text-yellow-400 dark:border-yellow-900',
+  internal: 'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-400 dark:border-blue-900',
+  public: 'bg-green-100 text-green-700 border-green-200 dark:bg-green-950 dark:text-green-400 dark:border-green-900',
+}
+
+function ciaLabel(value: string): string {
+  if (!value || value === 'none') return 'N/A'
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+export function DataAssetsAtRisk({ assets }: DataAssetsAtRiskProps) {
+  if (assets.length === 0) {
+    return (
+      <ReportSection title="Data Assets at Risk">
+        <p className="text-sm text-muted-foreground italic">No data assets defined in the threat model.</p>
+      </ReportSection>
+    )
+  }
+
+  return (
+    <ReportSection title="Data Assets at Risk">
+      <div className="space-y-2.5">
+        {assets.map((asset) => {
+          const hasAtRestGap = asset.placements.some(p => !p.encrypted)
+          const hasTransitGap = asset.transitGaps > 0
+
+          return (
+            <div key={asset.id} className="rounded-lg border bg-muted/30 p-4">
+              {/* Top row: name + classification */}
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-sm font-semibold">{asset.name}</p>
+                <Badge className={CLASSIFICATION_CLASSES[asset.classification.toLowerCase()] ?? 'bg-muted text-muted-foreground'}>
+                  {asset.classification}
+                </Badge>
+              </div>
+
+              {/* Details */}
+              <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground">
+                {/* CIA ratings */}
+                <span>C: {ciaLabel(asset.confidentiality)}</span>
+                <span>I: {ciaLabel(asset.integrity)}</span>
+                <span>A: {ciaLabel(asset.availability)}</span>
+
+                {/* Storage locations */}
+                {asset.placements.length > 0 && (
+                  <span>
+                    Stored in: {asset.placements.map(p => p.componentName).join(', ')}
+                  </span>
+                )}
+
+                {/* Encryption at rest */}
+                <span className="flex items-center gap-1">
+                  At Rest:
+                  {hasAtRestGap ? (
+                    <>
+                      <X className="h-3 w-3 text-red-500" />
+                      <span className="text-red-500 font-semibold">GAP</span>
+                    </>
+                  ) : (
+                    <Check className="h-3 w-3 text-green-500" />
+                  )}
+                </span>
+
+                {/* Encryption in transit */}
+                <span className="flex items-center gap-1">
+                  In Transit:
+                  {hasTransitGap ? (
+                    <>
+                      <X className="h-3 w-3 text-red-500" />
+                      <span className="text-red-500 font-semibold">GAP</span>
+                    </>
+                  ) : asset.totalTransit > 0 ? (
+                    <Check className="h-3 w-3 text-green-500" />
+                  ) : (
+                    <span>N/A</span>
+                  )}
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </ReportSection>
+  )
+}

--- a/frontend/src/features/pentests/sections/PentestMetricsRow.tsx
+++ b/frontend/src/features/pentests/sections/PentestMetricsRow.tsx
@@ -1,0 +1,60 @@
+import { Card, CardContent } from '@/components/ui/card'
+import type { ScopeMetrics } from '../utils/scopeTransformers'
+
+interface PentestMetricsRowProps {
+  metrics: ScopeMetrics
+}
+
+export function PentestMetricsRow({ metrics }: PentestMetricsRowProps) {
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+      <Card>
+        <CardContent className="pt-4 pb-3 px-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1">
+            Critical Threats
+          </p>
+          <p className="text-2xl font-extrabold text-red-500">{metrics.criticalThreats}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {metrics.criticalWithGaps} with countermeasure gaps
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-4 pb-3 px-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1">
+            High Threats
+          </p>
+          <p className="text-2xl font-extrabold text-orange-500">{metrics.highThreats}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {metrics.highWithGaps} with countermeasure gaps
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-4 pb-3 px-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1">
+            Countermeasure Gaps
+          </p>
+          <p className="text-2xl font-extrabold text-red-500">{metrics.totalGaps}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {metrics.gapPercentage}% of all countermeasures
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-4 pb-3 px-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1">
+            Test Cases
+          </p>
+          <p className="text-2xl font-extrabold text-blue-500">{metrics.totalTestCases}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Across {metrics.totalComponents} components
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/features/pentests/sections/PentestScopeDefinition.tsx
+++ b/frontend/src/features/pentests/sections/PentestScopeDefinition.tsx
@@ -1,0 +1,98 @@
+import { CheckCircle, Ban, Lightbulb } from 'lucide-react'
+import { ReportSection } from '@/features/reports/ReportSection'
+import type { ScopeDefinitionData } from '../utils/scopeTransformers'
+
+interface PentestScopeDefinitionProps {
+  scope: ScopeDefinitionData
+}
+
+function categoryLabel(category: string): string {
+  switch (category) {
+    case 'process': return 'Process'
+    case 'datastore': return 'Data Store'
+    case 'external_human_actor': return 'Human Actor'
+    case 'external_system_actor': return 'System Actor'
+    default: return category
+  }
+}
+
+export function PentestScopeDefinition({ scope }: PentestScopeDefinitionProps) {
+  return (
+    <ReportSection title="Scope Definition">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* In Scope */}
+        <div className="rounded-lg border bg-muted/30 p-4">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3 flex items-center gap-1.5">
+            <CheckCircle className="h-3.5 w-3.5 text-green-500" />
+            In Scope
+          </h4>
+          <ul className="space-y-1.5">
+            {scope.inScopeComponents.map((comp, index) => (
+              <li key={index} className="flex items-start gap-2 text-sm">
+                <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-green-500 shrink-0" />
+                <span>
+                  {comp.name}
+                  {comp.trustZone && (
+                    <span className="text-muted-foreground"> ({comp.trustZone})</span>
+                  )}
+                </span>
+              </li>
+            ))}
+            {scope.inScopeFlows > 0 && (
+              <li className="flex items-start gap-2 text-sm">
+                <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-green-500 shrink-0" />
+                <span>{scope.inScopeFlows} data flow{scope.inScopeFlows !== 1 ? 's' : ''}</span>
+              </li>
+            )}
+          </ul>
+        </div>
+
+        {/* Out of Scope + Assumptions */}
+        <div className="rounded-lg border bg-muted/30 p-4">
+          {scope.outOfScopeItems.length > 0 && (
+            <>
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3 flex items-center gap-1.5">
+                <Ban className="h-3.5 w-3.5 text-red-500" />
+                Out of Scope
+              </h4>
+              <ul className="space-y-1.5 mb-4">
+                {scope.outOfScopeItems.map((item, index) => (
+                  <li key={index} className="flex items-start gap-2 text-sm">
+                    <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-red-500 shrink-0" />
+                    <span>
+                      {item.name}
+                      {item.reason && (
+                        <span className="text-muted-foreground"> &mdash; {item.reason}</span>
+                      )}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+
+          {scope.assumptions.length > 0 && (
+            <>
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3 flex items-center gap-1.5">
+                <Lightbulb className="h-3.5 w-3.5 text-yellow-500" />
+                Assumptions
+              </h4>
+              <ul className="space-y-1.5">
+                {scope.assumptions.map((assumption, index) => (
+                  <li key={index} className="flex items-start gap-2 text-sm">
+                    <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-yellow-500 shrink-0" />
+                    <span>{assumption.description}</span>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+
+          {scope.outOfScopeItems.length === 0 && scope.assumptions.length === 0 && (
+            <p className="text-sm text-muted-foreground italic">No out-of-scope items or assumptions defined.</p>
+          )}
+        </div>
+      </div>
+    </ReportSection>
+  )
+}

--- a/frontend/src/features/pentests/sections/RiskCrossReference.tsx
+++ b/frontend/src/features/pentests/sections/RiskCrossReference.tsx
@@ -1,0 +1,79 @@
+import { AlertTriangle } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { ReportSection } from '@/features/reports/ReportSection'
+import type { RiskCrossRef } from '../utils/scopeTransformers'
+
+interface RiskCrossReferenceProps {
+  risks: RiskCrossRef[]
+}
+
+const LEVEL_BADGE_CLASSES: Record<string, string> = {
+  critical: 'bg-red-100 text-red-700 border-red-200 dark:bg-red-950 dark:text-red-400 dark:border-red-900',
+  high: 'bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-950 dark:text-orange-400 dark:border-orange-900',
+  medium: 'bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-950 dark:text-yellow-400 dark:border-yellow-900',
+  low: 'bg-green-100 text-green-700 border-green-200 dark:bg-green-950 dark:text-green-400 dark:border-green-900',
+}
+
+const LEVEL_ICON_COLORS: Record<string, string> = {
+  critical: 'text-red-500',
+  high: 'text-orange-500',
+  medium: 'text-yellow-500',
+  low: 'text-green-500',
+}
+
+export function RiskCrossReference({ risks }: RiskCrossReferenceProps) {
+  if (risks.length === 0) {
+    return (
+      <ReportSection title="Risk Cross-Reference">
+        <p className="text-sm text-muted-foreground italic">No risks defined in the threat model.</p>
+      </ReportSection>
+    )
+  }
+
+  return (
+    <ReportSection title="Risk Cross-Reference">
+      <div className="space-y-2.5">
+        {risks.map((risk) => (
+          <div key={risk.id} className="rounded-lg border bg-muted/30 p-4">
+            {/* Top: name + level badge */}
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className={`h-4 w-4 ${LEVEL_ICON_COLORS[risk.inherentLevel.toLowerCase()] ?? 'text-muted-foreground'}`} />
+                <p className="text-sm font-semibold">{risk.name}</p>
+              </div>
+              <Badge className={LEVEL_BADGE_CLASSES[risk.inherentLevel.toLowerCase()] ?? ''}>
+                {risk.inherentLevel}
+              </Badge>
+            </div>
+
+            {/* Scores */}
+            <p className="text-xs text-muted-foreground mb-2">
+              Score: <span className="font-semibold text-foreground">{risk.inherentScore.toFixed(1)}</span> (Inherent)
+              {' '}&rarr;{' '}
+              <span className={`font-semibold ${LEVEL_ICON_COLORS[risk.residualLevel.toLowerCase()] ?? ''}`}>
+                {risk.residualScore.toFixed(1)}
+              </span> (Residual)
+              {risk.ownerEmail && (
+                <span> &middot; Owner: {risk.ownerEmail}</span>
+              )}
+            </p>
+
+            {/* Contributing threats */}
+            {risk.contributingThreats.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {risk.contributingThreats.map((threat, index) => (
+                  <span
+                    key={index}
+                    className="text-[11px] px-2.5 py-1 rounded-md bg-muted text-muted-foreground"
+                  >
+                    {threat.threatName}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </ReportSection>
+  )
+}

--- a/frontend/src/features/pentests/sections/TestCasesByComponent.tsx
+++ b/frontend/src/features/pentests/sections/TestCasesByComponent.tsx
@@ -1,0 +1,212 @@
+import { useState } from 'react'
+import { Server, Database, User, Monitor, ArrowLeftRight, ChevronRight, ChevronDown } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ReportSection } from '@/features/reports/ReportSection'
+import { TaxonomyBadges } from '@/components/shared/TaxonomyBadges'
+import { COUNTERMEASURE_STATUS_CONFIG } from '@/features/dfd-editor/types/threat-analysis'
+import type { ReportCountermeasure } from '@/features/reports/types/report'
+import type { ComponentTestGroup, TestCase } from '../utils/scopeTransformers'
+
+interface TestCasesByComponentProps {
+  groups: ComponentTestGroup[]
+}
+
+const SEVERITY_BADGE_CLASSES: Record<string, string> = {
+  critical: 'bg-red-100 text-red-700 border-red-200 dark:bg-red-950 dark:text-red-400 dark:border-red-900',
+  high: 'bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-950 dark:text-orange-400 dark:border-orange-900',
+  medium: 'bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-950 dark:text-yellow-400 dark:border-yellow-900',
+  low: 'bg-green-100 text-green-700 border-green-200 dark:bg-green-950 dark:text-green-400 dark:border-green-900',
+}
+
+const STATUS_BADGE_CLASSES: Record<string, string> = {
+  gap: 'bg-red-100 text-red-700 border-red-200 dark:bg-red-950 dark:text-red-400 dark:border-red-900',
+  planned: 'bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-950 dark:text-yellow-400 dark:border-yellow-900',
+  in_progress: 'bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-950 dark:text-orange-400 dark:border-orange-900',
+  verified: 'bg-green-100 text-green-700 border-green-200 dark:bg-green-950 dark:text-green-400 dark:border-green-900',
+  platform: 'bg-green-100 text-green-700 border-green-200 dark:bg-green-950 dark:text-green-400 dark:border-green-900',
+  waived: 'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-400 dark:border-blue-900',
+}
+
+function getCategoryIcon(category: string) {
+  switch (category) {
+    case 'process': return <Server className="h-4 w-4" />
+    case 'datastore': return <Database className="h-4 w-4" />
+    case 'external_human_actor': return <User className="h-4 w-4" />
+    case 'external_system_actor': return <Monitor className="h-4 w-4" />
+    case 'dataflow': return <ArrowLeftRight className="h-4 w-4" />
+    default: return <Server className="h-4 w-4" />
+  }
+}
+
+function statusLabel(status: string): string {
+  const config = COUNTERMEASURE_STATUS_CONFIG[status as keyof typeof COUNTERMEASURE_STATUS_CONFIG]
+  return config?.label ?? status
+}
+
+function CountermeasureDetail({ countermeasures }: { countermeasures: ReportCountermeasure[] }) {
+  if (countermeasures.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground italic py-1">No countermeasures defined for this threat.</p>
+    )
+  }
+
+  return (
+    <div className="rounded-md border bg-muted/30">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-b">
+            <th className="text-left px-3 py-1.5 font-semibold text-muted-foreground uppercase tracking-wide text-[10px]">Countermeasure</th>
+            <th className="text-left px-3 py-1.5 font-semibold text-muted-foreground uppercase tracking-wide text-[10px] w-[90px]">Status</th>
+            <th className="text-left px-3 py-1.5 font-semibold text-muted-foreground uppercase tracking-wide text-[10px] w-[80px]">Type</th>
+            <th className="text-left px-3 py-1.5 font-semibold text-muted-foreground uppercase tracking-wide text-[10px] w-[80px]">Priority</th>
+            <th className="text-left px-3 py-1.5 font-semibold text-muted-foreground uppercase tracking-wide text-[10px]">Owner</th>
+          </tr>
+        </thead>
+        <tbody>
+          {countermeasures.map((cm) => (
+            <tr key={cm.id} className="border-b last:border-b-0">
+              <td className="px-3 py-1.5 font-medium">{cm.countermeasureName}</td>
+              <td className="px-3 py-1.5">
+                <Badge className={`text-[10px] ${STATUS_BADGE_CLASSES[cm.status] ?? ''}`}>
+                  {statusLabel(cm.status)}
+                </Badge>
+              </td>
+              <td className="px-3 py-1.5 text-muted-foreground capitalize">{cm.controlType || '\u2014'}</td>
+              <td className="px-3 py-1.5 text-muted-foreground capitalize">{cm.priority || '\u2014'}</td>
+              <td className="px-3 py-1.5 text-muted-foreground">{cm.assignedOwnerEmail || '\u2014'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function TestCaseRow({ testCase }: { testCase: TestCase }) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const hasCountermeasures = testCase.countermeasures.length > 0
+
+  return (
+    <>
+      <TableRow
+        className={hasCountermeasures ? 'cursor-pointer' : ''}
+        onClick={() => hasCountermeasures && setIsExpanded(!isExpanded)}
+      >
+        <TableCell className="w-6 pr-0">
+          {hasCountermeasures && (
+            isExpanded
+              ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+              : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+          )}
+        </TableCell>
+        <TableCell>
+          <Badge
+            className={SEVERITY_BADGE_CLASSES[testCase.inherentSeverity.toLowerCase()] ?? ''}
+          >
+            {testCase.inherentSeverity}
+          </Badge>
+        </TableCell>
+        <TableCell>
+          <div>
+            <span className="font-medium">{testCase.threatName}</span>
+            {testCase.threatDescription && (
+              <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">{testCase.threatDescription}</p>
+            )}
+          </div>
+        </TableCell>
+        <TableCell>
+          <TaxonomyBadges entries={testCase.taxonomyEntries} maxVisible={3} size="sm" />
+        </TableCell>
+        <TableCell>
+          <div className="flex items-center gap-1.5">
+            <Badge
+              className={STATUS_BADGE_CLASSES[testCase.defenseGapStatus] ?? ''}
+            >
+              {statusLabel(testCase.defenseGapStatus)}
+            </Badge>
+            {hasCountermeasures && (
+              <span className="text-[11px] text-muted-foreground">
+                {testCase.countermeasures.length} countermeasure{testCase.countermeasures.length !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+        </TableCell>
+      </TableRow>
+      {isExpanded && (
+        <TableRow className="hover:bg-transparent">
+          <TableCell colSpan={5} className="pt-0 pb-3 px-4">
+            <CountermeasureDetail countermeasures={testCase.countermeasures} />
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  )
+}
+
+export function TestCasesByComponent({ groups }: TestCasesByComponentProps) {
+  if (groups.length === 0) {
+    return (
+      <ReportSection title="Test Cases by Component">
+        <p className="text-sm text-muted-foreground italic">No threats identified to generate test cases.</p>
+      </ReportSection>
+    )
+  }
+
+  return (
+    <ReportSection title="Test Cases by Component">
+      <div className="space-y-6">
+        {groups.map((group) => (
+          <div key={`${group.componentType}-${group.componentName}`}>
+            {/* Component header */}
+            <div className="flex items-center justify-between mb-3 pb-2 border-b">
+              <div className="flex items-center gap-2.5">
+                <div className={`flex items-center justify-center h-8 w-8 rounded-lg ${
+                  group.componentType === 'dataflow' ? 'bg-yellow-500/10 text-yellow-600' : 'bg-blue-500/10 text-blue-600'
+                }`}>
+                  {getCategoryIcon(group.category)}
+                </div>
+                <div>
+                  <p className="text-sm font-semibold">
+                    {group.componentType === 'dataflow' ? `Data Flow: ${group.componentName}` : group.componentName}
+                  </p>
+                  {group.trustZone && (
+                    <p className="text-xs text-muted-foreground">{group.trustZone}</p>
+                  )}
+                </div>
+              </div>
+              <span className="text-xs text-muted-foreground">
+                <span className="font-bold">{group.testCases.length}</span> test case{group.testCases.length !== 1 ? 's' : ''}
+              </span>
+            </div>
+
+            {/* Test cases table */}
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-6" />
+                  <TableHead className="w-[80px]">Priority</TableHead>
+                  <TableHead>Test Case</TableHead>
+                  <TableHead className="w-[150px]">Taxonomy</TableHead>
+                  <TableHead className="w-[180px]">Defense Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {group.testCases.map((testCase) => (
+                  <TestCaseRow key={testCase.id} testCase={testCase} />
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        ))}
+      </div>
+    </ReportSection>
+  )
+}

--- a/frontend/src/features/pentests/sections/TestingPrioritySummary.tsx
+++ b/frontend/src/features/pentests/sections/TestingPrioritySummary.tsx
@@ -1,0 +1,67 @@
+import { ReportSection } from '@/features/reports/ReportSection'
+import type { SeverityPriorityRow } from '../utils/scopeTransformers'
+
+interface TestingPrioritySummaryProps {
+  rows: SeverityPriorityRow[]
+}
+
+const SEVERITY_COLORS: Record<string, { text: string; bar: string }> = {
+  critical: { text: 'text-red-500', bar: 'bg-red-500' },
+  high: { text: 'text-orange-500', bar: 'bg-orange-500' },
+  medium: { text: 'text-yellow-500', bar: 'bg-yellow-500' },
+  low: { text: 'text-green-500', bar: 'bg-green-500' },
+}
+
+export function TestingPrioritySummary({ rows }: TestingPrioritySummaryProps) {
+  if (rows.length === 0) {
+    return (
+      <ReportSection title="Testing Priority Summary">
+        <p className="text-sm text-muted-foreground italic">No threats to prioritize.</p>
+      </ReportSection>
+    )
+  }
+
+  const maxTotal = Math.max(...rows.map(r => r.totalThreats), 1)
+
+  return (
+    <ReportSection title="Testing Priority Summary">
+      {/* Header row */}
+      <div className="grid grid-cols-[80px_1fr_60px_60px] gap-3 mb-2">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Severity</span>
+        <span />
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground text-center">Total</span>
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground text-center">Gaps</span>
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        {rows.map((row) => {
+          const colors = SEVERITY_COLORS[row.severity] ?? SEVERITY_COLORS.low
+          const barWidth = Math.max((row.gapPercentage / 100) * 100, 2) // min 2% for visibility
+
+          return (
+            <div key={row.severity} className="grid grid-cols-[80px_1fr_60px_60px] gap-3 items-center">
+              <span className={`text-xs font-semibold capitalize ${colors.text}`}>
+                {row.severity}
+              </span>
+              <div className="h-6 rounded-md bg-muted overflow-hidden">
+                <div
+                  className={`h-full rounded-md transition-all ${colors.bar}`}
+                  style={{ width: `${barWidth}%` }}
+                />
+              </div>
+              <span className="text-sm text-center font-semibold">{row.totalThreats}</span>
+              <span className="text-sm text-center font-semibold text-red-500">
+                {row.threatsWithGaps}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      <p className="text-xs text-muted-foreground italic mt-4">
+        Bar width represents the percentage of threats in each severity that have countermeasure gaps.
+        Prioritize testing critical and high severity threats with known gaps first.
+      </p>
+    </ReportSection>
+  )
+}

--- a/frontend/src/features/pentests/utils/scopeTransformers.ts
+++ b/frontend/src/features/pentests/utils/scopeTransformers.ts
@@ -1,0 +1,443 @@
+import type {
+  ReportData,
+  ReportThreat,
+  ReportCountermeasure,
+  ReportComponent,
+  ReportDataAsset,
+  ReportRisk,
+  ReportComplianceFramework,
+  ReportThreatTaxonomyEntry,
+} from '@/features/reports/types/report'
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const SEVERITY_ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  info: 4,
+}
+
+function severityRank(severity: string): number {
+  return SEVERITY_ORDER[severity.toLowerCase()] ?? 99
+}
+
+function hasGap(countermeasure: ReportCountermeasure): boolean {
+  return countermeasure.status === 'gap'
+}
+
+function threatHasGap(threat: ReportThreat): boolean {
+  return threat.countermeasures.some(hasGap)
+}
+
+/** Worst (lowest-rank = most severe) countermeasure status for a threat */
+function worstCountermeasureStatus(threat: ReportThreat): string {
+  const statusPriority: Record<string, number> = {
+    gap: 0,
+    planned: 1,
+    in_progress: 2,
+    verified: 3,
+    platform: 4,
+    waived: 5,
+  }
+  let worst = 'verified'
+  let worstRank = statusPriority['verified'] ?? 99
+  for (const cm of threat.countermeasures) {
+    const rank = statusPriority[cm.status] ?? 99
+    if (rank < worstRank) {
+      worstRank = rank
+      worst = cm.status
+    }
+  }
+  return worst
+}
+
+// ---------------------------------------------------------------------------
+// 1. Scope Metrics
+// ---------------------------------------------------------------------------
+
+export interface ScopeMetrics {
+  criticalThreats: number
+  criticalWithGaps: number
+  highThreats: number
+  highWithGaps: number
+  totalGaps: number
+  gapPercentage: number
+  totalTestCases: number
+  totalComponents: number
+}
+
+export function computeScopeMetrics(data: ReportData): ScopeMetrics {
+  const allThreats = collectAllThreats(data)
+
+  const criticalThreats = allThreats.filter(t => t.inherentSeverity.toLowerCase() === 'critical')
+  const highThreats = allThreats.filter(t => t.inherentSeverity.toLowerCase() === 'high')
+
+  const totalCountermeasures = data.summaryMetrics.totalCountermeasures
+  const totalGaps = data.summaryMetrics.totalGaps
+
+  const componentCount =
+    data.components.processes.length +
+    data.components.dataStores.length +
+    data.components.humanActors.length +
+    data.components.systemActors.length
+
+  return {
+    criticalThreats: criticalThreats.length,
+    criticalWithGaps: criticalThreats.filter(threatHasGap).length,
+    highThreats: highThreats.length,
+    highWithGaps: highThreats.filter(threatHasGap).length,
+    totalGaps,
+    gapPercentage: totalCountermeasures > 0 ? Math.round((totalGaps / totalCountermeasures) * 100) : 0,
+    totalTestCases: allThreats.length,
+    totalComponents: componentCount,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Trust Zone Groups (Attack Surface Map)
+// ---------------------------------------------------------------------------
+
+export interface TrustZoneComponent {
+  id: number
+  name: string
+  category: string
+  componentType: string
+  provider: string
+}
+
+export interface BoundaryCrossingFlow {
+  id: number
+  label: string
+  source: string | null
+  destination: string | null
+  protocol: string
+  encrypted: boolean
+}
+
+export interface TrustZoneGroup {
+  zoneName: string
+  trustLevel: number
+  description: string
+  components: TrustZoneComponent[]
+  boundaryCrossings: BoundaryCrossingFlow[]
+}
+
+export function buildTrustZoneGroups(data: ReportData): TrustZoneGroup[] {
+  const allComponents = [
+    ...data.components.processes,
+    ...data.components.dataStores,
+    ...data.components.humanActors,
+    ...data.components.systemActors,
+  ]
+
+  // Build zone lookup
+  const zoneMap = new Map<string, { trustLevel: number; description: string }>()
+  for (const zone of data.architecture.trustZones) {
+    zoneMap.set(zone.name, { trustLevel: zone.trustLevel, description: zone.description })
+  }
+
+  // Group components by trust zone
+  const groups = new Map<string, TrustZoneComponent[]>()
+  for (const comp of allComponents) {
+    const zoneName = comp.trustZone ?? 'Unassigned'
+    if (!groups.has(zoneName)) groups.set(zoneName, [])
+    groups.get(zoneName)!.push({
+      id: comp.id,
+      name: comp.name,
+      category: comp.category,
+      componentType: comp.componentType,
+      provider: comp.provider,
+    })
+  }
+
+  // Boundary-crossing data flows
+  const boundaryCrossings = data.dataFlows.filter(f => f.crossesTrustZone)
+
+  // Build zone groups
+  const result: TrustZoneGroup[] = []
+  for (const [zoneName, components] of groups) {
+    const zoneInfo = zoneMap.get(zoneName)
+
+    // Flows that touch this zone's components
+    const componentNames = new Set(components.map(c => c.name))
+    const zoneFlows = boundaryCrossings.filter(
+      f => (f.source && componentNames.has(f.source)) || (f.destination && componentNames.has(f.destination))
+    )
+
+    result.push({
+      zoneName,
+      trustLevel: zoneInfo?.trustLevel ?? 999,
+      description: zoneInfo?.description ?? '',
+      components,
+      boundaryCrossings: zoneFlows.map(f => ({
+        id: f.id,
+        label: f.label,
+        source: f.source,
+        destination: f.destination,
+        protocol: f.protocol,
+        encrypted: f.encrypted,
+      })),
+    })
+  }
+
+  // Sort by trust level ascending (least trusted first)
+  result.sort((a, b) => a.trustLevel - b.trustLevel)
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// 3. Severity Priority Summary
+// ---------------------------------------------------------------------------
+
+export interface SeverityPriorityRow {
+  severity: string
+  totalThreats: number
+  threatsWithGaps: number
+  gapPercentage: number
+}
+
+export function buildSeverityPrioritySummary(data: ReportData): SeverityPriorityRow[] {
+  const allThreats = collectAllThreats(data)
+
+  const groupedBySeverity = new Map<string, ReportThreat[]>()
+  for (const threat of allThreats) {
+    const severity = threat.inherentSeverity.toLowerCase()
+    if (!groupedBySeverity.has(severity)) groupedBySeverity.set(severity, [])
+    groupedBySeverity.get(severity)!.push(threat)
+  }
+
+  const severities = ['critical', 'high', 'medium', 'low']
+  return severities
+    .filter(s => groupedBySeverity.has(s))
+    .map(severity => {
+      const threats = groupedBySeverity.get(severity)!
+      const withGaps = threats.filter(threatHasGap).length
+      return {
+        severity,
+        totalThreats: threats.length,
+        threatsWithGaps: withGaps,
+        gapPercentage: threats.length > 0 ? Math.round((withGaps / threats.length) * 100) : 0,
+      }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// 4. Component Test Groups (Test Cases by Component)
+// ---------------------------------------------------------------------------
+
+export interface TestCase {
+  id: number
+  threatName: string
+  threatDescription: string
+  inherentSeverity: string
+  strideCategory: string | null
+  taxonomyEntries: ReportThreatTaxonomyEntry[]
+  defenseGapStatus: string
+  worstGapCountermeasureName: string | null
+  countermeasures: ReportCountermeasure[]
+}
+
+export interface ComponentTestGroup {
+  componentName: string
+  componentType: 'component' | 'dataflow'
+  category: string
+  trustZone: string | null
+  testCases: TestCase[]
+  priority: number // higher = more urgent
+}
+
+export function buildComponentTestGroups(data: ReportData): ComponentTestGroup[] {
+  const groups: ComponentTestGroup[] = []
+
+  // Find component metadata by name
+  const allComponents = [
+    ...data.components.processes,
+    ...data.components.dataStores,
+    ...data.components.humanActors,
+    ...data.components.systemActors,
+  ]
+  const componentLookup = new Map<string, ReportComponent>()
+  for (const comp of allComponents) {
+    componentLookup.set(comp.name, comp)
+  }
+
+  // Component threats
+  for (const [componentName, threats] of Object.entries(data.threatAnalysis.componentThreats)) {
+    const comp = componentLookup.get(componentName)
+    const testCases = threats.map(threatToTestCase)
+    testCases.sort((a, b) => severityRank(a.inherentSeverity) - severityRank(b.inherentSeverity))
+
+    groups.push({
+      componentName,
+      componentType: 'component',
+      category: comp?.category ?? 'process',
+      trustZone: comp?.trustZone ?? null,
+      testCases,
+      priority: computeGroupPriority(threats),
+    })
+  }
+
+  // Data flow threats
+  for (const [flowLabel, threats] of Object.entries(data.threatAnalysis.dataFlowThreats)) {
+    const testCases = threats.map(threatToTestCase)
+    testCases.sort((a, b) => severityRank(a.inherentSeverity) - severityRank(b.inherentSeverity))
+
+    groups.push({
+      componentName: flowLabel,
+      componentType: 'dataflow',
+      category: 'dataflow',
+      trustZone: null,
+      testCases,
+      priority: computeGroupPriority(threats),
+    })
+  }
+
+  // Sort by priority descending (highest priority first)
+  groups.sort((a, b) => b.priority - a.priority)
+
+  return groups
+}
+
+// ---------------------------------------------------------------------------
+// 5. Scope Definition helpers
+// ---------------------------------------------------------------------------
+
+export interface ScopeDefinitionData {
+  inScopeComponents: Array<{ name: string; category: string; trustZone: string | null }>
+  inScopeFlows: number
+  outOfScopeItems: Array<{ name: string; reason: string }>
+  assumptions: Array<{ description: string; validity: string }>
+}
+
+export function buildScopeDefinition(data: ReportData): ScopeDefinitionData {
+  const allComponents = [
+    ...data.components.processes,
+    ...data.components.dataStores,
+    ...data.components.humanActors,
+    ...data.components.systemActors,
+  ]
+
+  return {
+    inScopeComponents: allComponents.map(c => ({
+      name: c.name,
+      category: c.category,
+      trustZone: c.trustZone,
+    })),
+    inScopeFlows: data.dataFlows.length,
+    outOfScopeItems: data.scope.outOfScopeItems.map(item => ({
+      name: item.name,
+      reason: item.reason,
+    })),
+    assumptions: data.scope.assumptions.map(a => ({
+      description: a.description,
+      validity: a.validity,
+    })),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Data Assets helpers
+// ---------------------------------------------------------------------------
+
+export interface DataAssetRisk {
+  id: number
+  name: string
+  description: string
+  classification: string
+  confidentiality: string
+  integrity: string
+  availability: string
+  placements: Array<{ componentName: string; encrypted: boolean }>
+  transitGaps: number
+  totalTransit: number
+}
+
+export function buildDataAssetsAtRisk(data: ReportData): DataAssetRisk[] {
+  return data.dataAssets.map(asset => ({
+    id: asset.id,
+    name: asset.name,
+    description: asset.description,
+    classification: asset.classification,
+    confidentiality: asset.confidentiality,
+    integrity: asset.integrity,
+    availability: asset.availability,
+    placements: asset.placements.map(p => ({
+      componentName: p.componentName,
+      encrypted: p.encrypted,
+    })),
+    transitGaps: asset.inTransit.filter(t => t.encryptionType === 'none' || t.encryptionType === '').length,
+    totalTransit: asset.inTransit.length,
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// 7. Compliance helpers
+// ---------------------------------------------------------------------------
+
+export type ComplianceFrameworkSummary = ReportComplianceFramework
+
+export function buildComplianceSummary(data: ReportData): ComplianceFrameworkSummary[] {
+  return data.compliance.frameworks
+}
+
+// ---------------------------------------------------------------------------
+// 8. Risk cross-reference helpers
+// ---------------------------------------------------------------------------
+
+export type RiskCrossRef = ReportRisk
+
+export function buildRiskCrossReferences(data: ReportData): RiskCrossRef[] {
+  // Sort by inherent score descending
+  return [...data.risks].sort((a, b) => b.inherentScore - a.inherentScore)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function collectAllThreats(data: ReportData): ReportThreat[] {
+  const threats: ReportThreat[] = []
+  for (const group of Object.values(data.threatAnalysis.componentThreats)) {
+    threats.push(...group)
+  }
+  for (const group of Object.values(data.threatAnalysis.dataFlowThreats)) {
+    threats.push(...group)
+  }
+  return threats
+}
+
+function threatToTestCase(threat: ReportThreat): TestCase {
+  const gapStatus = worstCountermeasureStatus(threat)
+  const worstGapCm = threat.countermeasures.find(cm => cm.status === gapStatus)
+
+  return {
+    id: threat.id,
+    threatName: threat.threatName,
+    threatDescription: threat.threatDescription,
+    inherentSeverity: threat.inherentSeverity,
+    strideCategory: threat.strideCategory,
+    taxonomyEntries: threat.taxonomyEntries ?? [],
+    defenseGapStatus: gapStatus,
+    worstGapCountermeasureName: worstGapCm?.countermeasureName ?? null,
+    countermeasures: threat.countermeasures,
+  }
+}
+
+function computeGroupPriority(threats: ReportThreat[]): number {
+  let score = 0
+  for (const threat of threats) {
+    const severity = threat.inherentSeverity.toLowerCase()
+    if (severity === 'critical') score += 10
+    else if (severity === 'high') score += 5
+    else if (severity === 'medium') score += 2
+    else score += 1
+
+    if (threatHasGap(threat)) score += 3
+  }
+  return score
+}

--- a/frontend/src/features/reports/types/report.ts
+++ b/frontend/src/features/reports/types/report.ts
@@ -131,11 +131,19 @@ export interface ReportCountermeasure {
   inheritedFromZoneName: string | null
 }
 
+export interface ReportThreatTaxonomyEntry {
+  taxonomySlug: string
+  externalId: string
+  title: string
+  referenceUrl?: string
+}
+
 export interface ReportThreat {
   id: number
   threatName: string
   threatDescription: string
   strideCategory: string | null
+  taxonomyEntries?: ReportThreatTaxonomyEntry[]
   inherentSeverity: string
   residualSeverity: string
   status: string

--- a/frontend/src/features/threat-models/pages/ThreatModelDetail.tsx
+++ b/frontend/src/features/threat-models/pages/ThreatModelDetail.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react'
 import { Link, useParams, useNavigate } from 'react-router-dom'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { ChevronLeft, Loader2, LayoutDashboard, Shield, Trash2, BarChart3, FileText, Share2, Download, Pencil } from 'lucide-react'
+import { ChevronLeft, Loader2, LayoutDashboard, Shield, Trash2, BarChart3, FileText, Share2, Download, Pencil, Crosshair } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
@@ -23,6 +23,7 @@ import {
 import { OverviewTab } from '@/features/threat-models/components/OverviewTab'
 import { MagicLinkDialog } from '@/features/threat-models/components/MagicLinkDialog'
 import { ReportView } from '@/features/reports/ReportView'
+import { PentestView } from '@/features/pentests/PentestView'
 import { useWorkspaceThreatAnalysis } from '@/features/threat-models/hooks'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import { ComponentView } from '@/features/dfd-editor/components/threat-analysis/ComponentView'
@@ -596,6 +597,13 @@ export function ThreatModelDetail() {
               Risk Analysis
             </TabsTrigger>
             <TabsTrigger
+              value="pentests"
+              className="h-12 px-4 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none gap-2"
+            >
+              <Crosshair className="h-4 w-4" />
+              Pentests
+            </TabsTrigger>
+            <TabsTrigger
               value="reports"
               className="h-12 px-4 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none gap-2"
             >
@@ -774,6 +782,11 @@ export function ThreatModelDetail() {
             riskScoringMethod={threatModel.riskScoringMethod ?? 'tm_library'}
             onScoringMethodChange={handleScoringMethodChange}
           />
+        </TabsContent>
+
+        {/* Pentests Tab */}
+        <TabsContent value="pentests" className="flex-1 flex flex-col m-0 overflow-hidden">
+          <PentestView threatModelId={id!} />
         </TabsContent>
 
         {/* Reports Tab */}


### PR DESCRIPTION
  Derives pentest scope from existing threat model data, giving
  pentesters targets, attack surface, and test cases before an
  engagement. Reuses the existing report API — no new backend
  endpoints.

  Sections: metrics row, scope definition, data assets at risk,
  attack surface map, testing priority summary, test cases by
  component (with expandable countermeasure details and taxonomy
  badges), compliance coverage, and risk cross-reference.

  Backend: serialize taxonomy entries (CAPEC/CWE/ATT&CK) per threat
  in report_service.py so pentest test cases show full taxonomy refs.

  Reconcile sub-tab shows placeholder for future implementation.

  Refs: #122