### PR TITLE
feat: add capec taxonomy pack

### DIFF
--- a/libraries/packs/taxonomies/capec/pack.yaml
+++ b/libraries/packs/taxonomies/capec/pack.yaml
@@ -1,0 +1,17 @@
+pack:
+  schema_version: 1
+  slug: capec
+  name: CAPEC Attack Patterns
+  description: Curated subset of MITRE CAPEC (v3.9) selected by CWE Top 25 (2025)
+    overlap, MITRE ATT&CK technique mapping, and cloud-relevant keyword scoring
+    (credential abuse, API exploitation, injection, privilege escalation), plus a
+    small set of manually added canonical patterns that matched the same criteria
+    but scored just under the automated threshold. See taxonomy.yaml for the full
+    selection rule.
+  version: 1.0.0
+  pack_type: taxonomy
+  author: Precogly
+  tags:
+  - capec
+  - attack-patterns
+  - mitre

--- a/libraries/packs/taxonomies/capec/taxonomy.yaml
+++ b/libraries/packs/taxonomies/capec/taxonomy.yaml
@@ -1,0 +1,358 @@
+taxonomies:
+  - slug: capec
+    name: CAPEC Attack Patterns
+    description: "Common Attack Pattern Enumeration and Classification: curated subset of MITRE CAPEC (v3.9). Selection rule: patterns scoring >=5 on a formula of CWE Top 25 (2025) overlap (+3, via the Related_Weaknesses field in the CAPEC XML), MITRE ATT&CK technique mapping (+3, via the Taxonomy_Mappings field in the CAPEC XML), and a cloud-relevant keyword bonus (credential abuse, API exploitation, injection, privilege escalation) -- 74 patterns cleared this threshold. An additional 14 canonical patterns (e.g. SSRF, Password Spraying, Pass The Hash, CSRF, XSS, Credential Stuffing) were manually added after review because they matched the same criteria but scored just under the threshold due to keyword-phrasing gaps. Deprecated/Obsolete-status patterns were excluded."
+    source_url: "https://capec.mitre.org/"
+    entries:
+      - external_id: CAPEC-1
+        title: Accessing Functionality Not Properly Constrained by ACLs
+        description: "In applications, particularly web applications, access to functionality is mitigated by an authorization framework. This framework maps Access Control Lists (ACLs) to elements of the application's functionality; particularly URL's for web apps."
+        reference_url: "https://capec.mitre.org/data/definitions/1.html"
+      - external_id: CAPEC-6
+        title: Argument Injection
+        description: "An attacker changes the behavior or state of a targeted application through injecting data or command syntax through the targets use of non-validated and non-filtered arguments of exposed services or methods."
+        reference_url: "https://capec.mitre.org/data/definitions/6.html"
+      - external_id: CAPEC-7
+        title: Blind SQL Injection
+        description: "Blind SQL Injection results from an insufficient mitigation for SQL Injection. Although suppressing database error messages are considered best practice, the suppression alone is not sufficient to prevent SQL Injection."
+        reference_url: "https://capec.mitre.org/data/definitions/7.html"
+      - external_id: CAPEC-13
+        title: Subverting Environment Variable Values
+        description: "The adversary directly or indirectly modifies environment variables used by or controlling the target software. The adversary's goal is to cause the target software to deviate from its expected operation in a manner that benefits the adversary."
+        reference_url: "https://capec.mitre.org/data/definitions/13.html"
+      - external_id: CAPEC-14
+        title: Client-side Injection-induced Buffer Overflow
+        description: "This type of attack exploits a buffer overflow vulnerability in targeted client software through injection of malicious content from a custom-built hostile service. This hostile service is created to deliver the correct content to the client software."
+        reference_url: "https://capec.mitre.org/data/definitions/14.html"
+      - external_id: CAPEC-19
+        title: Embedding Scripts within Scripts
+        description: "An adversary leverages the capability to execute their own script by embedding it within other scripts that the target software is likely to execute due to programs' vulnerabilities that are brought on by allowing remote hosts to execute scripts."
+        reference_url: "https://capec.mitre.org/data/definitions/19.html"
+      - external_id: CAPEC-23
+        title: File Content Injection
+        description: "An adversary poisons files with a malicious payload (targeting the file systems accessible by the target software), which may be passed through by standard channels such as via email, and standard web content like PDF and multimedia files. The adversary exploits known vulnerabilities or handling routines in the target processes, in order to exploit the host's trust in executing remote content, including binary files."
+        reference_url: "https://capec.mitre.org/data/definitions/23.html"
+      - external_id: CAPEC-30
+        title: Hijacking a Privileged Thread of Execution
+        description: "An adversary hijacks a privileged thread of execution by injecting malicious code into a running process. By using a privleged thread to do their bidding, adversaries can evade process-based detection that would stop an attack that creates a new process."
+        reference_url: "https://capec.mitre.org/data/definitions/30.html"
+      - external_id: CAPEC-31
+        title: Accessing/Intercepting/Modifying HTTP Cookies
+        description: "This attack relies on the use of HTTP Cookies to store credentials, state information and other critical data on client systems. There are several different forms of this attack."
+        reference_url: "https://capec.mitre.org/data/definitions/31.html"
+      - external_id: CAPEC-35
+        title: Leverage Executable Code in Non-Executable Files
+        description: "An attack of this type exploits a system's trust in configuration and resource files. When the executable loads the resource (such as an image file or configuration file) the attacker has modified the file to either execute malicious code directly or manipulate the target process (e.g. application server) to execute based on the malicious configuration parameters."
+        reference_url: "https://capec.mitre.org/data/definitions/35.html"
+      - external_id: CAPEC-59
+        title: Session Credential Falsification through Prediction
+        description: "This attack targets predictable session ID in order to gain privileges. The attacker can predict the session ID used during a transaction to perform spoofing and session hijacking."
+        reference_url: "https://capec.mitre.org/data/definitions/59.html"
+      - external_id: CAPEC-60
+        title: Reusing Session IDs (aka Session Replay)
+        description: "This attack targets the reuse of valid session ID to spoof the target system in order to gain privileges. The attacker tries to reuse a stolen session ID used previously during a transaction to perform spoofing and session hijacking."
+        reference_url: "https://capec.mitre.org/data/definitions/60.html"
+      - external_id: CAPEC-62
+        title: Cross Site Request Forgery
+        description: "An attacker crafts malicious web links and distributes them (via web pages, email, etc.), typically in a targeted manner, hoping to induce users to click on the link and execute the malicious action against some third-party application. If successful, the action embedded in the malicious link will be processed and accepted by the targeted application with the users' privilege level."
+        reference_url: "https://capec.mitre.org/data/definitions/62.html"
+      - external_id: CAPEC-63
+        title: Cross-Site Scripting (XSS)
+        description: "An adversary embeds malicious scripts in content that will be served to web browsers. The goal of the attack is for the target software, the client-side browser, to execute the script with the users' privilege level."
+        reference_url: "https://capec.mitre.org/data/definitions/63.html"
+      - external_id: CAPEC-66
+        title: SQL Injection
+        description: "This attack exploits target software that constructs SQL statements based on user input. An attacker crafts input strings so that when the target software constructs SQL statements based on the input, the resulting SQL statement performs actions other than those the application intended."
+        reference_url: "https://capec.mitre.org/data/definitions/66.html"
+      - external_id: CAPEC-67
+        title: String Format Overflow in syslog()
+        description: "This attack targets applications and software that uses the syslog() function insecurely. If an application does not explicitely use a format string parameter in a call to syslog(), user input can be placed in the format string parameter leading to a format string injection attack."
+        reference_url: "https://capec.mitre.org/data/definitions/67.html"
+      - external_id: CAPEC-70
+        title: Try Common or Default Usernames and Passwords
+        description: "An adversary may try certain common or default usernames and passwords to gain access into the system and perform unauthorized actions. An adversary may try an intelligent brute force using empty passwords, known vendor default credentials, as well as a dictionary of common usernames and passwords."
+        reference_url: "https://capec.mitre.org/data/definitions/70.html"
+      - external_id: CAPEC-83
+        title: XPath Injection
+        description: "An attacker can craft special user-controllable input consisting of XPath expressions to inject the XML database and bypass authentication or glean information that they normally would not be able to. XPath Injection enables an attacker to talk directly to the XML database, thus bypassing the application completely."
+        reference_url: "https://capec.mitre.org/data/definitions/83.html"
+      - external_id: CAPEC-88
+        title: OS Command Injection
+        description: "In this type of an attack, an adversary injects operating system commands into existing application functions. An application that uses untrusted input to build command strings is vulnerable."
+        reference_url: "https://capec.mitre.org/data/definitions/88.html"
+      - external_id: CAPEC-94
+        title: Adversary in the Middle (AiTM)
+        description: "An adversary targets the communication between two components (typically client and server), in order to alter or obtain data from transactions. A general approach entails the adversary placing themself within the communication channel between the two components."
+        reference_url: "https://capec.mitre.org/data/definitions/94.html"
+      - external_id: CAPEC-98
+        title: Phishing
+        description: "Phishing is a social engineering technique where an attacker masquerades as a legitimate entity with which the victim might do business in order to prompt the user to reveal some confidential information (very frequently authentication credentials) that can later be used by an attacker. Phishing is essentially a form of information gathering or \"fishing\" for information."
+        reference_url: "https://capec.mitre.org/data/definitions/98.html"
+      - external_id: CAPEC-101
+        title: Server Side Include (SSI) Injection
+        description: "An attacker can use Server Side Include (SSI) Injection to send code to a web application that then gets executed by the web server. Doing so enables the attacker to achieve similar results to Cross Site Scripting, viz., arbitrary code execution and information disclosure, albeit on a more limited scale, since the SSI directives are nowhere near as powerful as a full-fledged scripting language."
+        reference_url: "https://capec.mitre.org/data/definitions/101.html"
+      - external_id: CAPEC-108
+        title: Command Line Execution through SQL Injection
+        description: "An attacker uses standard SQL injection methods to inject data into the command line for execution. This could be done directly through misuse of directives such as MSSQL_xp_cmdshell or indirectly through injection of data into the database that would be interpreted as shell commands."
+        reference_url: "https://capec.mitre.org/data/definitions/108.html"
+      - external_id: CAPEC-109
+        title: Object Relational Mapping Injection
+        description: "An attacker leverages a weakness present in the database access layer code generated with an Object Relational Mapping (ORM) tool or a weakness in the way that a developer used a persistence framework to inject their own SQL commands to be executed against the underlying database. The attack here is similar to plain SQL injection, except that the application does not use JDBC to directly talk to the database, but instead it uses a data access layer generated by an ORM tool or framework (e.g. Hibernate)."
+        reference_url: "https://capec.mitre.org/data/definitions/109.html"
+      - external_id: CAPEC-110
+        title: SQL Injection through SOAP Parameter Tampering
+        description: "An attacker modifies the parameters of the SOAP message that is sent from the service consumer to the service provider to initiate a SQL injection attack. On the service provider side, the SOAP message is parsed and parameters are not properly validated before being used to access a database in a way that does not use parameter binding, thus enabling the attacker to control the structure of the executed SQL query."
+        reference_url: "https://capec.mitre.org/data/definitions/110.html"
+      - external_id: CAPEC-112
+        title: Brute Force
+        description: "In this attack, some asset (information, functionality, identity, etc.) is protected by a finite secret value. The attacker attempts to gain access to this asset by using trial-and-error to exhaustively explore all the possible secret values in the hope of finding the secret (or a value that is functionally equivalent) that will unlock the asset."
+        reference_url: "https://capec.mitre.org/data/definitions/112.html"
+      - external_id: CAPEC-115
+        title: Authentication Bypass
+        description: "An attacker gains access to application, service, or device with the privileges of an authorized or privileged user by evading or circumventing an authentication mechanism. The attacker is therefore able to access protected data without authentication ever having taken place."
+        reference_url: "https://capec.mitre.org/data/definitions/115.html"
+      - external_id: CAPEC-120
+        title: Double Encoding
+        description: "The adversary utilizes a repeating of the encoding process for a set of characters (that is, character encoding a character encoding of a character) to obfuscate the payload of a particular request. This may allow the adversary to bypass filters that attempt to detect illegal characters or strings, such as those that might be used in traversal or injection attacks."
+        reference_url: "https://capec.mitre.org/data/definitions/120.html"
+      - external_id: CAPEC-122
+        title: Privilege Abuse
+        description: "An adversary is able to exploit features of the target that should be reserved for privileged users or administrators but are exposed to use by lower or non-privileged accounts. Access to sensitive information and functionality must be controlled to ensure that only authorized users are able to access these resources."
+        reference_url: "https://capec.mitre.org/data/definitions/122.html"
+      - external_id: CAPEC-125
+        title: Flooding
+        description: "An adversary consumes the resources of a target by rapidly engaging in a large number of interactions with the target. This type of attack generally exposes a weakness in rate limiting or flow."
+        reference_url: "https://capec.mitre.org/data/definitions/125.html"
+      - external_id: CAPEC-130
+        title: Excessive Allocation
+        description: "An adversary causes the target to allocate excessive resources to servicing the attackers' request, thereby reducing the resources available for legitimate services and degrading or denying services. Usually, this attack focuses on memory allocation, but any finite resource on the target could be the attacked, including bandwidth, processing cycles, or other resources."
+        reference_url: "https://capec.mitre.org/data/definitions/130.html"
+      - external_id: CAPEC-135
+        title: Format String Injection
+        description: "An adversary includes formatting characters in a string input field on the target application. Most applications assume that users will provide static text and may respond unpredictably to the presence of formatting character."
+        reference_url: "https://capec.mitre.org/data/definitions/135.html"
+      - external_id: CAPEC-136
+        title: LDAP Injection
+        description: "An attacker manipulates or crafts an LDAP query for the purpose of undermining the security of the target. Some applications use user input to create LDAP queries that are processed by an LDAP server."
+        reference_url: "https://capec.mitre.org/data/definitions/136.html"
+      - external_id: CAPEC-160
+        title: Exploit Script-Based APIs
+        description: "Some APIs support scripting instructions as arguments. Methods that take scripted instructions (or references to scripted instructions) can be very flexible and powerful."
+        reference_url: "https://capec.mitre.org/data/definitions/160.html"
+      - external_id: CAPEC-169
+        title: Footprinting
+        description: "An adversary engages in probing and exploration activities to identify constituents and properties of the target."
+        reference_url: "https://capec.mitre.org/data/definitions/169.html"
+      - external_id: CAPEC-182
+        title: Flash Injection
+        description: "An attacker tricks a victim to execute malicious flash content that executes commands or makes flash calls specified by the attacker. One example of this attack is cross-site flashing, an attacker controlled parameter to a reference call loads from content specified by the attacker."
+        reference_url: "https://capec.mitre.org/data/definitions/182.html"
+      - external_id: CAPEC-183
+        title: IMAP/SMTP Command Injection
+        description: "An adversary exploits weaknesses in input validation on web-mail servers to execute commands on the IMAP/SMTP server. Web-mail servers often sit between the Internet and the IMAP or SMTP mail server."
+        reference_url: "https://capec.mitre.org/data/definitions/183.html"
+      - external_id: CAPEC-233
+        title: Privilege Escalation
+        description: "An adversary exploits a weakness enabling them to elevate their privilege and perform an action that they are not supposed to be authorized to perform."
+        reference_url: "https://capec.mitre.org/data/definitions/233.html"
+      - external_id: CAPEC-242
+        title: Code Injection
+        description: "An adversary exploits a weakness in input validation on the target to inject new code into that which is currently executing. This differs from code inclusion in that code inclusion involves the addition or replacement of a reference to a code file, which is subsequently loaded by the target and used as part of the code of some application."
+        reference_url: "https://capec.mitre.org/data/definitions/242.html"
+      - external_id: CAPEC-248
+        title: Command Injection
+        description: "An adversary looking to execute a command of their choosing, injects new items into an existing command thus modifying interpretation away from what was intended. Commands in this context are often standalone strings that are interpreted by a downstream component and cause specific responses."
+        reference_url: "https://capec.mitre.org/data/definitions/248.html"
+      - external_id: CAPEC-250
+        title: XML Injection
+        description: "An attacker utilizes crafted XML user-controllable input to probe, attack, and inject data into the XML database, using techniques similar to SQL injection. The user-controllable input can allow for unauthorized viewing of data, bypassing authentication or the front-end application for direct XML database access, and possibly altering database information."
+        reference_url: "https://capec.mitre.org/data/definitions/250.html"
+      - external_id: CAPEC-267
+        title: Leverage Alternate Encoding
+        description: "An adversary leverages the possibility to encode potentially harmful input or content used by applications such that the applications are ineffective at validating this encoding standard."
+        reference_url: "https://capec.mitre.org/data/definitions/267.html"
+      - external_id: CAPEC-268
+        title: Audit Log Manipulation
+        description: "The attacker injects, manipulates, deletes, or forges malicious log entries into the log file, in an attempt to mislead an audit of the log file or cover tracks of an attack. Due to either insufficient access controls of the log files or the logging mechanism, the attacker is able to perform such actions."
+        reference_url: "https://capec.mitre.org/data/definitions/268.html"
+      - external_id: CAPEC-292
+        title: Host Discovery
+        description: "An adversary sends a probe to an IP address to determine if the host is alive. Host discovery is one of the earliest phases of network reconnaissance."
+        reference_url: "https://capec.mitre.org/data/definitions/292.html"
+      - external_id: CAPEC-295
+        title: Timestamp Request
+        description: "This pattern of attack leverages standard requests to learn the exact time associated with a target system. An adversary may be able to use the timestamp returned from the target to attack time-based security algorithms, such as random number generators, or time-based authentication mechanisms."
+        reference_url: "https://capec.mitre.org/data/definitions/295.html"
+      - external_id: CAPEC-300
+        title: Port Scanning
+        description: "An adversary uses a combination of techniques to determine the state of the ports on a remote target. Any service or application available for TCP or UDP networking will have a port open for communications over the network."
+        reference_url: "https://capec.mitre.org/data/definitions/300.html"
+      - external_id: CAPEC-309
+        title: Network Topology Mapping
+        description: "An adversary engages in scanning activities to map network nodes, hosts, devices, and routes. Adversaries usually perform this type of network reconnaissance during the early stages of attack against an external network."
+        reference_url: "https://capec.mitre.org/data/definitions/309.html"
+      - external_id: CAPEC-312
+        title: Active OS Fingerprinting
+        description: "An adversary engages in activity to detect the operating system or firmware version of a remote target by interrogating a device, server, or platform with a probe designed to solicit behavior that will reveal information about the operating systems or firmware in the environment. Operating System detection is possible because implementations of common protocols (Such as IP or TCP) differ in distinct ways."
+        reference_url: "https://capec.mitre.org/data/definitions/312.html"
+      - external_id: CAPEC-313
+        title: Passive OS Fingerprinting
+        description: "An adversary engages in activity to detect the version or type of OS software in a an environment by passively monitoring communication between devices, nodes, or applications. Passive techniques for operating system detection send no actual probes to a target, but monitor network or client-server communication between nodes in order to identify operating systems based on observed behavior as compared to a database of known signatures or values."
+        reference_url: "https://capec.mitre.org/data/definitions/313.html"
+      - external_id: CAPEC-443
+        title: Malicious Logic Inserted Into Product by Authorized Developer
+        description: "An adversary uses their privileged position within an authorized development organization to inject malicious logic into a codebase or product."
+        reference_url: "https://capec.mitre.org/data/definitions/443.html"
+      - external_id: CAPEC-469
+        title: HTTP DoS
+        description: "An attacker performs flooding at the HTTP level to bring down only a particular web application rather than anything listening on a TCP/IP connection. This denial of service attack requires substantially fewer packets to be sent which makes DoS harder to detect."
+        reference_url: "https://capec.mitre.org/data/definitions/469.html"
+      - external_id: CAPEC-470
+        title: Expanding Control over the Operating System from the Database
+        description: "An attacker is able to leverage access gained to the database to read / write data to the file system, compromise the operating system, create a tunnel for accessing the host machine, and use this access to potentially attack other machines on the same network as the database machine. Traditionally SQL injections attacks are viewed as a way to gain unauthorized read access to the data stored in the database, modify the data in the database, delete the data, etc. However, almost every data base management system (DBMS) system includes facilities that if compromised allow an attacker complete access to the file system, operating system, and full access to the host running the database."
+        reference_url: "https://capec.mitre.org/data/definitions/470.html"
+      - external_id: CAPEC-473
+        title: Signature Spoof
+        description: "An attacker generates a message or datablock that causes the recipient to believe that the message or datablock was generated and cryptographically signed by an authoritative or reputable source, misleading a victim or victim operating system into performing malicious actions."
+        reference_url: "https://capec.mitre.org/data/definitions/473.html"
+      - external_id: CAPEC-478
+        title: Modification of Windows Service Configuration
+        description: "An adversary exploits a weakness in access control to modify the execution parameters of a Windows service. The goal of this attack is to execute a malicious binary in place of an existing service."
+        reference_url: "https://capec.mitre.org/data/definitions/478.html"
+      - external_id: CAPEC-479
+        title: Malicious Root Certificate
+        description: "An adversary exploits a weakness in authorization and installs a new root certificate on a compromised system. Certificates are commonly used for establishing secure TLS/SSL communications within a web browser."
+        reference_url: "https://capec.mitre.org/data/definitions/479.html"
+      - external_id: CAPEC-482
+        title: TCP Flood
+        description: "An adversary may execute a flooding attack using the TCP protocol with the intent to deny legitimate users access to a service. These attacks exploit the weakness within the TCP protocol where there is some state information for the connection the server needs to maintain."
+        reference_url: "https://capec.mitre.org/data/definitions/482.html"
+      - external_id: CAPEC-488
+        title: HTTP Flood
+        description: "An adversary may execute a flooding attack using the HTTP protocol with the intent to deny legitimate users access to a service by consuming resources at the application layer such as web services and their infrastructure. These attacks use legitimate session-based HTTP GET requests designed to consume large amounts of a server's resources."
+        reference_url: "https://capec.mitre.org/data/definitions/488.html"
+      - external_id: CAPEC-489
+        title: SSL Flood
+        description: "An adversary may execute a flooding attack using the SSL protocol with the intent to deny legitimate users access to a service by consuming all the available resources on the server side. These attacks take advantage of the asymmetric relationship between the processing power used by the client and the processing power used by the server to create a secure connection."
+        reference_url: "https://capec.mitre.org/data/definitions/489.html"
+      - external_id: CAPEC-490
+        title: Amplification
+        description: "An adversary may execute an amplification where the size of a response is far greater than that of the request that generates it. The goal of this attack is to use a relatively few resources to create a large amount of traffic against a target server."
+        reference_url: "https://capec.mitre.org/data/definitions/490.html"
+      - external_id: CAPEC-497
+        title: File Discovery
+        description: "An adversary engages in probing and exploration activities to determine if common key files exists. Such files often contain configuration and security parameters of the targeted application, system or network."
+        reference_url: "https://capec.mitre.org/data/definitions/497.html"
+      - external_id: CAPEC-502
+        title: Intent Spoof
+        description: "An adversary, through a previously installed malicious application, issues an intent directed toward a specific trusted application's component in an attempt to achieve a variety of different objectives including modification of data, information disclosure, and data injection. Components that have been unintentionally exported and made public are subject to this type of an attack."
+        reference_url: "https://capec.mitre.org/data/definitions/502.html"
+      - external_id: CAPEC-509
+        title: Kerberoasting
+        description: "Through the exploitation of how service accounts leverage Kerberos authentication with Service Principal Names (SPNs), the adversary obtains and subsequently cracks the hashed credentials of a service account target to exploit its privileges. The Kerberos authentication protocol centers around a ticketing system which is used to request/grant access to services and to then access the requested services."
+        reference_url: "https://capec.mitre.org/data/definitions/509.html"
+      - external_id: CAPEC-528
+        title: XML Flood
+        description: "An adversary may execute a flooding attack using XML messages with the intent to deny legitimate users access to a web service. These attacks are accomplished by sending a large number of XML based requests and letting the service attempt to parse each one."
+        reference_url: "https://capec.mitre.org/data/definitions/528.html"
+      - external_id: CAPEC-550
+        title: Install New Service
+        description: "When an operating system starts, it also starts programs called services or daemons. Adversaries may install a new service which will be executed at startup (on a Windows system, by modifying the registry)."
+        reference_url: "https://capec.mitre.org/data/definitions/550.html"
+      - external_id: CAPEC-551
+        title: Modify Existing Service
+        description: "When an operating system starts, it also starts programs called services or daemons. Modifying existing services may break existing services or may enable services that are disabled/not commonly used."
+        reference_url: "https://capec.mitre.org/data/definitions/551.html"
+      - external_id: CAPEC-552
+        title: Install Rootkit 
+        description: "An adversary exploits a weakness in authentication to install malware that alters the functionality and information provide by targeted operating system API calls. Often referred to as rootkits, it is often used to hide the presence of programs, files, network connections, services, drivers, and other system components."
+        reference_url: "https://capec.mitre.org/data/definitions/552.html"
+      - external_id: CAPEC-556
+        title: Replace File Extension Handlers
+        description: "When a file is opened, its file handler is checked to determine which program opens the file. File handlers are configuration properties of many operating systems."
+        reference_url: "https://capec.mitre.org/data/definitions/556.html"
+      - external_id: CAPEC-558
+        title: Replace Trusted Executable
+        description: "An adversary exploits weaknesses in privilege management or access control to replace a trusted executable with a malicious version and enable the execution of malware when that trusted executable is called."
+        reference_url: "https://capec.mitre.org/data/definitions/558.html"
+      - external_id: CAPEC-560
+        title: Use of Known Domain Credentials
+        description: "An adversary guesses or obtains (i.e. steals or purchases) legitimate credentials (e.g. userID/password) to achieve authentication and to perform authorized actions under the guise of an authenticated user or service."
+        reference_url: "https://capec.mitre.org/data/definitions/560.html"
+      - external_id: CAPEC-562
+        title: Modify Shared File
+        description: "An adversary manipulates the files in a shared location by adding malicious programs, scripts, or exploit code to valid content. Once a user opens the shared content, the tainted content is executed."
+        reference_url: "https://capec.mitre.org/data/definitions/562.html"
+      - external_id: CAPEC-564
+        title: Run Software at Logon
+        description: "Operating system allows logon scripts to be run whenever a specific user or users logon to a system. If adversaries can access these scripts, they may insert additional code into the logon script."
+        reference_url: "https://capec.mitre.org/data/definitions/564.html"
+      - external_id: CAPEC-565
+        title: Password Spraying
+        description: "In a Password Spraying attack, an adversary tries a small list (e.g. 3-5) of common or expected passwords, often matching the target's complexity policy, against a known list of user accounts to gain valid credentials. The adversary tries a particular password for each user account, before moving onto the next password in the list."
+        reference_url: "https://capec.mitre.org/data/definitions/565.html"
+      - external_id: CAPEC-573
+        title: Process Footprinting
+        description: "An adversary exploits functionality meant to identify information about the currently running processes on the target system to an authorized user. By knowing what processes are running on the target system, the adversary can learn about the target environment as a means towards further malicious behavior."
+        reference_url: "https://capec.mitre.org/data/definitions/573.html"
+      - external_id: CAPEC-574
+        title: Services Footprinting
+        description: "An adversary exploits functionality meant to identify information about the services on the target system to an authorized user. By knowing what services are registered on the target system, the adversary can learn about the target environment as a means towards further malicious behavior."
+        reference_url: "https://capec.mitre.org/data/definitions/574.html"
+      - external_id: CAPEC-575
+        title: Account Footprinting
+        description: "An adversary exploits functionality meant to identify information about the domain accounts and their permissions on the target system to an authorized user. By knowing what accounts are registered on the target system, the adversary can inform further and more targeted malicious behavior."
+        reference_url: "https://capec.mitre.org/data/definitions/575.html"
+      - external_id: CAPEC-576
+        title: Group Permission Footprinting
+        description: "An adversary exploits functionality meant to identify information about user groups and their permissions on the target system to an authorized user. By knowing what users/permissions are registered on the target system, the adversary can inform further and more targeted malicious behavior."
+        reference_url: "https://capec.mitre.org/data/definitions/576.html"
+      - external_id: CAPEC-577
+        title: Owner Footprinting
+        description: "An adversary exploits functionality meant to identify information about the primary users on the target system to an authorized user. They may do this, for example, by reviewing logins or file modification times."
+        reference_url: "https://capec.mitre.org/data/definitions/577.html"
+      - external_id: CAPEC-578
+        title: Disable Security Software
+        description: "An adversary exploits a weakness in access control to disable security tools so that detection does not occur. This can take the form of killing processes, deleting registry keys so that tools do not start at run time, deleting log files, or other methods."
+        reference_url: "https://capec.mitre.org/data/definitions/578.html"
+      - external_id: CAPEC-586
+        title: Object Injection
+        description: "An adversary attempts to exploit an application by injecting additional, malicious content during its processing of serialized objects. Developers leverage serialization in order to convert data or state into a static, binary format for saving to disk or transferring over a network."
+        reference_url: "https://capec.mitre.org/data/definitions/586.html"
+      - external_id: CAPEC-593
+        title: Session Hijacking
+        description: "This type of attack involves an adversary that exploits weaknesses in an application's use of sessions in performing authentication. The adversary is able to steal or manipulate an active session and use it to gain unathorized access to the application."
+        reference_url: "https://capec.mitre.org/data/definitions/593.html"
+      - external_id: CAPEC-600
+        title: Credential Stuffing
+        description: "An adversary tries known username/password combinations against different systems, applications, or services to gain additional authenticated access. Credential Stuffing attacks rely upon the fact that many users leverage the same username/password combination for multiple systems, applications, and services."
+        reference_url: "https://capec.mitre.org/data/definitions/600.html"
+      - external_id: CAPEC-616
+        title: Establish Rogue Location
+        description: "An adversary provides a malicious version of a resource at a location that is similar to the expected location of a legitimate resource. After establishing the rogue location, the adversary waits for a victim to visit the location and access the malicious resource."
+        reference_url: "https://capec.mitre.org/data/definitions/616.html"
+      - external_id: CAPEC-643
+        title: Identify Shared Files/Directories on System
+        description: "An adversary discovers connections between systems by exploiting the target system's standard practice of revealing them in searchable, common areas. Through the identification of shared folders/drives between systems, the adversary may further their goals of locating and collecting sensitive information/files, or map potential routes for lateral movement within the network."
+        reference_url: "https://capec.mitre.org/data/definitions/643.html"
+      - external_id: CAPEC-644
+        title: Use of Captured Hashes (Pass The Hash)
+        description: "An adversary obtains (i.e. steals or purchases) legitimate Windows domain credential hash values to access systems within the domain that leverage the Lan Man (LM) and/or NT Lan Man (NTLM) authentication protocols."
+        reference_url: "https://capec.mitre.org/data/definitions/644.html"
+      - external_id: CAPEC-646
+        title: Peripheral Footprinting
+        description: "Adversaries may attempt to obtain information about attached peripheral devices and components connected to a computer system. Examples may include discovering the presence of iOS devices by searching for backups, analyzing the Windows registry to determine what USB devices have been connected, or infecting a victim system with malware to report when a USB device has been connected."
+        reference_url: "https://capec.mitre.org/data/definitions/646.html"
+      - external_id: CAPEC-651
+        title: Eavesdropping
+        description: "An adversary intercepts a form of communication (e.g. text, audio, video) by way of software (e.g., microphone and audio recording application), hardware (e.g., recording equipment), or physical means (e.g., physical proximity). The goal of eavesdropping is typically to gain unauthorized access to sensitive information about the target for financial, personal, political, or other gains."
+        reference_url: "https://capec.mitre.org/data/definitions/651.html"
+      - external_id: CAPEC-664
+        title: Server Side Request Forgery
+        description: "An adversary exploits improper input validation by submitting maliciously crafted input to a target application running on a server, with the goal of forcing the server to make a request either to itself, to web services running in the server’s internal network, or to external third parties. If successful, the adversary’s request will be made with the server’s privilege level, bypassing its authentication controls."
+        reference_url: "https://capec.mitre.org/data/definitions/664.html"
+      - external_id: CAPEC-665
+        title: Exploitation of Thunderbolt Protection Flaws
+        description: "An adversary leverages a firmware weakness within the Thunderbolt protocol, on a computing device to manipulate Thunderbolt controller firmware in order to exploit vulnerabilities in the implementation of authorization and verification schemes within Thunderbolt protection mechanisms. Upon gaining physical access to a target device, the adversary conducts high-level firmware manipulation of the victim Thunderbolt controller SPI (Serial Peripheral Interface) flash, through the use of a SPI Programing device and an external Thunderbolt device, typically as the target device is booting up."
+        reference_url: "https://capec.mitre.org/data/definitions/665.html"


### PR DESCRIPTION
Refs #99

Adds a CAPEC taxonomy pack to replace mini-capec.

Source: MITRE's official CAPEC list (XML export from capec.mitre.org), including its native Related_Weaknesses and Taxonomy_Mappings fields for CWE/ATT&CK cross-references no separate relationship file needed, unlike CWE's AWS FSBP/Prowler gap.

Scope: 88 entries.
- 74 came from a natural score-tier threshold (score ≥5, weighted on CWE Top 25 overlap + ATT&CK references + cloud-relevant keywords)
- 14 manually added on top canonical patterns that theme-matched the scope (CSRF, XSS, SSRF, Credential Stuffing, Password Spraying, Pass the Hash, Adversary-in-the-Middle, Session Hijacking, Privilege Abuse, etc.) but scored just under the cutoff. Went back through the whole 3-4 score band specifically to check for other misses like these rather than trusting the threshold alone, since an earlier score≥4 cutoff would've silently dropped CSRF/XSS by ID sort order
- Excluded 56 Deprecated + 1 Obsolete entries from the source data

So the real selection rule is "score≥5 plus manually reinstated canonical patterns," not a clean automatic cutoff documented that plainly in the pack description rather than implying it was a single clean threshold.

Also worth flagging: caught a real extraction bug during review 44 of 615 CAPEC entries use a nested <p> XML structure that a plain .text extraction silently truncated. Fixed by switching to itertext(), then went back and re-verified the CWE pack didn't share the same bug (it didn't, different source format).

Verification:
- 88/88 unique external_ids, zero dupes, independently checked
- reference_urls spot-checked, including entries from the manually-added set and ones affected by the itertext() fix
- Descriptions confirmed sourced from CAPEC's native XML Description field
- Imported locally, all entries render clean, zero errors/warnings from validate_pack()

Part of the same batch as #99 see #143 (mitre-atlas) for the sibling PR, mitre-attack also up separately.