### PR TITLE
feat: add mitre-attack taxonomy pack

### DIFF
--- a/libraries/packs/taxonomies/mitre-attack/pack.yaml
+++ b/libraries/packs/taxonomies/mitre-attack/pack.yaml
@@ -1,0 +1,18 @@
+pack:
+  schema_version: 1
+  slug: mitre-attack
+  name: MITRE ATT&CK Enterprise (Cloud)
+  description: MITRE ATT&CK Enterprise v19.1 techniques relevant to cloud workloads.
+    Includes the full Cloud matrix (IaaS, SaaS, Identity Provider, Office Suite
+    platforms, no curation) plus a curated set of general Enterprise techniques
+    applicable to cloud workloads (container-native techniques, infrastructure
+    acquisition, and the Valid Accounts family). Deprecated and revoked techniques
+    excluded. See taxonomy.yaml for the full selection rule.
+  version: 1.0.0
+  pack_type: taxonomy
+  author: Precogly
+  tags:
+  - mitre-attack
+  - adversary-techniques
+  - mitre
+  - cloud

--- a/libraries/packs/taxonomies/mitre-attack/taxonomy.yaml
+++ b/libraries/packs/taxonomies/mitre-attack/taxonomy.yaml
@@ -1,0 +1,690 @@
+taxonomies:
+  - slug: mitre-attack
+    name: ATT&CK Enterprise Techniques
+    description: "MITRE ATT&CK Enterprise v19.1 (released 2026-05-12, current as of extraction -- verified against GitHub tagged releases with zero drift from the master branch). Selection rule, two tiers: (1) the full Cloud matrix -- all active techniques tagged IaaS, SaaS, Identity Provider, or Office Suite, per MITRE's own Cloud matrix definition -- 152 techniques, no curation; (2) a curated Enterprise tier of 19 additional techniques relevant to cloud workloads but not cloud-platform-tagged (container-native techniques, infrastructure acquisition, and the Valid Accounts family), selected by keyword score plus manual review for near-miss gaps. Deprecated and revoked STIX objects were excluded (161 of 858 total)."
+    source_url: "https://attack.mitre.org/"
+    entries:
+      - external_id: T1020.001
+        title: "Automated Exfiltration: Traffic Duplication"
+        description: "Adversaries may leverage traffic mirroring in order to automate data exfiltration over compromised infrastructure. Traffic mirroring is a native feature for some devices, often used for network analysis."
+        reference_url: "https://attack.mitre.org/techniques/T1020/001"
+      - external_id: T1021
+        title: Remote Services
+        description: "Adversaries may use Valid Accounts to log into a service that accepts remote connections, such as telnet, SSH, and VNC. The adversary may then perform actions as the logged-on user."
+        reference_url: "https://attack.mitre.org/techniques/T1021"
+      - external_id: T1021.007
+        title: "Remote Services: Cloud Services"
+        description: "Adversaries may log into accessible cloud services within a compromised environment using Valid Accounts that are synchronized with or federated to on-premises user identities. The adversary may then perform management actions or access cloud-hosted resources as the logged-on user."
+        reference_url: "https://attack.mitre.org/techniques/T1021/007"
+      - external_id: T1021.008
+        title: "Remote Services: Direct Cloud VM Connections"
+        description: "Adversaries may leverage Valid Accounts to log directly into accessible cloud hosted compute infrastructure through cloud native methods. Many cloud providers offer interactive connections to virtual infrastructure that can be accessed through the Cloud API, such as Azure Serial Console, AWS EC2 Instance Connect, and AWS System Manager.."
+        reference_url: "https://attack.mitre.org/techniques/T1021/008"
+      - external_id: T1036.010
+        title: "Masquerading: Masquerade Account Name"
+        description: "Adversaries may match or approximate the names of legitimate accounts to make newly created ones appear benign. This will typically occur during Create Account, although accounts may also be renamed at a later date."
+        reference_url: "https://attack.mitre.org/techniques/T1036/010"
+      - external_id: T1040
+        title: Network Sniffing
+        description: "Adversaries may passively sniff network traffic to capture information about an environment, including authentication material passed over the network. Network sniffing refers to using the network interface on a system to monitor or capture information sent over a wired or wireless connection."
+        reference_url: "https://attack.mitre.org/techniques/T1040"
+      - external_id: T1046
+        title: Network Service Discovery
+        description: "Adversaries may attempt to get a listing of services running on remote hosts and local network infrastructure devices, including those that may be vulnerable to remote software exploitation. Common methods to acquire this information include port, vulnerability, and/or wordlist scans using tools that are brought onto a system."
+        reference_url: "https://attack.mitre.org/techniques/T1046"
+      - external_id: T1048
+        title: Exfiltration Over Alternative Protocol
+        description: "Adversaries may steal data by exfiltrating it over a different protocol than that of the existing command and control channel. The data may also be sent to an alternate network location from the main command and control server."
+        reference_url: "https://attack.mitre.org/techniques/T1048"
+      - external_id: T1049
+        title: System Network Connections Discovery
+        description: "Adversaries may attempt to get a listing of network connections to or from the compromised system they are currently accessing or from remote systems by querying for information over the network. An adversary who gains access to a system that is part of a cloud-based environment may map out Virtual Private Clouds or Virtual Networks in order to determine what systems and services are connected."
+        reference_url: "https://attack.mitre.org/techniques/T1049"
+      - external_id: T1053.007
+        title: "Scheduled Task/Job: Container Orchestration Job"
+        description: "Adversaries may abuse task scheduling functionality provided by container orchestration tools such as Kubernetes to schedule deployment of containers configured to execute malicious code. Container orchestration jobs run these automated tasks at a specific date and time, similar to cron jobs on a Linux system."
+        reference_url: "https://attack.mitre.org/techniques/T1053/007"
+      - external_id: T1059
+        title: Command and Scripting Interpreter
+        description: "Adversaries may abuse command and script interpreters to execute commands, scripts, or binaries. These interfaces and languages provide ways of interacting with computer systems and are a common feature across many different platforms."
+        reference_url: "https://attack.mitre.org/techniques/T1059"
+      - external_id: T1059.009
+        title: "Command and Scripting Interpreter: Cloud API"
+        description: "Adversaries may abuse cloud APIs to execute malicious commands. APIs available in cloud environments provide various functionalities and are a feature-rich method for programmatic access to nearly all aspects of a tenant."
+        reference_url: "https://attack.mitre.org/techniques/T1059/009"
+      - external_id: T1059.013
+        title: "Command and Scripting Interpreter: Container CLI/API"
+        description: "Adversaries may abuse built-in CLI tools or API calls to execute malicious commands in containerized environments. The Docker CLI is used for managing containers via an exposed API point from the dockerd daemon."
+        reference_url: "https://attack.mitre.org/techniques/T1059/013"
+      - external_id: T1069
+        title: Permission Groups Discovery
+        description: "Adversaries may attempt to discover group and permission settings. This information can help adversaries determine which user accounts and groups are available, the membership of users in particular groups, and which users and groups have elevated permissions."
+        reference_url: "https://attack.mitre.org/techniques/T1069"
+      - external_id: T1069.003
+        title: "Permission Groups Discovery: Cloud Groups"
+        description: "Adversaries may attempt to find cloud groups and permission settings. The knowledge of cloud permission groups can help adversaries determine the particular roles of users and groups within an environment, as well as which users are associated with a particular group."
+        reference_url: "https://attack.mitre.org/techniques/T1069/003"
+      - external_id: T1070
+        title: Indicator Removal
+        description: "Adversaries may selectively delete or modify artifacts generated to reduce indications of their presence and blend in with legitimate activity. Rather than broadly removing evidence, adversaries may target specific artifacts that appear anomalous or are likely to draw scrutiny, while leaving sufficient data intact to maintain the appearance of normal system behavior."
+        reference_url: "https://attack.mitre.org/techniques/T1070"
+      - external_id: T1070.008
+        title: "Indicator Removal: Clear Mailbox Data"
+        description: "Adversaries may modify mail and mail application data to remove evidence of their activity. Email applications allow users and other programs to export and delete mailbox data via command line tools or use of APIs."
+        reference_url: "https://attack.mitre.org/techniques/T1070/008"
+      - external_id: T1072
+        title: Software Deployment Tools
+        description: "Adversaries may gain access to and use centralized software suites installed within an enterprise to execute commands and move laterally through the network. Configuration management and software deployment applications may be used in an enterprise network or cloud environment for routine administration purposes."
+        reference_url: "https://attack.mitre.org/techniques/T1072"
+      - external_id: T1074
+        title: Data Staged
+        description: "Adversaries may stage collected data in a central location or directory prior to Exfiltration. Data may be kept in separate files or combined into one file through techniques such as Archive Collected Data."
+        reference_url: "https://attack.mitre.org/techniques/T1074"
+      - external_id: T1074.002
+        title: "Data Staged: Remote Data Staging"
+        description: "Adversaries may stage data collected from multiple systems in a central location or directory on one system prior to Exfiltration. Data may be kept in separate files or combined into one file through techniques such as Archive Collected Data."
+        reference_url: "https://attack.mitre.org/techniques/T1074/002"
+      - external_id: T1078
+        title: Valid Accounts
+        description: "Adversaries may obtain and abuse credentials of existing accounts as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Compromised credentials may be used to bypass access controls placed on various resources on systems within the network and may even be used for persistent access to remote systems and externally available services, such as VPNs, Outlook Web Access, network devices, and remote desktop."
+        reference_url: "https://attack.mitre.org/techniques/T1078"
+      - external_id: T1078.001
+        title: "Valid Accounts: Default Accounts"
+        description: "Adversaries may obtain and abuse credentials of a default account as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Default accounts are those that are built-into an OS, such as the Guest or Administrator accounts on Windows systems."
+        reference_url: "https://attack.mitre.org/techniques/T1078/001"
+      - external_id: T1078.002
+        title: "Valid Accounts: Domain Accounts"
+        description: "Adversaries may obtain and abuse credentials of a domain account as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Domain accounts are those managed by Active Directory Domain Services where access and permissions are configured across systems and services that are part of that domain."
+        reference_url: "https://attack.mitre.org/techniques/T1078/002"
+      - external_id: T1078.003
+        title: "Valid Accounts: Local Accounts"
+        description: "Adversaries may obtain and abuse credentials of a local account as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Local accounts are those configured by an organization for use by users, remote support, services, or for administration on a single system or service."
+        reference_url: "https://attack.mitre.org/techniques/T1078/003"
+      - external_id: T1078.004
+        title: "Valid Accounts: Cloud Accounts"
+        description: "Valid accounts in cloud environments may allow adversaries to perform actions to achieve Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Cloud accounts are those created and configured by an organization for use by users, remote support, services, or for administration of resources within a cloud service provider or SaaS application."
+        reference_url: "https://attack.mitre.org/techniques/T1078/004"
+      - external_id: T1080
+        title: Taint Shared Content
+        description: "Adversaries may deliver payloads to remote systems by adding content to shared storage locations, such as network drives or internal code repositories. Content stored on network drives or in other shared locations may be tainted by adding malicious programs, scripts, or exploit code to otherwise valid files."
+        reference_url: "https://attack.mitre.org/techniques/T1080"
+      - external_id: T1082
+        title: System Information Discovery
+        description: "An adversary may attempt to get detailed information about the operating system and hardware, including version, patches, hotfixes, service packs, and architecture. Adversaries may use this information to shape follow-on behaviors, including whether or not the adversary fully infects the target and/or attempts specific actions."
+        reference_url: "https://attack.mitre.org/techniques/T1082"
+      - external_id: T1087
+        title: Account Discovery
+        description: "Adversaries may attempt to get a listing of valid accounts, usernames, or email addresses on a system or within a compromised environment. This information can help adversaries determine which accounts exist, which can aid in follow-on behavior such as brute-forcing, spear-phishing attacks, or account takeovers (e.g., Valid Accounts)."
+        reference_url: "https://attack.mitre.org/techniques/T1087"
+      - external_id: T1087.003
+        title: "Account Discovery: Email Account"
+        description: "Adversaries may attempt to get a listing of email addresses and accounts. Adversaries may try to dump Exchange address lists such as global address lists (GALs)."
+        reference_url: "https://attack.mitre.org/techniques/T1087/003"
+      - external_id: T1087.004
+        title: "Account Discovery: Cloud Account"
+        description: "Adversaries may attempt to get a listing of cloud accounts. Cloud accounts are those created and configured by an organization for use by users, remote support, services, or for administration of resources within a cloud service provider or SaaS application."
+        reference_url: "https://attack.mitre.org/techniques/T1087/004"
+      - external_id: T1098
+        title: Account Manipulation
+        description: "Adversaries may manipulate accounts to maintain and/or elevate access to victim systems. Account manipulation may consist of any action that preserves or modifies adversary access to a compromised account, such as modifying credentials or permission groups."
+        reference_url: "https://attack.mitre.org/techniques/T1098"
+      - external_id: T1098.001
+        title: "Account Manipulation: Additional Cloud Credentials"
+        description: "Adversaries may add adversary-controlled credentials to a cloud account to maintain persistent access to victim accounts and instances within the environment. For example, adversaries may add credentials for Service Principals and Applications in addition to existing legitimate credentials in Azure / Entra ID."
+        reference_url: "https://attack.mitre.org/techniques/T1098/001"
+      - external_id: T1098.002
+        title: "Account Manipulation: Additional Email Delegate Permissions"
+        description: "Adversaries may grant additional permission levels to maintain persistent access to an adversary-controlled email account. For example, the Add-MailboxPermission PowerShell cmdlet, available in on-premises Exchange and in the cloud-based service Office 365, adds permissions to a mailbox."
+        reference_url: "https://attack.mitre.org/techniques/T1098/002"
+      - external_id: T1098.003
+        title: "Account Manipulation: Additional Cloud Roles"
+        description: "An adversary may add additional roles or permissions to an adversary-controlled cloud account to maintain persistent access to a tenant. For example, adversaries may update IAM policies in cloud-based environments or add a new global administrator in Office 365 environments."
+        reference_url: "https://attack.mitre.org/techniques/T1098/003"
+      - external_id: T1098.004
+        title: "Account Manipulation: SSH Authorized Keys"
+        description: "Adversaries may modify the SSH authorized_keys file to maintain persistence on a victim host. Linux distributions, macOS, and ESXi hypervisors commonly use key-based authentication to secure the authentication process of SSH sessions for remote management."
+        reference_url: "https://attack.mitre.org/techniques/T1098/004"
+      - external_id: T1098.005
+        title: "Account Manipulation: Device Registration"
+        description: "Adversaries may register a device to an adversary-controlled account. Devices may be registered in a multifactor authentication (MFA) system, which handles authentication to the network, or in a device management system, which handles device access and compliance."
+        reference_url: "https://attack.mitre.org/techniques/T1098/005"
+      - external_id: T1098.006
+        title: "Account Manipulation: Additional Container Cluster Roles"
+        description: "An adversary may add additional roles or permissions to an adversary-controlled user or service account to maintain persistent access to a container orchestration system. For example, an adversary with sufficient permissions may create a RoleBinding or a ClusterRoleBinding to bind a Role or ClusterRole to a Kubernetes account."
+        reference_url: "https://attack.mitre.org/techniques/T1098/006"
+      - external_id: T1110
+        title: Brute Force
+        description: "Adversaries may use brute force techniques to gain access to accounts when passwords are unknown or when password hashes are obtained. Without knowledge of the password for an account or set of accounts, an adversary may systematically guess the password using a repetitive or iterative mechanism."
+        reference_url: "https://attack.mitre.org/techniques/T1110"
+      - external_id: T1110.001
+        title: "Brute Force: Password Guessing"
+        description: "Adversaries with no prior knowledge of legitimate credentials within the system or environment may guess passwords to attempt access to accounts. Without knowledge of the password for an account, an adversary may opt to systematically guess the password using a repetitive or iterative mechanism."
+        reference_url: "https://attack.mitre.org/techniques/T1110/001"
+      - external_id: T1110.002
+        title: "Brute Force: Password Cracking"
+        description: "Adversaries may use password cracking to attempt to recover usable credentials, such as plaintext passwords, when credential material such as password hashes are obtained. OS Credential Dumping can be used to obtain password hashes, this may only get an adversary so far when Pass the Hash is not an option."
+        reference_url: "https://attack.mitre.org/techniques/T1110/002"
+      - external_id: T1110.003
+        title: "Brute Force: Password Spraying"
+        description: "Adversaries may use a single or small list of commonly used passwords against many different accounts to attempt to acquire valid account credentials. Password spraying uses one password (e.g. 'Password01'), or a small list of commonly used passwords, that may match the complexity policy of the domain."
+        reference_url: "https://attack.mitre.org/techniques/T1110/003"
+      - external_id: T1110.004
+        title: "Brute Force: Credential Stuffing"
+        description: "Adversaries may use credentials obtained from breach dumps of unrelated accounts to gain access to target accounts through credential overlap. Occasionally, large numbers of username and password pairs are dumped online when a website or service is compromised and the user account credentials accessed."
+        reference_url: "https://attack.mitre.org/techniques/T1110/004"
+      - external_id: T1114
+        title: Email Collection
+        description: "Adversaries may target user email to collect sensitive information. Emails may contain sensitive data, including trade secrets or personal information, that can prove valuable to adversaries."
+        reference_url: "https://attack.mitre.org/techniques/T1114"
+      - external_id: T1114.002
+        title: "Email Collection: Remote Email Collection"
+        description: "Adversaries may target an Exchange server, Office 365, or Google Workspace to collect sensitive information. Adversaries may leverage a user's credentials and interact directly with the Exchange server to acquire information from within a network."
+        reference_url: "https://attack.mitre.org/techniques/T1114/002"
+      - external_id: T1114.003
+        title: "Email Collection: Email Forwarding Rule"
+        description: "Adversaries may setup email forwarding rules to collect sensitive information. Adversaries may abuse email forwarding rules to monitor the activities of a victim, steal information, and further gain intelligence on the victim or the victim’s organization to use as part of further exploits or operations."
+        reference_url: "https://attack.mitre.org/techniques/T1114/003"
+      - external_id: T1119
+        title: Automated Collection
+        description: "Once established within a system or network, an adversary may use automated techniques for collecting internal data. Methods for performing this technique could include use of a Command and Scripting Interpreter to search for and copy information fitting set criteria such as file type, location, or name at specific time intervals."
+        reference_url: "https://attack.mitre.org/techniques/T1119"
+      - external_id: T1136
+        title: Create Account
+        description: "Adversaries may create an account to maintain access to victim systems. With a sufficient level of access, creating such accounts may be used to establish secondary credentialed access that do not require persistent remote access tools to be deployed on the system."
+        reference_url: "https://attack.mitre.org/techniques/T1136"
+      - external_id: T1136.003
+        title: "Create Account: Cloud Account"
+        description: "Adversaries may create a cloud account to maintain access to victim systems. With a sufficient level of access, such accounts may be used to establish secondary credentialed access that does not require persistent remote access tools to be deployed on the system."
+        reference_url: "https://attack.mitre.org/techniques/T1136/003"
+      - external_id: T1137
+        title: Office Application Startup
+        description: "Adversaries may leverage Microsoft Office-based applications for persistence between startups. Microsoft Office is a fairly common application suite on Windows-based operating systems within an enterprise network."
+        reference_url: "https://attack.mitre.org/techniques/T1137"
+      - external_id: T1137.001
+        title: "Office Application Startup: Office Template Macros"
+        description: "Adversaries may abuse Microsoft Office templates to obtain persistence on a compromised system. Microsoft Office contains templates that are part of common Office applications and are used to customize styles."
+        reference_url: "https://attack.mitre.org/techniques/T1137/001"
+      - external_id: T1137.002
+        title: "Office Application Startup: Office Test"
+        description: "Adversaries may abuse the Microsoft Office \"Office Test\" Registry key to obtain persistence on a compromised system. An Office Test Registry location exists that allows a user to specify an arbitrary DLL that will be executed every time an Office application is started."
+        reference_url: "https://attack.mitre.org/techniques/T1137/002"
+      - external_id: T1137.003
+        title: "Office Application Startup: Outlook Forms"
+        description: "Adversaries may abuse Microsoft Outlook forms to obtain persistence on a compromised system. Outlook forms are used as templates for presentation and functionality in Outlook messages."
+        reference_url: "https://attack.mitre.org/techniques/T1137/003"
+      - external_id: T1137.004
+        title: "Office Application Startup: Outlook Home Page"
+        description: "Adversaries may abuse Microsoft Outlook's Home Page feature to obtain persistence on a compromised system. Outlook Home Page is a legacy feature used to customize the presentation of Outlook folders."
+        reference_url: "https://attack.mitre.org/techniques/T1137/004"
+      - external_id: T1137.005
+        title: "Office Application Startup: Outlook Rules"
+        description: "Adversaries may abuse Microsoft Outlook rules to obtain persistence on a compromised system. Outlook rules allow a user to define automated behavior to manage email messages."
+        reference_url: "https://attack.mitre.org/techniques/T1137/005"
+      - external_id: T1137.006
+        title: "Office Application Startup: Add-ins"
+        description: "Adversaries may abuse Microsoft Office add-ins to obtain persistence on a compromised system. Office add-ins can be used to add functionality to Office programs."
+        reference_url: "https://attack.mitre.org/techniques/T1137/006"
+      - external_id: T1189
+        title: Drive-by Compromise
+        description: "Adversaries may gain access to a system through a user visiting a website over the normal course of browsing."
+        reference_url: "https://attack.mitre.org/techniques/T1189"
+      - external_id: T1190
+        title: Exploit Public-Facing Application
+        description: "Adversaries may attempt to exploit a weakness in an Internet-facing host or system to initially access a network. The weakness in the system can be a software bug, a temporary glitch, or a misconfiguration."
+        reference_url: "https://attack.mitre.org/techniques/T1190"
+      - external_id: T1195
+        title: Supply Chain Compromise
+        description: "Adversaries may manipulate products or product delivery mechanisms prior to receipt by a final consumer for the purpose of data or system compromise."
+        reference_url: "https://attack.mitre.org/techniques/T1195"
+      - external_id: T1199
+        title: Trusted Relationship
+        description: "Adversaries may breach or otherwise leverage organizations who have access to intended victims. Access through trusted third party relationship abuses an existing connection that may not be protected or receives less scrutiny than standard mechanisms of gaining access to a network."
+        reference_url: "https://attack.mitre.org/techniques/T1199"
+      - external_id: T1201
+        title: Password Policy Discovery
+        description: "Adversaries may attempt to access detailed information about the password policy used within an enterprise network or cloud environment. Password policies are a way to enforce complex passwords that are difficult to guess or crack through Brute Force."
+        reference_url: "https://attack.mitre.org/techniques/T1201"
+      - external_id: T1204
+        title: User Execution
+        description: "An adversary may rely upon specific actions by a user in order to gain execution. Users may be subjected to social engineering to get them to execute malicious code by, for example, opening a malicious document file or link."
+        reference_url: "https://attack.mitre.org/techniques/T1204"
+      - external_id: T1204.003
+        title: "User Execution: Malicious Image"
+        description: "Adversaries may rely on a user running a malicious image to facilitate execution. Amazon Web Services (AWS) Amazon Machine Images (AMIs), Google Cloud Platform (GCP) Images, and Azure Images as well as popular container runtimes such as Docker can be backdoored."
+        reference_url: "https://attack.mitre.org/techniques/T1204/003"
+      - external_id: T1211
+        title: Exploitation for Stealth
+        description: "Adversaries may exploit vulnerabilities to evade detection by hiding activity, suppressing logging, or operating within trusted or unmonitored components. Adversaries may exploit a system or application vulnerability to avoid detection while maintaining access within an environment."
+        reference_url: "https://attack.mitre.org/techniques/T1211"
+      - external_id: T1212
+        title: Exploitation for Credential Access
+        description: "Adversaries may exploit software vulnerabilities in an attempt to collect credentials. Exploitation of a software vulnerability occurs when an adversary takes advantage of a programming error in a program, service, or within the operating system software or kernel itself to execute adversary-controlled code."
+        reference_url: "https://attack.mitre.org/techniques/T1212"
+      - external_id: T1213
+        title: Data from Information Repositories
+        description: "Adversaries may leverage information repositories to mine valuable information. Information repositories are tools that allow for storage of information, typically to facilitate collaboration or information sharing between users, and can store a wide variety of data that may aid adversaries in further objectives, such as Credential Access, Lateral Movement, or Defense Evasion, or direct access to the target information."
+        reference_url: "https://attack.mitre.org/techniques/T1213"
+      - external_id: T1213.001
+        title: "Data from Information Repositories: Confluence"
+        description: "Adversaries may leverage Confluence repositories to mine valuable information."
+        reference_url: "https://attack.mitre.org/techniques/T1213/001"
+      - external_id: T1213.002
+        title: "Data from Information Repositories: Sharepoint"
+        description: "Adversaries may leverage the SharePoint repository as a source to mine valuable information. SharePoint will often contain useful information for an adversary to learn about the structure and functionality of the internal network and systems."
+        reference_url: "https://attack.mitre.org/techniques/T1213/002"
+      - external_id: T1213.003
+        title: "Data from Information Repositories: Code Repositories"
+        description: "Adversaries may leverage code repositories to collect valuable information. Code repositories are tools/services that store source code and automate software builds."
+        reference_url: "https://attack.mitre.org/techniques/T1213/003"
+      - external_id: T1213.004
+        title: "Data from Information Repositories: Customer Relationship Management Software"
+        description: "Adversaries may leverage Customer Relationship Management (CRM) software to mine valuable information. CRM software is used to assist organizations in tracking and managing customer interactions, as well as storing customer data."
+        reference_url: "https://attack.mitre.org/techniques/T1213/004"
+      - external_id: T1213.005
+        title: "Data from Information Repositories: Messaging Applications"
+        description: "Adversaries may leverage chat and messaging applications, such as Microsoft Teams, Google Chat, and Slack, to mine valuable information."
+        reference_url: "https://attack.mitre.org/techniques/T1213/005"
+      - external_id: T1213.006
+        title: "Data from Information Repositories: Databases"
+        description: "Adversaries may leverage databases to mine valuable information. These databases may be hosted on-premises or in the cloud (both in platform-as-a-service and software-as-a-service environments)."
+        reference_url: "https://attack.mitre.org/techniques/T1213/006"
+      - external_id: T1484
+        title: Domain or Tenant Policy Modification
+        description: "Adversaries may modify the configuration settings of a domain or identity tenant to evade defenses and/or escalate privileges in centrally managed environments. Such services provide a centralized means of managing identity resources such as devices and accounts, and often include configuration settings that may apply between domains or tenants such as trust relationships, identity syncing, or identity federation."
+        reference_url: "https://attack.mitre.org/techniques/T1484"
+      - external_id: T1484.002
+        title: "Domain or Tenant Policy Modification: Trust Modification"
+        description: "Adversaries may add new domain trusts, modify the properties of existing domain trusts, or otherwise change the configuration of trust relationships between domains and tenants to evade defenses and/or elevate privileges.Trust details, such as whether or not user identities are federated, allow authentication and authorization properties to apply between domains or tenants for the purpose of accessing shared resources. These trust objects may include accounts, credentials, and other authentication material applied to servers, tokens, and domains."
+        reference_url: "https://attack.mitre.org/techniques/T1484/002"
+      - external_id: T1485
+        title: Data Destruction
+        description: "Adversaries may destroy data and files on specific systems or in large numbers on a network to interrupt availability to systems, services, and network resources. Data destruction is likely to render stored data irrecoverable by forensic techniques through overwriting files or data on local and remote drives."
+        reference_url: "https://attack.mitre.org/techniques/T1485"
+      - external_id: T1485.001
+        title: "Data Destruction: Lifecycle-Triggered Deletion"
+        description: "Adversaries may modify the lifecycle policies of a cloud storage bucket to destroy all objects stored within. Cloud storage buckets often allow users to set lifecycle policies to automate the migration, archival, or deletion of objects after a set period of time."
+        reference_url: "https://attack.mitre.org/techniques/T1485/001"
+      - external_id: T1486
+        title: Data Encrypted for Impact
+        description: "Adversaries may encrypt data on target systems or on large numbers of systems in a network to interrupt availability to system and network resources. They can attempt to render stored data inaccessible by encrypting files or data on local and remote drives and withholding access to a decryption key."
+        reference_url: "https://attack.mitre.org/techniques/T1486"
+      - external_id: T1489
+        title: Service Stop
+        description: "Adversaries may stop or disable services on a system to render those services unavailable to legitimate users. Stopping critical services or processes can inhibit or stop response to an incident or aid in the adversary's overall objectives to cause damage to the environment."
+        reference_url: "https://attack.mitre.org/techniques/T1489"
+      - external_id: T1490
+        title: Inhibit System Recovery
+        description: "Adversaries may delete or remove built-in data and turn off services designed to aid in the recovery of a corrupted system to prevent recovery. This may deny access to available backups and recovery options."
+        reference_url: "https://attack.mitre.org/techniques/T1490"
+      - external_id: T1491
+        title: Defacement
+        description: "Adversaries may modify visual content available internally or externally to an enterprise network, thus affecting the integrity of the original content. Reasons for Defacement include delivering messaging, intimidation, or claiming (possibly false) credit for an intrusion."
+        reference_url: "https://attack.mitre.org/techniques/T1491"
+      - external_id: T1491.002
+        title: "Defacement: External Defacement"
+        description: "An adversary may deface systems external to an organization in an attempt to deliver messaging, intimidate, or otherwise mislead an organization or users. External Defacement may ultimately cause users to distrust the systems and to question/discredit the system’s integrity."
+        reference_url: "https://attack.mitre.org/techniques/T1491/002"
+      - external_id: T1496
+        title: Resource Hijacking
+        description: "Adversaries may leverage the resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability. Resource hijacking may take a number of different forms."
+        reference_url: "https://attack.mitre.org/techniques/T1496"
+      - external_id: T1496.001
+        title: "Resource Hijacking: Compute Hijacking"
+        description: "Adversaries may leverage the compute resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability. One common purpose for Compute Hijacking is to validate transactions of cryptocurrency networks and earn virtual currency."
+        reference_url: "https://attack.mitre.org/techniques/T1496/001"
+      - external_id: T1496.002
+        title: "Resource Hijacking: Bandwidth Hijacking"
+        description: "Adversaries may leverage the network bandwidth resources of co-opted systems to complete resource-intensive tasks, which may impact system and/or hosted service availability. Adversaries may also use malware that leverages a system's network bandwidth as part of a botnet in order to facilitate Network Denial of Service campaigns and/or to seed malicious torrents."
+        reference_url: "https://attack.mitre.org/techniques/T1496/002"
+      - external_id: T1496.003
+        title: "Resource Hijacking: SMS Pumping"
+        description: "Adversaries may leverage messaging services for SMS pumping, which may impact system and/or hosted service availability. SMS pumping is a type of telecommunications fraud whereby a threat actor first obtains a set of phone numbers from a telecommunications provider, then leverages a victim’s messaging infrastructure to send large amounts of SMS messages to numbers in that set."
+        reference_url: "https://attack.mitre.org/techniques/T1496/003"
+      - external_id: T1496.004
+        title: "Resource Hijacking: Cloud Service Hijacking"
+        description: "Adversaries may leverage compromised software-as-a-service (SaaS) applications to complete resource-intensive tasks, which may impact hosted service availability. For example, adversaries may leverage email and messaging services, such as AWS Simple Email Service (SES), AWS Simple Notification Service (SNS), SendGrid, and Twilio, in order to send large quantities of spam / Phishing emails and SMS messages."
+        reference_url: "https://attack.mitre.org/techniques/T1496/004"
+      - external_id: T1498
+        title: Network Denial of Service
+        description: "Adversaries may perform Network Denial of Service (DoS) attacks to degrade or block the availability of targeted resources to users. Network DoS can be performed by exhausting the network bandwidth services rely on."
+        reference_url: "https://attack.mitre.org/techniques/T1498"
+      - external_id: T1498.001
+        title: "Network Denial of Service: Direct Network Flood"
+        description: "Adversaries may attempt to cause a denial of service (DoS) by directly sending a high-volume of network traffic to a target. This DoS attack may also reduce the availability and functionality of the targeted system(s) and network."
+        reference_url: "https://attack.mitre.org/techniques/T1498/001"
+      - external_id: T1498.002
+        title: "Network Denial of Service: Reflection Amplification"
+        description: "Adversaries may attempt to cause a denial of service (DoS) by reflecting a high-volume of network traffic to a target. This type of Network DoS takes advantage of a third-party server intermediary that hosts and will respond to a given spoofed source IP address."
+        reference_url: "https://attack.mitre.org/techniques/T1498/002"
+      - external_id: T1499
+        title: Endpoint Denial of Service
+        description: "Adversaries may perform Endpoint Denial of Service (DoS) attacks to degrade or block the availability of services to users. Endpoint DoS can be performed by exhausting the system resources those services are hosted on or exploiting the system to cause a persistent crash condition."
+        reference_url: "https://attack.mitre.org/techniques/T1499"
+      - external_id: T1499.002
+        title: "Endpoint Denial of Service: Service Exhaustion Flood"
+        description: "Adversaries may target the different network services provided by systems to conduct a denial of service (DoS). Adversaries often target the availability of DNS and web services, however others have been targeted as well."
+        reference_url: "https://attack.mitre.org/techniques/T1499/002"
+      - external_id: T1499.003
+        title: "Endpoint Denial of Service: Application Exhaustion Flood"
+        description: "Adversaries may target resource intensive features of applications to cause a denial of service (DoS), denying availability to those applications. For example, specific features in web applications may be highly resource intensive."
+        reference_url: "https://attack.mitre.org/techniques/T1499/003"
+      - external_id: T1499.004
+        title: "Endpoint Denial of Service: Application or System Exploitation"
+        description: "Adversaries may exploit software vulnerabilities that can cause an application or system to crash and deny availability to users. Some systems may automatically restart critical applications and services when crashes occur, but they can likely be re-exploited to cause a persistent denial of service (DoS) condition."
+        reference_url: "https://attack.mitre.org/techniques/T1499/004"
+      - external_id: T1518
+        title: Software Discovery
+        description: "Adversaries may attempt to get a listing of software and software versions that are installed on a system or in a cloud environment. Adversaries may use the information from Software Discovery during automated discovery to shape follow-on behaviors, including whether or not the adversary fully infects the target and/or attempts specific actions."
+        reference_url: "https://attack.mitre.org/techniques/T1518"
+      - external_id: T1518.001
+        title: "Software Discovery: Security Software Discovery"
+        description: "Adversaries may attempt to get a listing of security software, configurations, defensive tools, and sensors that are installed on a system or in a cloud environment. This may include things such as cloud monitoring agents and anti-virus."
+        reference_url: "https://attack.mitre.org/techniques/T1518/001"
+      - external_id: T1525
+        title: Implant Internal Image
+        description: "Adversaries may implant cloud or container images with malicious code to establish persistence after gaining access to an environment. Amazon Web Services (AWS) Amazon Machine Images (AMIs), Google Cloud Platform (GCP) Images, and Azure Images as well as popular container runtimes such as Docker can be implanted or backdoored."
+        reference_url: "https://attack.mitre.org/techniques/T1525"
+      - external_id: T1526
+        title: Cloud Service Discovery
+        description: "An adversary may attempt to enumerate the cloud services running on a system after gaining access. These methods can differ from platform-as-a-service (PaaS), to infrastructure-as-a-service (IaaS), or software-as-a-service (SaaS)."
+        reference_url: "https://attack.mitre.org/techniques/T1526"
+      - external_id: T1528
+        title: Steal Application Access Token
+        description: "Adversaries can steal application access tokens as a means of acquiring credentials to access remote systems and resources. Application access tokens are used to make authorized API requests on behalf of a user or service and are commonly used as a way to access resources in cloud and container-based applications and software-as-a-service (SaaS)."
+        reference_url: "https://attack.mitre.org/techniques/T1528"
+      - external_id: T1530
+        title: Data from Cloud Storage
+        description: "Adversaries may access data from cloud storage. Many IaaS providers offer solutions for online data object storage such as Amazon S3, Azure Storage, and Google Cloud Storage."
+        reference_url: "https://attack.mitre.org/techniques/T1530"
+      - external_id: T1531
+        title: Account Access Removal
+        description: "Adversaries may interrupt availability of system and network resources by inhibiting access to accounts utilized by legitimate users. Accounts may be deleted, locked, or manipulated (ex: changed credentials, revoked permissions for SaaS platforms such as Sharepoint) to remove access to accounts."
+        reference_url: "https://attack.mitre.org/techniques/T1531"
+      - external_id: T1534
+        title: Internal Spearphishing
+        description: "After they already have access to accounts or systems within the environment, adversaries may use internal spearphishing to gain access to additional information or compromise other users within the same organization. Internal spearphishing is multi-staged campaign where a legitimate account is initially compromised either by controlling the user's device or by compromising the account credentials of the user."
+        reference_url: "https://attack.mitre.org/techniques/T1534"
+      - external_id: T1535
+        title: Unused/Unsupported Cloud Regions
+        description: "Adversaries may create cloud instances in unused geographic service regions in order to evade detection. Access is usually obtained through compromising accounts used to manage cloud infrastructure."
+        reference_url: "https://attack.mitre.org/techniques/T1535"
+      - external_id: T1537
+        title: Transfer Data to Cloud Account
+        description: "Adversaries may exfiltrate data by transferring the data, including through sharing/syncing and creating backups of cloud environments, to another cloud account they control on the same service. A defender who is monitoring for large transfers to outside the cloud environment through normal file transfers or over command and control channels may not be watching for data transfers to another account within the same cloud provider."
+        reference_url: "https://attack.mitre.org/techniques/T1537"
+      - external_id: T1538
+        title: Cloud Service Dashboard
+        description: "An adversary may use a cloud service dashboard GUI with stolen credentials to gain useful information from an operational cloud environment, such as specific services, resources, and features. For example, the GCP Command Center can be used to view all assets, review findings of potential security risks, and run additional queries, such as finding public IP addresses and open ports."
+        reference_url: "https://attack.mitre.org/techniques/T1538"
+      - external_id: T1539
+        title: Steal Web Session Cookie
+        description: "An adversary may steal web application or service session cookies and use them to gain access to web applications or Internet services as an authenticated user without needing credentials. Web applications and services often use session cookies as an authentication token after a user has authenticated to a website."
+        reference_url: "https://attack.mitre.org/techniques/T1539"
+      - external_id: T1543.005
+        title: "Create or Modify System Process: Container Service"
+        description: "Adversaries may create or modify container or container cluster management tools that run as daemons, agents, or services on individual hosts. These include software for creating and managing individual containers, such as Docker and Podman, as well as container cluster node-level agents such as kubelet."
+        reference_url: "https://attack.mitre.org/techniques/T1543/005"
+      - external_id: T1546
+        title: Event Triggered Execution
+        description: "Adversaries may establish persistence and/or elevate privileges using system mechanisms that trigger execution based on specific events. Various operating systems have means to monitor and subscribe to events such as logons or other user activity such as running specific applications/binaries."
+        reference_url: "https://attack.mitre.org/techniques/T1546"
+      - external_id: T1548
+        title: Abuse Elevation Control Mechanism
+        description: "Adversaries may circumvent mechanisms designed to control privilege elevation to gain higher-level permissions. Most modern systems contain native elevation control mechanisms that are intended to limit privileges that a user can perform on a machine."
+        reference_url: "https://attack.mitre.org/techniques/T1548"
+      - external_id: T1548.005
+        title: "Abuse Elevation Control Mechanism: Temporary Elevated Cloud Access"
+        description: "Adversaries may abuse permission configurations that allow them to gain temporarily elevated access to cloud resources. Many cloud environments allow administrators to grant user or service accounts permission to request just-in-time access to roles, impersonate other accounts, pass roles onto resources and services, or otherwise gain short-term access to a set of privileges that may be distinct from their own."
+        reference_url: "https://attack.mitre.org/techniques/T1548/005"
+      - external_id: T1550
+        title: Use Alternate Authentication Material
+        description: "Adversaries may use alternate authentication material, such as password hashes, Kerberos tickets, and application access tokens, in order to move laterally within an environment and bypass normal system access controls. Authentication processes generally require a valid identity (e.g., username) along with one or more authentication factors (e.g., password, pin, physical smart card, token generator, etc.)."
+        reference_url: "https://attack.mitre.org/techniques/T1550"
+      - external_id: T1550.001
+        title: "Use Alternate Authentication Material: Application Access Token"
+        description: "Adversaries may use stolen application access tokens to bypass the typical authentication process and access restricted accounts, information, or services on remote systems. These tokens are typically stolen from users or services and used in lieu of login credentials."
+        reference_url: "https://attack.mitre.org/techniques/T1550/001"
+      - external_id: T1550.004
+        title: "Use Alternate Authentication Material: Web Session Cookie"
+        description: "Adversaries can use stolen session cookies to authenticate to web applications and services. This technique bypasses some multi-factor authentication protocols since the session is already authenticated."
+        reference_url: "https://attack.mitre.org/techniques/T1550/004"
+      - external_id: T1552
+        title: Unsecured Credentials
+        description: "Adversaries may search compromised systems to find and obtain insecurely stored credentials. These credentials can be stored and/or misplaced in many locations on a system, including plaintext files (e.g. Shell History), operating system or application-specific repositories (e.g. Credentials in Registry), or other specialized files/artifacts (e.g. Private Keys)."
+        reference_url: "https://attack.mitre.org/techniques/T1552"
+      - external_id: T1552.001
+        title: "Unsecured Credentials: Credentials In Files"
+        description: "Adversaries may search local file systems and remote file shares for files containing insecurely stored credentials. These can be files created by users to store their own credentials, shared credential stores for a group of individuals, configuration files containing passwords for a system or service, or source code/binary files containing embedded passwords."
+        reference_url: "https://attack.mitre.org/techniques/T1552/001"
+      - external_id: T1552.005
+        title: "Unsecured Credentials: Cloud Instance Metadata API"
+        description: "Adversaries may attempt to access the Cloud Instance Metadata API to collect credentials and other sensitive data. Most cloud service providers support a Cloud Instance Metadata API which is a service provided to running virtual instances that allows applications to access information about the running virtual instance."
+        reference_url: "https://attack.mitre.org/techniques/T1552/005"
+      - external_id: T1552.007
+        title: "Unsecured Credentials: Container API"
+        description: "Adversaries may gather credentials via APIs within a containers environment. APIs in these environments, such as the Docker API and Kubernetes APIs, allow a user to remotely manage their container resources and cluster components."
+        reference_url: "https://attack.mitre.org/techniques/T1552/007"
+      - external_id: T1552.008
+        title: "Unsecured Credentials: Chat Messages"
+        description: "Adversaries may directly collect unsecured credentials stored or passed through user communication services. Credentials may be sent and stored in user chat communication applications such as email, chat services like Slack or Teams, collaboration tools like Jira or Trello, and any other services that support user communication."
+        reference_url: "https://attack.mitre.org/techniques/T1552/008"
+      - external_id: T1555
+        title: Credentials from Password Stores
+        description: "Adversaries may search for common password storage locations to obtain user credentials. Passwords are stored in several places on a system, depending on the operating system or application holding the credentials."
+        reference_url: "https://attack.mitre.org/techniques/T1555"
+      - external_id: T1555.006
+        title: "Credentials from Password Stores: Cloud Secrets Management Stores"
+        description: "Adversaries may acquire credentials from cloud-native secret management solutions such as AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, and Terraform Vault. Secrets managers support the secure centralized management of passwords, API keys, and other credential material."
+        reference_url: "https://attack.mitre.org/techniques/T1555/006"
+      - external_id: T1556
+        title: Modify Authentication Process
+        description: "Adversaries may modify authentication mechanisms and processes to access user credentials or enable otherwise unwarranted access to accounts. The authentication process is handled by mechanisms, such as the Local Security Authentication Server (LSASS) process and the Security Accounts Manager (SAM) on Windows, pluggable authentication modules (PAM) on Unix-based systems, and authorization plugins on MacOS systems, responsible for gathering, storing, and validating credentials."
+        reference_url: "https://attack.mitre.org/techniques/T1556"
+      - external_id: T1556.006
+        title: "Modify Authentication Process: Multi-Factor Authentication"
+        description: "Adversaries may disable or modify multi-factor authentication (MFA) mechanisms to enable persistent access to compromised accounts. Once adversaries have gained access to a network by either compromising an account lacking MFA or by employing an MFA bypass method such as Multi-Factor Authentication Request Generation, adversaries may leverage their access to modify or completely disable MFA defenses."
+        reference_url: "https://attack.mitre.org/techniques/T1556/006"
+      - external_id: T1556.007
+        title: "Modify Authentication Process: Hybrid Identity"
+        description: "Adversaries may patch, modify, or otherwise backdoor cloud authentication processes that are tied to on-premises user identities in order to bypass typical authentication mechanisms, access credentials, and enable persistent access to accounts. Many organizations maintain hybrid user and device identities that are shared between on-premises and cloud-based environments."
+        reference_url: "https://attack.mitre.org/techniques/T1556/007"
+      - external_id: T1556.009
+        title: "Modify Authentication Process: Conditional Access Policies"
+        description: "Adversaries may disable or modify conditional access policies to enable persistent access to compromised accounts. Conditional access policies are additional verifications used by identity providers and identity and access management systems to determine whether a user should be granted access to a resource."
+        reference_url: "https://attack.mitre.org/techniques/T1556/009"
+      - external_id: T1564
+        title: Hide Artifacts
+        description: "Adversaries may attempt to hide artifacts associated with their behaviors to evade detection. Operating systems may have features to hide various artifacts, such as important system files and administrative task execution, to avoid disrupting user work environments and prevent users from changing files or features on the system."
+        reference_url: "https://attack.mitre.org/techniques/T1564"
+      - external_id: T1564.008
+        title: "Hide Artifacts: Email Hiding Rules"
+        description: "Adversaries may use email rules to hide inbound emails in a compromised user's mailbox. Many email clients allow users to create inbox rules for various email functions, including moving emails to other folders, marking emails as read, or deleting emails."
+        reference_url: "https://attack.mitre.org/techniques/T1564/008"
+      - external_id: T1566
+        title: Phishing
+        description: "Adversaries may send phishing messages to gain access to victim systems. All forms of phishing are electronically delivered social engineering."
+        reference_url: "https://attack.mitre.org/techniques/T1566"
+      - external_id: T1566.002
+        title: "Phishing: Spearphishing Link"
+        description: "Adversaries may send spearphishing emails with a malicious link in an attempt to gain access to victim systems. Spearphishing with a link is a specific variant of spearphishing."
+        reference_url: "https://attack.mitre.org/techniques/T1566/002"
+      - external_id: T1566.004
+        title: "Phishing: Spearphishing Voice"
+        description: "Adversaries may use voice communications to ultimately gain access to victim systems. Spearphishing voice is a specific variant of spearphishing."
+        reference_url: "https://attack.mitre.org/techniques/T1566/004"
+      - external_id: T1567
+        title: Exfiltration Over Web Service
+        description: "Adversaries may use an existing, legitimate external Web service to exfiltrate data rather than their primary command and control channel. Popular Web services acting as an exfiltration mechanism may give a significant amount of cover due to the likelihood that hosts within a network are already communicating with them prior to compromise."
+        reference_url: "https://attack.mitre.org/techniques/T1567"
+      - external_id: T1567.002
+        title: "Exfiltration Over Web Service: Exfiltration to Cloud Storage"
+        description: "Adversaries may exfiltrate data to a cloud storage service rather than over their primary command and control channel. Cloud storage services allow for the storage, edit, and retrieval of data from a remote cloud storage server over the Internet."
+        reference_url: "https://attack.mitre.org/techniques/T1567/002"
+      - external_id: T1567.004
+        title: "Exfiltration Over Web Service: Exfiltration Over Webhook"
+        description: "Adversaries may exfiltrate data to a webhook endpoint rather than over their primary command and control channel. Webhooks are simple mechanisms for allowing a server to push data over HTTP/S to a client without the need for the client to continuously poll the server."
+        reference_url: "https://attack.mitre.org/techniques/T1567/004"
+      - external_id: T1578
+        title: Modify Cloud Compute Infrastructure
+        description: "An adversary may attempt to modify a cloud account's compute service infrastructure to evade defenses. A modification to the compute service infrastructure can include the creation, deletion, or modification of one or more components such as compute instances, virtual machines, and snapshots."
+        reference_url: "https://attack.mitre.org/techniques/T1578"
+      - external_id: T1578.001
+        title: "Modify Cloud Compute Infrastructure: Create Snapshot"
+        description: "An adversary may create a snapshot or data backup within a cloud account to evade defenses. A snapshot is a point-in-time copy of an existing cloud compute component such as a virtual machine (VM), virtual hard drive, or volume."
+        reference_url: "https://attack.mitre.org/techniques/T1578/001"
+      - external_id: T1578.002
+        title: "Modify Cloud Compute Infrastructure: Create Cloud Instance"
+        description: "An adversary may create a new instance or virtual machine (VM) within the compute service of a cloud account to evade defenses. Creating a new instance may allow an adversary to bypass firewall rules and permissions that exist on instances currently residing within an account."
+        reference_url: "https://attack.mitre.org/techniques/T1578/002"
+      - external_id: T1578.003
+        title: "Modify Cloud Compute Infrastructure: Delete Cloud Instance"
+        description: "An adversary may delete a cloud instance after they have performed malicious activities in an attempt to evade detection and remove evidence of their presence. Deleting an instance or virtual machine can remove valuable forensic artifacts and other evidence of suspicious behavior if the instance is not recoverable."
+        reference_url: "https://attack.mitre.org/techniques/T1578/003"
+      - external_id: T1578.004
+        title: "Modify Cloud Compute Infrastructure: Revert Cloud Instance"
+        description: "An adversary may revert changes made to a cloud instance after they have performed malicious activities in attempt to evade detection and remove evidence of their presence. In highly virtualized environments, such as cloud-based infrastructure, this may be accomplished by restoring virtual machine (VM) or data storage snapshots through the cloud management dashboard or cloud APIs."
+        reference_url: "https://attack.mitre.org/techniques/T1578/004"
+      - external_id: T1578.005
+        title: "Modify Cloud Compute Infrastructure: Modify Cloud Compute Configurations"
+        description: "Adversaries may modify settings that directly affect the size, locations, and resources available to cloud compute infrastructure in order to evade defenses. These settings may include service quotas, subscription associations, tenant-wide policies, or other configurations that impact available compute."
+        reference_url: "https://attack.mitre.org/techniques/T1578/005"
+      - external_id: T1580
+        title: Cloud Infrastructure Discovery
+        description: "An adversary may attempt to discover infrastructure and resources that are available within an infrastructure-as-a-service (IaaS) environment. This includes compute service resources such as instances, virtual machines, and snapshots as well as resources of other services including the storage and database services."
+        reference_url: "https://attack.mitre.org/techniques/T1580"
+      - external_id: T1583.003
+        title: "Acquire Infrastructure: Virtual Private Server"
+        description: "Adversaries may rent Virtual Private Servers (VPSs) that can be used during targeting. There exist a variety of cloud service providers that will sell virtual machines/containers as a service."
+        reference_url: "https://attack.mitre.org/techniques/T1583/003"
+      - external_id: T1583.007
+        title: "Acquire Infrastructure: Serverless"
+        description: "Adversaries may purchase and configure serverless cloud infrastructure, such as Cloudflare Workers, AWS Lambda functions, or Google Apps Scripts, that can be used during targeting. By utilizing serverless infrastructure, adversaries can make it more difficult to attribute infrastructure used during operations back to them."
+        reference_url: "https://attack.mitre.org/techniques/T1583/007"
+      - external_id: T1584.003
+        title: "Compromise Infrastructure: Virtual Private Server"
+        description: "Adversaries may compromise third-party Virtual Private Servers (VPSs) that can be used during targeting. There exist a variety of cloud service providers that will sell virtual machines/containers as a service."
+        reference_url: "https://attack.mitre.org/techniques/T1584/003"
+      - external_id: T1584.007
+        title: "Compromise Infrastructure: Serverless"
+        description: "Adversaries may compromise serverless cloud infrastructure, such as Cloudflare Workers, AWS Lambda functions, or Google Apps Scripts, that can be used during targeting. By utilizing serverless infrastructure, adversaries can make it more difficult to attribute infrastructure used during operations back to them."
+        reference_url: "https://attack.mitre.org/techniques/T1584/007"
+      - external_id: T1585.003
+        title: "Establish Accounts: Cloud Accounts"
+        description: "Adversaries may create accounts with cloud providers that can be used during targeting. Adversaries can use cloud accounts to further their operations, including leveraging cloud storage services such as Dropbox, MEGA, Microsoft OneDrive, or AWS S3 buckets for Exfiltration to Cloud Storage or to Upload Tools."
+        reference_url: "https://attack.mitre.org/techniques/T1585/003"
+      - external_id: T1586.003
+        title: "Compromise Accounts: Cloud Accounts"
+        description: "Adversaries may compromise cloud accounts that can be used during targeting. Adversaries can use compromised cloud accounts to further their operations, including leveraging cloud storage services such as Dropbox, Microsoft OneDrive, or AWS S3 buckets for Exfiltration to Cloud Storage or to Upload Tools."
+        reference_url: "https://attack.mitre.org/techniques/T1586/003"
+      - external_id: T1606
+        title: Forge Web Credentials
+        description: "Adversaries may forge credential materials that can be used to gain access to web applications or Internet services. Web applications and services (hosted in cloud SaaS environments or on-premise servers) often use session cookies, tokens, or other materials to authenticate and authorize user access."
+        reference_url: "https://attack.mitre.org/techniques/T1606"
+      - external_id: T1606.001
+        title: "Forge Web Credentials: Web Cookies"
+        description: "Adversaries may forge web cookies that can be used to gain access to web applications or Internet services. Web applications and services (hosted in cloud SaaS environments or on-premise servers) often use session cookies to authenticate and authorize user access."
+        reference_url: "https://attack.mitre.org/techniques/T1606/001"
+      - external_id: T1606.002
+        title: "Forge Web Credentials: SAML Tokens"
+        description: "An adversary may forge SAML tokens with any permissions claims and lifetimes if they possess a valid SAML token-signing certificate. The default lifetime of a SAML token is one hour, but the validity period can be specified in the NotOnOrAfter value of the conditions ... element in a token."
+        reference_url: "https://attack.mitre.org/techniques/T1606/002"
+      - external_id: T1609
+        title: Container Administration Command
+        description: "Adversaries may abuse a container administration service to execute commands within a container. A container administration service such as the Docker daemon, the Kubernetes API server, or the kubelet may allow remote management of containers within an environment."
+        reference_url: "https://attack.mitre.org/techniques/T1609"
+      - external_id: T1610
+        title: Deploy Container
+        description: "Adversaries may deploy a container into an environment to facilitate execution or evade defenses. In some cases, adversaries may deploy a new container to execute processes associated with a particular image or deployment, such as processes that execute or download malware."
+        reference_url: "https://attack.mitre.org/techniques/T1610"
+      - external_id: T1611
+        title: Escape to Host
+        description: "Adversaries may break out of a container or virtualized environment to gain access to the underlying host. This can allow an adversary access to other containerized or virtualized resources from the host level or to the host itself."
+        reference_url: "https://attack.mitre.org/techniques/T1611"
+      - external_id: T1612
+        title: Build Image on Host
+        description: "Adversaries may build a container image directly on a host to bypass defenses that monitor for the retrieval of malicious images from a public registry. A remote build request may be sent to the Docker API that includes a Dockerfile that pulls a vanilla base image, such as alpine, from a public or local registry and then builds a custom image upon it."
+        reference_url: "https://attack.mitre.org/techniques/T1612"
+      - external_id: T1613
+        title: Container and Resource Discovery
+        description: "Adversaries may attempt to discover containers and other resources that are available within a containers environment. Other resources may include images, deployments, pods, nodes, and other information such as the status of a cluster."
+        reference_url: "https://attack.mitre.org/techniques/T1613"
+      - external_id: T1614
+        title: System Location Discovery
+        description: "Adversaries may gather information in an attempt to calculate the geographical location of a victim host. Adversaries may use the information from System Location Discovery during automated discovery to shape follow-on behaviors, including whether or not the adversary fully infects the target and/or attempts specific actions."
+        reference_url: "https://attack.mitre.org/techniques/T1614"
+      - external_id: T1619
+        title: Cloud Storage Object Discovery
+        description: "Adversaries may enumerate objects in cloud storage infrastructure. Adversaries may use this information during automated discovery to shape follow-on behaviors, including requesting all or specific objects from cloud storage."
+        reference_url: "https://attack.mitre.org/techniques/T1619"
+      - external_id: T1621
+        title: Multi-Factor Authentication Request Generation
+        description: "Adversaries may attempt to bypass multi-factor authentication (MFA) mechanisms and gain access to accounts by generating MFA requests sent to users. Adversaries in possession of credentials to Valid Accounts may be unable to complete the login process if they lack access to the 2FA or MFA mechanisms required as an additional credential and security control."
+        reference_url: "https://attack.mitre.org/techniques/T1621"
+      - external_id: T1648
+        title: Serverless Execution
+        description: "Adversaries may abuse serverless computing, integration, and automation services to execute arbitrary code in cloud environments. Many cloud providers offer a variety of serverless resources, including compute engines, application integration services, and web servers."
+        reference_url: "https://attack.mitre.org/techniques/T1648"
+      - external_id: T1649
+        title: Steal or Forge Authentication Certificates
+        description: "Adversaries may steal or forge certificates used for authentication to access remote systems or resources. Digital certificates are often used to sign and encrypt messages and/or files."
+        reference_url: "https://attack.mitre.org/techniques/T1649"
+      - external_id: T1651
+        title: Cloud Administration Command
+        description: "Adversaries may abuse cloud management services to execute commands within virtual machines. Resources such as AWS Systems Manager, Azure RunCommand, and Runbooks allow users to remotely run scripts in virtual machines by leveraging installed virtual machine agents."
+        reference_url: "https://attack.mitre.org/techniques/T1651"
+      - external_id: T1654
+        title: Log Enumeration
+        description: "Adversaries may enumerate system and service logs to find useful data. These logs may highlight various types of valuable insights for an adversary, such as user authentication records (Account Discovery), security or vulnerable software (Software Discovery), or hosts within a compromised network (Remote System Discovery)."
+        reference_url: "https://attack.mitre.org/techniques/T1654"
+      - external_id: T1657
+        title: Financial Theft
+        description: "Adversaries may steal monetary resources from targets through extortion, social engineering, technical theft, or other methods aimed at their own financial gain at the expense of the availability of these resources for victims. Financial theft is the ultimate objective of several popular campaign types including extortion by ransomware, business email compromise (BEC) and fraud, \"pig butchering,\" bank hacking, and exploiting cryptocurrency networks."
+        reference_url: "https://attack.mitre.org/techniques/T1657"
+      - external_id: T1666
+        title: Modify Cloud Resource Hierarchy
+        description: "Adversaries may attempt to modify hierarchical structures in infrastructure-as-a-service (IaaS) environments in order to evade defenses. IaaS environments often group resources into a hierarchy, enabling improved resource management and application of policies to relevant groups."
+        reference_url: "https://attack.mitre.org/techniques/T1666"
+      - external_id: T1667
+        title: Email Bombing
+        description: "Adversaries may flood targeted email addresses with an overwhelming volume of messages. This may bury legitimate emails in a flood of spam and disrupt business operations."
+        reference_url: "https://attack.mitre.org/techniques/T1667"
+      - external_id: T1671
+        title: Cloud Application Integration
+        description: "Adversaries may achieve persistence by leveraging OAuth application integrations in a software-as-a-service environment. Adversaries may create a custom application, add a legitimate application into the environment, or even co-opt an existing integration to achieve malicious ends."
+        reference_url: "https://attack.mitre.org/techniques/T1671"
+      - external_id: T1677
+        title: Poisoned Pipeline Execution
+        description: "Adversaries may manipulate continuous integration / continuous development (CI/CD) processes by injecting malicious code into the build process."
+        reference_url: "https://attack.mitre.org/techniques/T1677"
+      - external_id: T1680
+        title: Local Storage Discovery
+        description: "Adversaries may enumerate local drives, disks, and/or volumes and their attributes like total or free space and volume serial number. This can be done to prepare for ransomware-related encryption, to perform Lateral Movement, or as a precursor to Direct Volume Access."
+        reference_url: "https://attack.mitre.org/techniques/T1680"
+      - external_id: T1684
+        title: Social Engineering
+        description: "Adversaries may use social engineering techniques to influence users to take actions that result in unauthorized access, approval of changes, disclosure of sensitive information, or execution of adversary-supplied instructions (i.e., introduction of malicious payloads or software), while minimizing technical indicators. Adversaries may leverage trust-building methods across multiple channels (e.g., executive, vendor, or help desk scenarios, including AI-enabled voice interactions) to prompt user-authorized actions such as password resets, MFA changes, financial approvals, or the disclosure of sensitive information."
+        reference_url: "https://attack.mitre.org/techniques/T1684"
+      - external_id: T1684.001
+        title: "Social Engineering: Impersonation"
+        description: "Adversaries may impersonate a trusted person or organization in order to persuade and trick a target into performing some action on their behalf. For example, adversaries may communicate with victims (via Phishing for Information, Phishing, or Internal Spearphishing) while impersonating a known sender such as an executive, colleague, or third-party vendor."
+        reference_url: "https://attack.mitre.org/techniques/T1684/001"
+      - external_id: T1684.002
+        title: "Social Engineering: Email Spoofing"
+        description: "Adversaries may fake, or spoof, a sender’s identity by modifying the value of relevant email headers in order to establish contact with victims under false pretenses. In addition to actual email content, email headers (such as the FROM header, which contains the email address of the sender) may also be modified."
+        reference_url: "https://attack.mitre.org/techniques/T1684/002"
+      - external_id: T1685
+        title: Disable or Modify Tools
+        description: "Adversaries may disable, degrade, or tamper with security tools or applications (e.g., endpoint detection and response (EDR) tools, intrusion detection systems (IDS), antivirus, logging agents, sensors, etc.) to impair or reduce visibility of defensive capabilities. This may include stopping specific services, killing processes, modifying or deleting tool configuration files and Registry keys, or preventing tools from updating."
+        reference_url: "https://attack.mitre.org/techniques/T1685"
+      - external_id: T1685.002
+        title: "Disable or Modify Tools: Disable or Modify Cloud Log"
+        description: "An adversary may disable or modify cloud logging capabilities and integrations to limit what data is collected on their activities and avoid detection. Cloud environments allow for collection and analysis of audit and application logs that provide insight into what activities a user does within the environment."
+        reference_url: "https://attack.mitre.org/techniques/T1685/002"
+      - external_id: T1686.001
+        title: "Disable or Modify System Firewall: Cloud Firewall"
+        description: "Adversaries may disable or modify a firewall within a cloud environment to bypass controls that limit access to cloud resources. Cloud environments typically utilize restrictive security groups and firewall rules that only allow network activity from trusted IP addresses via expected ports and protocols."
+        reference_url: "https://attack.mitre.org/techniques/T1686/001"
+      - external_id: T1687
+        title: Exploitation for Defense Impairment
+        description: "Adversaries may exploit vulnerabilities in security software, infrastructure, or defensive components to degrade, disable, or otherwise continue to impair their ability to prevent, detect, or respond to malicious activity. Adversaries may exploit a system or application vulnerability to directly interfere with defensive mechanisms."
+        reference_url: "https://attack.mitre.org/techniques/T1687"

--- a/libraries/packs/taxonomies/mitre-attack/taxonomy.yaml
+++ b/libraries/packs/taxonomies/mitre-attack/taxonomy.yaml
@@ -688,3 +688,27 @@ taxonomies:
         title: Exploitation for Defense Impairment
         description: "Adversaries may exploit vulnerabilities in security software, infrastructure, or defensive components to degrade, disable, or otherwise continue to impair their ability to prevent, detect, or respond to malicious activity. Adversaries may exploit a system or application vulnerability to directly interfere with defensive mechanisms."
         reference_url: "https://attack.mitre.org/techniques/T1687"
+      - external_id: T1005
+        title: Data from Local System
+        description: "Adversaries may search local system sources, such as file systems, configuration files, local databases, virtual machine files, or process memory, to find files of interest and sensitive data prior to Exfiltration."
+        reference_url: "https://attack.mitre.org/techniques/T1005"
+      - external_id: T1068
+        title: Exploitation for Privilege Escalation
+        description: "Adversaries may exploit software vulnerabilities in an attempt to elevate privileges. Exploitation of a software vulnerability occurs when an adversary takes advantage of a programming error in a program, service, or within the operating system software or kernel itself to execute adversary-controlled code."
+        reference_url: "https://attack.mitre.org/techniques/T1068"
+      - external_id: T1071
+        title: Application Layer Protocol
+        description: "Adversaries may communicate using OSI application layer protocols to avoid detection/network filtering by blending in with existing traffic."
+        reference_url: "https://attack.mitre.org/techniques/T1071"
+      - external_id: T1542
+        title: Pre-OS Boot
+        description: "Adversaries may abuse Pre-OS Boot mechanisms as a way to establish persistence on a system."
+        reference_url: "https://attack.mitre.org/techniques/T1542"
+      - external_id: T1557
+        title: Adversary-in-the-Middle
+        description: "Adversaries may attempt to position themselves between two or more networked devices using an adversary-in-the-middle technique to support follow-on behaviors such as Network Sniffing, Transmitted Data Manipulation, or replay attacks."
+        reference_url: "https://attack.mitre.org/techniques/T1557"
+      - external_id: T1565
+        title: Data Manipulation
+        description: "Adversaries may insert, delete, or manipulate data in order to influence external outcomes or hide activity, thus threatening the integrity of the data."
+        reference_url: "https://attack.mitre.org/techniques/T1565"


### PR DESCRIPTION
Refs #99

Adds a MITRE ATT&CK Enterprise (Cloud) taxonomy pack to replace mini-attack.

Source: STIX JSON bundle from github.com/mitre/cti, ATT&CK Enterprise v19.1 (current release, verified byte-identical against the tagged GitHub release, zero drift from master).

Scope: 171 entries, split two ways since the issue's scope is genuinely two-tiered:
- 152 entries (77 top-level + 75 sub-techniques) the full Cloud matrix, no curation, matched against active techniques tagged IaaS/SaaS/Identity Provider/Office Suite per MITRE's own Cloud matrix definition
- 19 entries curated general Enterprise techniques relevant to cloud workloads, not part of the Cloud-tagged set on their own. 13 came from keyword scoring (container/serverless/infrastructure-acquisition/credential themes), 6 added manually after review (container-native techniques like Deploy Container, Escape to Host, Container and Resource Discovery, plus completing the T1078 Valid Accounts sub-technique family T1078.002/.003 were missing while .001/.004 were already Cloud-tagged, which looked like an inconsistent gap rather than an intentional exclusion)

Both of the issue's named examples (T1190, T1078) are included via the Cloud tier's platform tagging.

Unlike ATLAS's versioned snapshot, this STIX bundle is append-only, so filtered out 12 x_mitre_deprecated + 149 revoked objects from the 858-object bundle before building either tier 697 active objects were the actual base.

Also worth flagging: STIX description fields turned out messier than CAPEC's XML found embedded HTML tags, backtick code spans, and markdown bullet lists with no per-item punctuation, which broke naive sentence-boundary extraction on a handful of entries (list content merging into run-on text). Fixed by stripping structural markup and truncating cleanly before list markers rather than trying to sentence-split through them. Every one of the 171 final descriptions was then checked byte-for-byte against its source STIX description field (after only the disclosed mechanical transformations) to confirm nothing else got mangled.

Same flat schema as the other three packs no parent/hierarchy field exists, sub-techniques represented via dotted IDs (e.g. T1078.002) same as ATLAS's convention.

Verification:
- 171/171 unique external_ids, zero dupes, independently checked
- reference_urls spot-checked, including the two entries affected by the list-flattening bug, to confirm the live ATT&CK page matches what's in the YAML
- Imported locally, all entries render clean, zero errors/warnings from validate_pack()

Part of the same batch as #99 see #143 (mitre-atlas) for the sibling PR, cwe and capec also up separately.