### PR TITLE
docs : Added contributing overview and development setup pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for wanting to help build Precogly! We're glad you're here. :)
 
 For detailed setup instructions and architecture docs, head over to our
-[full documentation site](https://precogly.github.io/precogly/contributing/development-setup/).
+[full documentation site](https://precogly.github.io/precogly/contributing/).
 
 ## 🦉 Owl's Orders\*
 

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -1,13 +1,129 @@
 # Development Setup
 
-Get your local development environment ready for contributing to Precogly.
+Use this guide when you want to contribute code or documentation to Precogly. The **recommended local workflow is Docker Compose** because it starts the same three services most contributors need: the React frontend, the Django API, and PostgreSQL. You can still run frontend commands such as `npm run dev` directly from `frontend/`, but Docker Compose is the fastest way to get a complete working application with seeded demo data.
 
-!!! note "Coming soon"
-    This page will cover:
+The development stack mounts the backend source, the frontend `src/` directory, and the shared `libraries/` directory into the containers. That means most frontend and backend code edits are picked up without rebuilding the whole stack. Rebuild when you change dependencies, Dockerfiles, or other files copied into the images during build.
 
-    - Prerequisites (Docker, Node.js, Python)
-    - Cloning and running the project
-    - Frontend development workflow
-    - Backend development workflow
-    - Running tests
-    - Code style and linting
+## Local Architecture
+
+```text
+Browser
+  |
+  | http://localhost:5173
+  v
+precogly-frontend
+  React + Vite dev server
+  |
+  | /api and /media requests
+  v
+precogly-backend
+  Django + Django REST Framework
+  |
+  | postgres://db:5432/precogly
+  v
+precogly-postgres
+  PostgreSQL 16
+```
+
+The frontend talks to the backend through Vite's development proxy. The browser sends API requests to `/api`, and Vite forwards them to the backend container using the `API_URL` value from `docker-compose.yml`.
+
+## Prerequisites
+
+Install:
+
+| Tool | Used for |
+| --- | --- |
+| Docker and Docker Compose | Running the application stack |
+| Git | Cloning the repository and preparing pull requests |
+| Node.js 22+ | Optional direct frontend workflow |
+| Python 3.12+ | Optional direct backend workflow |
+
+## Start the Stack
+
+From the **repository root**:
+
+```bash
+docker compose up --build
+```
+
+The first run builds the images, creates the PostgreSQL volume, runs migrations, and seeds demo data. After the services start, open [http://localhost:5173](http://localhost:5173) and log in with:
+
+| Field | Value |
+| --- | --- |
+| Email | `admin@precogly.dev` |
+| Password | `admin123` |
+
+The backend API is available at [http://localhost:8000](http://localhost:8000), and the Django admin is available at [http://localhost:8000/admin](http://localhost:8000/admin) with the same demo credentials.
+
+## Verify the Stack
+
+Use `docker compose ps` to confirm that all three services are running:
+
+```bash
+docker compose ps
+```
+
+You should see:
+
+| Service | Expected status |
+| --- | --- |
+| `precogly-frontend` | Running on port `5173` |
+| `precogly-backend` | Running on port `8000` |
+| `precogly-postgres` | Healthy on port `5432` |
+
+## Daily Development Commands
+
+Run these from the **repository root** unless noted otherwise:
+
+```bash
+docker compose ps
+docker compose logs backend
+docker compose logs frontend
+docker compose down
+```
+
+Use `docker compose down -v` only when you want to delete the local database volume and reseed from scratch on the next startup.
+
+## Frontend Workflow
+
+The frontend container runs Vite on port `5173`. API calls use `/api` in the browser and are proxied by Vite to the backend container through the `API_URL` value in `docker-compose.yml`.
+
+For direct local frontend work, install dependencies and start Vite from `frontend/`:
+
+```bash
+npm install
+npm run dev
+```
+
+Before opening a frontend pull request, run:
+
+```bash
+npm run build
+npm run lint
+```
+
+Frontend changes should include screenshots or a short screen recording in the pull request description.
+
+## Backend Workflow
+
+The backend container runs migrations, seeds demo data, and starts Django on port `8000`. To run backend commands inside the same environment as the app:
+
+```bash
+docker compose exec backend python manage.py migrate
+docker compose exec backend python manage.py seed
+docker compose exec backend python manage.py test
+```
+
+For direct local backend work, create a virtual environment, install development requirements from `backend/requirements/development.txt`, set `DJANGO_SETTINGS_MODULE=config.settings.development`, and run commands from `backend/`.
+
+## Troubleshooting
+
+If the frontend loads but API requests fail, check that the backend is healthy with `docker compose ps` and inspect logs with `docker compose logs backend`. If the database is in a bad local state, stop the stack with `docker compose down -v` and start again with `docker compose up --build`.
+
+If ports `5173`, `8000`, or `5432` are already in use, stop the conflicting process or change the port mapping in `docker-compose.yml`. Keep any changed local port mappings out of the pull request unless the project intentionally needs them.
+
+For a local PostgreSQL conflict, prefer setting `POSTGRES_PORT` instead of editing `docker-compose.yml`:
+
+```bash
+POSTGRES_PORT=5433 docker compose up --build
+```

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,0 +1,51 @@
+# Contributing to Precogly
+
+Precogly welcomes contributions to the application, documentation, and library packs. Start by choosing the contribution path that matches the work you want to do, then use the relevant guide before opening a pull request.
+
+Every contribution should be reviewed by a human before it is submitted. AI-assisted work is fine, but the contributor opening the pull request is responsible for understanding the change, testing it, and explaining the result clearly.
+
+## Contribution Paths
+
+| Path | Use this when | Start here |
+| --- | --- | --- |
+| **Code changes** | You are fixing bugs, improving UI flows, or changing backend behavior | [Development Setup](development-setup.md) |
+| **Documentation changes** | You are fixing existing docs or adding new contributor/user guidance | [Development Setup](development-setup.md) |
+| **Library packs** | You are adding or updating threat libraries, taxonomies, standards, or DFD templates | [Creating Library Packs](creating-library-packs.md) |
+
+## Before You Open a Pull Request
+
+Use this checklist before requesting review:
+
+- Confirm the pull request title follows conventional commit format, such as `docs: update development setup`.
+- Run the relevant local checks for the files you changed.
+- Include screenshots or a short recording when a change affects the frontend UI.
+- Explain the happy path you tested and at least one edge case.
+- Read the final diff and make sure you can explain every meaningful change.
+
+## Pull Request Titles
+
+Precogly uses conventional commit-style pull request titles because they feed release notes and changelog automation.
+
+| Prefix | Use for |
+| --- | --- |
+| `feat:` | New features |
+| `fix:` | Bug fixes |
+| `docs:` | Documentation-only changes |
+| `chore:` | Maintenance, CI, or dependency work |
+| `refactor:` | Code changes that are neither fixes nor features |
+
+Examples:
+
+```text
+docs: add Docker development setup
+fix: prevent schema generation crash
+feat: add OT/ICS threat library pack
+```
+
+## Contributor License Agreement
+
+Before your first pull request can be merged, you will need to accept the project Contributor License Agreement. CLA Assistant prompts you automatically on your first pull request.
+
+## Human Review Standard
+
+Treat the pull request description as the reviewer's starting point. It should state what changed, why it changed, how it was tested, and any known limitations. For documentation-only work, include the local docs preview command you used and a screenshot of the rendered page when useful.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - API:
       - Overview: api/overview.md
   - Contributing:
+      - Overview: contributing/index.md
       - Development Setup: contributing/development-setup.md
       - Creating Library Packs: contributing/creating-library-packs.md
 


### PR DESCRIPTION
Switched from placeholders in development setup to actual content and added an overview landing page for contributing section

Current state -
<img width="1920" height="925" alt="image" src="https://github.com/user-attachments/assets/e7103a8f-cb4c-4dc8-ba49-9baf1493e6c0" />

The update - 

https://github.com/user-attachments/assets/79edbb70-643a-4aeb-a278-7d798e09bd91
