### PR TITLE
fix: improve organization member role dropdown

### DIFF
--- a/backend/apps/organizations/models.py
+++ b/backend/apps/organizations/models.py
@@ -70,6 +70,15 @@ class OrganizationMember(TimestampedModel):
     def __str__(self):
         return f"{self.user} @ {self.organization} ({self.role})"
 
+    def is_last_security_team_member(self):
+        """Return True when demoting/removing this member would leave zero security team members."""
+        return (
+            self.role == self.Role.SECURITY_TEAM
+            and self.organization.members.filter(
+                role=self.Role.SECURITY_TEAM
+            ).count() <= 1
+        )
+
 
 class BusinessUnit(TimestampedModel):
     """

--- a/backend/apps/organizations/serializers.py
+++ b/backend/apps/organizations/serializers.py
@@ -105,11 +105,8 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
 
         new_role = attrs.get("role", self.instance.role)
         if (
-            self.instance.role == OrganizationMember.Role.SECURITY_TEAM
-            and new_role != OrganizationMember.Role.SECURITY_TEAM
-            and self.instance.organization.members.filter(
-                role=OrganizationMember.Role.SECURITY_TEAM
-            ).count() <= 1
+            new_role != OrganizationMember.Role.SECURITY_TEAM
+            and self.instance.is_last_security_team_member()
         ):
             raise serializers.ValidationError({
                 "role": "At least one organization member must remain on the security team."

--- a/backend/apps/organizations/serializers.py
+++ b/backend/apps/organizations/serializers.py
@@ -98,6 +98,25 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
             "organization_name",
         ]
 
+    def validate(self, attrs):
+        """Prevent removing the final security-team role from an organization."""
+        if not self.instance:
+            return attrs
+
+        new_role = attrs.get("role", self.instance.role)
+        if (
+            self.instance.role == OrganizationMember.Role.SECURITY_TEAM
+            and new_role != OrganizationMember.Role.SECURITY_TEAM
+            and self.instance.organization.members.filter(
+                role=OrganizationMember.Role.SECURITY_TEAM
+            ).count() <= 1
+        ):
+            raise serializers.ValidationError({
+                "role": "At least one organization member must remain on the security team."
+            })
+
+        return attrs
+
 
 class OrganizationMemberListSerializer(serializers.ModelSerializer):
     """Lightweight serializer for member listing."""

--- a/backend/apps/organizations/views.py
+++ b/backend/apps/organizations/views.py
@@ -45,16 +45,6 @@ from .serializers import (
 User = get_user_model()
 
 
-def is_last_security_team_member(member):
-    """Return true when removing/demoting this member would lock org administration."""
-    return (
-        member.role == OrganizationMember.Role.SECURITY_TEAM
-        and member.organization.members.filter(
-            role=OrganizationMember.Role.SECURITY_TEAM
-        ).count() <= 1
-    )
-
-
 class OrganizationViewSet(viewsets.ModelViewSet):
     """ViewSet for Organization CRUD operations."""
 
@@ -120,7 +110,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         user_id = request.data.get("user")
         try:
             member = org.members.get(user_id=user_id)
-            if is_last_security_team_member(member):
+            if member.is_last_security_team_member():
                 return Response(
                     {"detail": "At least one organization member must remain on the security team."},
                     status=status.HTTP_400_BAD_REQUEST,
@@ -153,7 +143,7 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
     def destroy(self, request, *args, **kwargs):
         """Prevent deleting the final security-team member from an organization."""
         member = self.get_object()
-        if is_last_security_team_member(member):
+        if member.is_last_security_team_member():
             return Response(
                 {"detail": "At least one organization member must remain on the security team."},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/backend/apps/organizations/views.py
+++ b/backend/apps/organizations/views.py
@@ -45,6 +45,16 @@ from .serializers import (
 User = get_user_model()
 
 
+def is_last_security_team_member(member):
+    """Return true when removing/demoting this member would lock org administration."""
+    return (
+        member.role == OrganizationMember.Role.SECURITY_TEAM
+        and member.organization.members.filter(
+            role=OrganizationMember.Role.SECURITY_TEAM
+        ).count() <= 1
+    )
+
+
 class OrganizationViewSet(viewsets.ModelViewSet):
     """ViewSet for Organization CRUD operations."""
 
@@ -110,6 +120,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         user_id = request.data.get("user")
         try:
             member = org.members.get(user_id=user_id)
+            if is_last_security_team_member(member):
+                return Response(
+                    {"detail": "At least one organization member must remain on the security team."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
             member.delete()
             return Response(status=status.HTTP_204_NO_CONTENT)
         except OrganizationMember.DoesNotExist:
@@ -134,6 +149,16 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
         return OrganizationMember.objects.filter(
             organization_id__in=org_ids
         ).select_related("organization", "user")
+
+    def destroy(self, request, *args, **kwargs):
+        """Prevent deleting the final security-team member from an organization."""
+        member = self.get_object()
+        if is_last_security_team_member(member):
+            return Response(
+                {"detail": "At least one organization member must remain on the security team."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return super().destroy(request, *args, **kwargs)
 
 
 class BusinessUnitViewSet(viewsets.ModelViewSet):

--- a/frontend/src/features/organization/api/organizations.ts
+++ b/frontend/src/features/organization/api/organizations.ts
@@ -361,7 +361,7 @@ export function useUpdateOrgMemberRole() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: ({ membershipId, role }: { membershipId: number; role: string }) =>
-      api.patch<OrganizationMembership>(`/organization-members/${membershipId}/`, { role }),
+      api.patch<OrganizationMembership>(`/memberships/${membershipId}/`, { role }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: organizationKeys.all })
     },
@@ -424,4 +424,3 @@ export function useDeleteBusinessUnit() {
     },
   })
 }
-

--- a/frontend/src/features/organization/pages/MemberManagement.tsx
+++ b/frontend/src/features/organization/pages/MemberManagement.tsx
@@ -166,7 +166,12 @@ export function MemberManagement() {
                           <SelectTrigger className="w-36">
                             <SelectValue />
                           </SelectTrigger>
-                          <SelectContent>
+                          <SelectContent
+                            position="popper"
+                            side="bottom"
+                            align="start"
+                            avoidCollisions={false}
+                          >
                             <SelectItem value="security_team">
                               <Badge className={roleColors.security_team}>
                                 Security Team

--- a/frontend/src/features/organization/pages/MemberManagement.tsx
+++ b/frontend/src/features/organization/pages/MemberManagement.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import {
   useOrganizationMembers,
@@ -112,6 +113,16 @@ export function MemberManagement() {
         role: pendingRoleChange.newRole,
       },
       {
+        onSuccess: () => {
+          toast.success('Member role updated successfully.')
+        },
+        onError: (error) => {
+          const message =
+            (error as any)?.response?.data?.role?.[0] ||
+            (error as any)?.response?.data?.detail ||
+            'Failed to update member role.'
+          toast.error(message)
+        },
         onSettled: () => setPendingRoleChange(null),
       }
     )

--- a/frontend/src/features/organization/pages/MemberManagement.tsx
+++ b/frontend/src/features/organization/pages/MemberManagement.tsx
@@ -2,6 +2,7 @@
  * Organization member management page with role change and removal.
  */
 
+import { useMemo, useState } from 'react'
 import { useWorkspace } from '@/contexts/WorkspaceContext'
 import {
   useOrganizationMembers,
@@ -22,7 +23,18 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
+  SelectValue,
 } from '@/components/ui/select'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Trash2 } from 'lucide-react'
@@ -42,8 +54,20 @@ export function MemberManagement() {
   const { data: members = [], isLoading: membersLoading } = useOrganizationMembers(
     currentOrganization?.id ?? 0
   )
+  const [pendingRoleChange, setPendingRoleChange] = useState<{
+    membershipId: number
+    userEmail: string
+    currentRole: string
+    newRole: string
+    isLastSecurityTeam: boolean
+  } | null>(null)
   const removeMemberMutation = useRemoveOrgMember()
   const updateRoleMutation = useUpdateOrgMemberRole()
+
+  const securityTeamCount = useMemo(
+    () => members.filter((member) => member.role === 'security_team').length,
+    [members]
+  )
 
   if (workspaceLoading || membersLoading) {
     return <div>Loading...</div>
@@ -61,8 +85,36 @@ export function MemberManagement() {
     })
   }
 
-  const handleRoleChange = (membershipId: number, newRole: string) => {
-    updateRoleMutation.mutate({ membershipId, role: newRole })
+  const handleRoleChange = (
+    membershipId: number,
+    userEmail: string,
+    currentRole: string,
+    newRole: string
+  ) => {
+    if (currentRole === newRole) return
+    setPendingRoleChange({
+      membershipId,
+      userEmail,
+      currentRole,
+      newRole,
+      isLastSecurityTeam:
+        currentRole === 'security_team' &&
+        newRole !== 'security_team' &&
+        securityTeamCount <= 1,
+    })
+  }
+
+  const confirmRoleChange = () => {
+    if (!pendingRoleChange || pendingRoleChange.isLastSecurityTeam) return
+    updateRoleMutation.mutate(
+      {
+        membershipId: pendingRoleChange.membershipId,
+        role: pendingRoleChange.newRole,
+      },
+      {
+        onSettled: () => setPendingRoleChange(null),
+      }
+    )
   }
 
   const formatDate = (dateString: string) => {
@@ -106,17 +158,25 @@ export function MemberManagement() {
                       {isSecurityTeam ? (
                         <Select
                           value={member.role}
-                          onValueChange={(value) => handleRoleChange(member.id, value)}
+                          onValueChange={(value) =>
+                            handleRoleChange(member.id, member.userEmail, member.role, value)
+                          }
                           disabled={updateRoleMutation.isPending}
                         >
                           <SelectTrigger className="w-36">
-                            <Badge className={roleColors[member.role] ?? 'bg-gray-100'}>
-                              {roleLabels[member.role] ?? member.role}
-                            </Badge>
+                            <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value="security_team">Security Team</SelectItem>
-                            <SelectItem value="member">Member</SelectItem>
+                            <SelectItem value="security_team">
+                              <Badge className={roleColors.security_team}>
+                                Security Team
+                              </Badge>
+                            </SelectItem>
+                            <SelectItem value="member">
+                              <Badge className={roleColors.member}>
+                                Member
+                              </Badge>
+                            </SelectItem>
                           </SelectContent>
                         </Select>
                       ) : (
@@ -148,6 +208,51 @@ export function MemberManagement() {
           )}
         </CardContent>
       </Card>
+
+      <AlertDialog
+        open={pendingRoleChange !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingRoleChange(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingRoleChange?.isLastSecurityTeam
+                ? 'Cannot change this role'
+                : 'Change organization role?'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingRoleChange?.isLastSecurityTeam ? (
+                <>
+                  {pendingRoleChange.userEmail} is the only Security Team member in this
+                  organization. At least one member must remain on the Security Team so
+                  organization settings do not become locked.
+                </>
+              ) : pendingRoleChange ? (
+                <>
+                  This will change {pendingRoleChange.userEmail} from{' '}
+                  {roleLabels[pendingRoleChange.currentRole] ?? pendingRoleChange.currentRole} to{' '}
+                  {roleLabels[pendingRoleChange.newRole] ?? pendingRoleChange.newRole}. Security
+                  Team members can manage organization settings, teams, members, and library
+                  imports. Members keep standard organization access without those admin
+                  permissions.
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {pendingRoleChange?.isLastSecurityTeam ? 'Close' : 'Cancel'}
+            </AlertDialogCancel>
+            {!pendingRoleChange?.isLastSecurityTeam && (
+              <AlertDialogAction onClick={confirmRoleChange}>
+                Confirm change
+              </AlertDialogAction>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }


### PR DESCRIPTION
[Screencast from 2026-07-07 14-31-06.webm](https://github.com/user-attachments/assets/d6ab1fcb-bdb3-4091-8e9c-498cd054cacf)

Fixes #150 

  ## Summary

  - Fixes the organization member role dropdown so it opens correctly on the Settings > Members page.
  - Keeps role options visually labeled with badges inside the dropdown.
  - Also added confirmation messages and warning messages for edge cases
  - Corrected the endpoint that earlier was giving 404 on updation
  

  ## Testing
  - Verified the role dropdown opens on `/settings/members`.


also updated to drop DOWN which was previously up, lol

[Screencast from 2026-07-07 14-54-23.webm](https://github.com/user-attachments/assets/2ac53e1c-864e-4fd8-b981-3f65e97c68b5)