### PR TITLE
fix: api/schema stale field error and drift in docs

### DIFF
--- a/backend/apps/threats/serializers.py
+++ b/backend/apps/threats/serializers.py
@@ -120,7 +120,6 @@ class CountermeasureLibrarySerializer(serializers.ModelSerializer):
         model = CountermeasureLibrary
         fields = [
             "id",
-            "organization",
             "name",
             "description",
             "control_type",

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -165,8 +165,8 @@ All endpoints require authentication by default. The only exceptions are magic l
 | `POST` | `/api/threat-models/{id}/remove_system/` | Unlink a system |
 | `POST` | `/api/threat-models/{id}/add_referenced_model/` | Add model relationship |
 | `POST` | `/api/threat-models/{id}/remove_referenced_model/` | Remove model relationship |
-| `POST` | `/api/threat-models/{id}/add_framework/` | Attach compliance framework |
-| `POST` | `/api/threat-models/{id}/remove_framework/` | Detach compliance framework |
+| `POST` | `/api/threat-models/{id}/add_pack/` | Attach a library pack |
+| `POST` | `/api/threat-models/{id}/remove_pack/` | Detach a library pack |
 | `POST` | `/api/threat-models/import/tm-library/` | Import from TM-Library JSON |
 | `GET` | `/api/threat-models/{id}/export/tm-library/` | Export as TM-Library JSON |
 


### PR DESCRIPTION
one backend api bug plus one tiny docs cleanup.

Fixes #153 

[Screencast from 2026-07-08 17-00-55.webm](https://github.com/user-attachments/assets/f3c57513-da4b-4614-955c-fbed90cd7c1a)


  1. The backend/API bug
      - File: backend/apps/threats/serializers.py:120
      - Removes stale organization from CountermeasureLibrarySerializer.
      - Fixes /api/schema/ crashing with:
        Field name organization is not valid for model CountermeasureLibrary

      - This also restores schema-backed API docs behavior.

  2. Small docs correction
      - File: docs/api/overview.md:165
      - Replaces nonexistent documented endpoints:
        /add_framework/, /remove_framework/
      - With real endpoints:
        /add_pack/, /remove_pack/