### PR TITLE
fix: remove stale NOT NULL columns from packs tables that block pack seeding/import

### DIFF
--- a/backend/apps/packs/migrations/0002_remove_stale_librarypack_columns.py
+++ b/backend/apps/packs/migrations/0002_remove_stale_librarypack_columns.py
@@ -1,0 +1,66 @@
+"""
+Remove stale columns from packs_librarypack and packs_librarypackdependency.
+
+These columns were removed from the models but never had a corresponding migration.
+Existing databases still have these NOT NULL columns, causing INSERT failures for
+any new pack or dependency.
+"""
+
+from django.db import migrations
+
+
+STALE_COLUMNS = {
+    "packs_librarypack": [
+        "tier", "source", "content", "industries",
+        "repository_url", "documentation_url", "icon_url",
+        "install_count", "is_published", "published_at",
+    ],
+    "packs_librarypackdependency": [
+        "version_constraint", "is_optional",
+    ],
+}
+
+
+def remove_columns_if_exist(apps, schema_editor):
+    """Drop stale columns only if they exist (safe for fresh installs)."""
+    connection = schema_editor.connection
+    for table, stale_columns in STALE_COLUMNS.items():
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = %s", [table]
+            )
+            existing = {row[0] for row in cursor.fetchall()}
+
+        columns_to_drop = [c for c in stale_columns if c in existing]
+        if columns_to_drop:
+            drops = ", ".join(f"DROP COLUMN {c}" for c in columns_to_drop)
+            with connection.cursor() as cursor:
+                cursor.execute(f"ALTER TABLE {table} {drops}")
+
+
+def clean_phantom_migration(apps, schema_editor):
+    """Remove the phantom 0002_add_standard_requirement_mapping record if present."""
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(
+            "DELETE FROM django_migrations "
+            "WHERE app = 'packs' AND name = '0002_add_standard_requirement_mapping'"
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("packs", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_columns_if_exist,
+            migrations.RunPython.noop,
+        ),
+        migrations.RunPython(
+            clean_phantom_migration,
+            migrations.RunPython.noop,
+        ),
+    ]


### PR DESCRIPTION
## Summary

- Adds migration to drop 12 stale NOT NULL columns from `packs_librarypack` and `packs_librarypackdependency` that were removed from the models but never had a corresponding migration
- Cleans phantom `0002_add_standard_requirement_mapping` migration record from `django_migrations`
- Safe for both existing databases and fresh installs (checks column existence before dropping)

Fixes #158 

## Problem

A prior commit simplified the `LibraryPack` model by removing fields (`tier`, `source`, `content`, `industries`, `repository_url`, `documentation_url`, `icon_url`, `install_count`, `is_published`, `published_at`) and rewrote `0001_initial.py` in place — but never generated a `RemoveField` migration. The same happened for `version_constraint` and `is_optional` on `LibraryPackDependency`.

Existing databases still have these as NOT NULL columns with no default, so any INSERT for a new pack fails:

Skipped: taxonomies/capec — Import failed: null value in column "tier" of relation
"packs_librarypack" violates not-null constraint

This causes 5 of 10 seeded packs to fail (CAPEC, CWE, MITRE ATT&CK, OWASP Top 10, OWASP ASVS) and `aws-mini` to fail on the dependency table. Users see only 10 packs in the Imported tab instead of 15.

[Screencast from 2026-07-11 19-19-41.webm](https://github.com/user-attachments/assets/ce01690c-4203-4394-be89-5c62d298a626)

