### PR TITLE
Add a data NULL check for tight code quality and UX

### DIFF
--- a/backend/apps/packs/views.py
+++ b/backend/apps/packs/views.py
@@ -247,6 +247,11 @@ class LibraryPackViewSet(viewsets.ReadOnlyModelViewSet):
         """
         pack = self.get_object()
         preview_data = get_pack_preview_from_database(pack)
+        if preview_data is None:
+            return Response(
+                {"detail": "Pack source files not found on disk."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         return Response(preview_data)
 
     @action(detail=False, methods=["get"])


### PR DESCRIPTION
Fixes #160 

Simple fix, just added a NULL check and return in case there's a mismatch of endpoints. This had come up as an actual bug when testing around #158.

You can actually see the packs not loading the preview and reproduce this if #159 hasn't yet been merged and migrations haven't run by going to the imported packs and trying to preview them in the library or reverting the migration once back to 001 only.