### PR TITLE
feat(guest-editor): add STRIDE category selection to threat dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ site/
 # Local working files (session notes, scratch artifacts)
 SESSION.md
 tmp/
+
+# Proposed icon (pending approval)
+frontend/src/features/ai/components/OwlMark_proposed.tsx

--- a/frontend/src/features/guest-editor/components/GuestAddThreatDialog.tsx
+++ b/frontend/src/features/guest-editor/components/GuestAddThreatDialog.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/select'
 import { useGuestEditor } from '../context/GuestEditorContext'
 import type { GuestThreat } from '../types'
+import { STRIDE_CATEGORIES, type STRIDECategory } from '@/types/domain'
 
 const SEVERITY_OPTIONS = [
   { value: 'low', label: 'Low' },
@@ -51,6 +52,7 @@ export function GuestThreatDialog({
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [severity, setSeverity] = useState<GuestThreat['severity']>('medium')
+  const [category, setCategory] = useState('')
 
   const isEditMode = !!editThreat
 
@@ -61,10 +63,12 @@ export function GuestThreatDialog({
         setName(editThreat.name)
         setDescription(editThreat.description)
         setSeverity(editThreat.severity)
+        setCategory(editThreat.category || '')
       } else {
         setName('')
         setDescription('')
         setSeverity('medium')
+        setCategory('')
       }
     }
   }, [open, editThreat])
@@ -77,9 +81,17 @@ export function GuestThreatDialog({
         name: name.trim(),
         description: description.trim(),
         severity,
+        category: (category as STRIDECategory) || undefined,
       })
     } else {
-      guestEditor.addThreat(targetId, targetType, name.trim(), description.trim(), severity)
+      guestEditor.addThreat(
+        targetId,
+        targetType,
+        name.trim(),
+        description.trim(),
+        severity,
+        (category as STRIDECategory) || undefined
+      )
     }
     onOpenChange(false)
   }
@@ -127,6 +139,22 @@ export function GuestThreatDialog({
               </SelectTrigger>
               <SelectContent>
                 {SEVERITY_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="threat-category">STRIDE Category</Label>
+            <Select value={category} onValueChange={setCategory}>
+              <SelectTrigger id="threat-category">
+                <SelectValue placeholder="Select a category..." />
+              </SelectTrigger>
+              <SelectContent>
+                {STRIDE_CATEGORIES.map((opt) => (
                   <SelectItem key={opt.value} value={opt.value}>
                     {opt.label}
                   </SelectItem>

--- a/frontend/src/features/guest-editor/components/GuestThreatAnalysis.tsx
+++ b/frontend/src/features/guest-editor/components/GuestThreatAnalysis.tsx
@@ -26,6 +26,7 @@ import { useGuestEditor } from '../context/GuestEditorContext'
 import { GuestThreatDialog } from './GuestAddThreatDialog'
 import { GuestCountermeasureDialog } from './GuestCountermeasureDialog'
 import type { GuestThreat, GuestCountermeasure } from '../types'
+import { STRIDE_CONFIG } from '@/types/domain'
 
 const SEVERITY_COLORS: Record<GuestThreat['severity'], string> = {
   low: 'bg-blue-100 text-blue-800',
@@ -363,6 +364,18 @@ export function GuestThreatAnalysis() {
                               >
                                 {threat.severity}
                               </Badge>
+                              {threat.category && STRIDE_CONFIG[threat.category] && (
+                                <Badge
+                                  variant="outline"
+                                  className="shrink-0 text-xs border"
+                                  style={{
+                                    color: STRIDE_CONFIG[threat.category].color,
+                                    borderColor: STRIDE_CONFIG[threat.category].color,
+                                  }}
+                                >
+                                  {STRIDE_CONFIG[threat.category].label}
+                                </Badge>
+                              )}
                               <span className="truncate">{threat.name}</span>
                             </div>
                             <div className="flex items-center gap-1 shrink-0">

--- a/frontend/src/features/guest-editor/components/GuestThreatSection.tsx
+++ b/frontend/src/features/guest-editor/components/GuestThreatSection.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils'
 import { useGuestEditor } from '../context/GuestEditorContext'
 import { GuestThreatDialog } from './GuestAddThreatDialog'
 import type { GuestThreat } from '../types'
+import { STRIDE_CONFIG } from '@/types/domain'
 
 const SEVERITY_COLORS: Record<GuestThreat['severity'], string> = {
   low: 'bg-blue-100 text-blue-800',
@@ -86,6 +87,18 @@ export function GuestThreatSection({
                     >
                       {threat.severity}
                     </Badge>
+                    {threat.category && STRIDE_CONFIG[threat.category] && (
+                      <Badge
+                        variant="outline"
+                        className="shrink-0 text-xs border"
+                        style={{
+                          color: STRIDE_CONFIG[threat.category].color,
+                          borderColor: STRIDE_CONFIG[threat.category].color,
+                        }}
+                      >
+                        {STRIDE_CONFIG[threat.category].label}
+                      </Badge>
+                    )}
                     <span className="truncate">{threat.name}</span>
                   </div>
                   <Button

--- a/frontend/src/features/guest-editor/context/GuestEditorContext.tsx
+++ b/frontend/src/features/guest-editor/context/GuestEditorContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, type ReactNode } from 'react'
 import type { DiagramNode, DiagramEdge } from '@/features/dfd-editor/types'
 import type { GuestThreat, GuestCountermeasure } from '../types'
+import type { STRIDECategory } from '@/types/domain'
 
 interface GuestEditorContextType {
   // Diagram data (read-only from context consumers)
@@ -14,11 +15,12 @@ interface GuestEditorContextType {
     targetType: GuestThreat['targetType'],
     name: string,
     description: string,
-    severity: GuestThreat['severity']
+    severity: GuestThreat['severity'],
+    category?: STRIDECategory
   ) => void
   updateThreat: (
     threatId: string,
-    updates: Partial<Pick<GuestThreat, 'name' | 'description' | 'severity'>>
+    updates: Partial<Pick<GuestThreat, 'name' | 'description' | 'severity' | 'category'>>
   ) => void
   removeThreat: (threatId: string) => void
   getThreatsForTarget: (targetId: string) => GuestThreat[]

--- a/frontend/src/features/guest-editor/hooks/useGuestThreats.ts
+++ b/frontend/src/features/guest-editor/hooks/useGuestThreats.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import type { GuestThreat } from '../types'
+import type { STRIDECategory } from '@/types/domain'
 
 export function useGuestThreats() {
   const [threats, setThreats] = useState<GuestThreat[]>([])
@@ -10,7 +11,8 @@ export function useGuestThreats() {
       targetType: GuestThreat['targetType'],
       name: string,
       description: string,
-      severity: GuestThreat['severity']
+      severity: GuestThreat['severity'],
+      category?: STRIDECategory
     ) => {
       const newThreat: GuestThreat = {
         id: crypto.randomUUID(),
@@ -19,6 +21,7 @@ export function useGuestThreats() {
         name,
         description,
         severity,
+        ...(category && { category }),
         createdAt: new Date().toISOString(),
       }
       setThreats((prev) => [...prev, newThreat])
@@ -27,7 +30,7 @@ export function useGuestThreats() {
   )
 
   const updateThreat = useCallback(
-    (threatId: string, updates: Partial<Pick<GuestThreat, 'name' | 'description' | 'severity'>>) => {
+    (threatId: string, updates: Partial<Pick<GuestThreat, 'name' | 'description' | 'severity' | 'category'>>) => {
       setThreats((prev) =>
         prev.map((t) => (t.id === threatId ? { ...t, ...updates } : t))
       )

--- a/frontend/src/features/guest-editor/lib/precogly-file.ts
+++ b/frontend/src/features/guest-editor/lib/precogly-file.ts
@@ -122,6 +122,7 @@ export function serializeToTmLibrary(
       name: t.name,
       description: t.description,
       severity: t.severity,
+      ...(t.category && { category: t.category }),
       [affectedKey]: [t.targetId],
     }
   })
@@ -211,6 +212,8 @@ function deserializeTmLibrary(json: string): DeserializedFile {
         targetType = node?.type === 'systemScope' ? 'systemScope' : 'component'
       }
 
+      const categoryValue = t.category as string | undefined
+
       return {
         id: t.symbolic_name,
         targetId,
@@ -218,6 +221,7 @@ function deserializeTmLibrary(json: string): DeserializedFile {
         name: t.name,
         description: t.description || '',
         severity: (t.severity as GuestThreat['severity']) || 'medium',
+        ...(categoryValue ? { category: categoryValue as GuestThreat['category'] } : {}),
         createdAt:
           parsed.extensions?.['precogly.org/guest-metadata']?.createdAt ||
           new Date().toISOString(),

--- a/frontend/src/features/guest-editor/types.ts
+++ b/frontend/src/features/guest-editor/types.ts
@@ -1,4 +1,5 @@
 import type { DiagramNode, DiagramEdge } from '@/features/dfd-editor/types'
+import type { STRIDECategory } from '@/types/domain'
 
 export interface GuestThreat {
   id: string
@@ -7,6 +8,7 @@ export interface GuestThreat {
   name: string
   description: string
   severity: 'low' | 'medium' | 'high' | 'critical'
+  category?: STRIDECategory
   createdAt: string
 }
 


### PR DESCRIPTION
  Adds an optional STRIDE Category dropdown to the guest editor's
  Add/Edit Threat dialog, allowing users to categorize threats by
  STRIDE taxonomy (Spoofing, Tampering, Repudiation, etc.).

  Selected categories display as colored badges in both the threat
  list sidebar and the Threat Analysis view. Categories persist
  through file serialization/deserialization.