### PR TITLE
  feat(dfd-editor): add DFD notation switching (DFD3 / Yourdon-DeMarco)

### DIFF
--- a/frontend/src/components/shared/ReadOnlyDFDViewer.tsx
+++ b/frontend/src/components/shared/ReadOnlyDFDViewer.tsx
@@ -6,12 +6,15 @@
 import { ReactFlow, Background, Controls, ReactFlowProvider } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { nodeTypes, edgeTypes } from '@/features/dfd-editor/components'
+import { DFDNotationProvider } from '@/features/dfd-editor/context/DFDNotationContext'
+import { DEFAULT_NOTATION } from '@/features/dfd-editor/types/notation'
 
 // Flexible canvas data type that accepts the API response format
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 interface CanvasData {
   nodes?: any[]
   edges?: any[]
+  notationStyle?: string
 }
 
 interface ReadOnlyDFDViewerProps {
@@ -22,46 +25,49 @@ interface ReadOnlyDFDViewerProps {
 function DFDViewerContent({ canvasData, className }: ReadOnlyDFDViewerProps) {
   const nodes = canvasData.nodes ?? []
   const edges = canvasData.edges ?? []
+  const notationStyle = (canvasData.notationStyle as 'dfd3' | 'yourdon') ?? DEFAULT_NOTATION
 
   return (
     <div className={className}>
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        fitView
-        fitViewOptions={{ padding: 0.2 }}
-        minZoom={0.1}
-        maxZoom={2}
-        // Disable all interactions except pan and zoom
-        nodesDraggable={false}
-        nodesConnectable={false}
-        elementsSelectable={false}
-        panOnDrag
-        zoomOnScroll
-        zoomOnPinch
-        preventScrolling
-      >
-        {/* SVG Definitions for edge markers */}
-        <svg style={{ position: 'absolute', width: 0, height: 0 }}>
-          <defs>
-            <marker
-              id="arrow"
-              viewBox="0 0 10 10"
-              refX="8"
-              refY="5"
-              markerWidth="6"
-              markerHeight="6"
-              orient="auto-start-reverse"
-            >
-              <path d="M 0 0 L 10 5 L 0 10 z" fill="#6b7280" />
-            </marker>
-          </defs>
-        </svg>
-        <Background gap={15} size={1} />
-        <Controls showInteractive={false} />
-      </ReactFlow>
+      <DFDNotationProvider notationStyle={notationStyle}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.2 }}
+          minZoom={0.1}
+          maxZoom={2}
+          // Disable all interactions except pan and zoom
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          panOnDrag
+          zoomOnScroll
+          zoomOnPinch
+          preventScrolling
+        >
+          {/* SVG Definitions for edge markers */}
+          <svg style={{ position: 'absolute', width: 0, height: 0 }}>
+            <defs>
+              <marker
+                id="arrow"
+                viewBox="0 0 10 10"
+                refX="8"
+                refY="5"
+                markerWidth="6"
+                markerHeight="6"
+                orient="auto-start-reverse"
+              >
+                <path d="M 0 0 L 10 5 L 0 10 z" fill="#6b7280" />
+              </marker>
+            </defs>
+          </svg>
+          <Background gap={15} size={1} />
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      </DFDNotationProvider>
     </div>
   )
 }

--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useRef } from 'react'
+import { useCallback, useState, useRef, useEffect } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import {
   ReactFlow,
@@ -31,12 +31,14 @@ import { EdgeEditPanel } from './components/panels/EdgeEditPanel'
 import { TrustBoundaryEdgeEditPanel } from './components/panels/TrustBoundaryEdgeEditPanel'
 import { TemplateBrowser } from './components/TemplateBrowser'
 import { CanvasOverlays } from './components/CanvasOverlays'
+import { DFDNotationProvider } from './context/DFDNotationContext'
 import { useDiagramState } from './hooks/useDiagramState'
 import { useParentRelationships } from './hooks/useParentRelationships'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useConnectionMode } from './hooks/useConnectionMode'
 import { useBoundaryMode } from './hooks/useBoundaryMode'
 import type { DiagramNode, DiagramEdge, DataFlowEdge, TrustBoundaryEdge } from './types'
+import { type DFDNotationStyle, NOTATION_NODE_SIZES } from './types/notation'
 
 function DFDEditorContent() {
   const { diagramId, id: threatModelId } = useParams<{ id: string; diagramId: string }>()
@@ -61,6 +63,7 @@ function DFDEditorContent() {
     diagram,
     nodes,
     edges,
+    initialNotationStyle,
     isLoading,
     isSaving,
     isError,
@@ -77,6 +80,49 @@ function DFDEditorContent() {
     diagramId: diagramId || '',
     autoSaveInterval: 30000,
   })
+
+  // Notation style state
+  const [notationStyle, setNotationStyle] = useState<DFDNotationStyle>('dfd3')
+
+  // Sync notationStyle from loaded diagram data
+  useEffect(() => {
+    setNotationStyle(initialNotationStyle)
+  }, [initialNotationStyle])
+
+  // Handle notation change — resize affected nodes to new notation defaults
+  const handleNotationChange = useCallback(
+    (newNotation: DFDNotationStyle) => {
+      setNotationStyle(newNotation)
+      const newSizes = NOTATION_NODE_SIZES[newNotation]
+
+      setNodes((currentNodes) => {
+        // Determine which process nodes are containers (have children)
+        const containerProcessIds = new Set(
+          currentNodes
+            .filter((n) => n.parentId)
+            .map((n) => n.parentId!)
+            .filter((parentId) => currentNodes.find((n) => n.id === parentId)?.type === 'process')
+        )
+
+        return currentNodes.map((node) => {
+          if (
+            (node.type === 'process' && !containerProcessIds.has(node.id)) ||
+            node.type === 'datastore'
+          ) {
+            const defaultSize = newSizes[node.type]
+            if (defaultSize) {
+              return {
+                ...node,
+                style: { ...node.style, width: defaultSize.width, height: defaultSize.height },
+              }
+            }
+          }
+          return node
+        })
+      })
+    },
+    [setNodes]
+  )
 
   // State for editable title
   const [isEditingTitle, setIsEditingTitle] = useState(false)
@@ -280,9 +326,14 @@ function DFDEditorContent() {
     }
   }, [boundaryMode, cancelBoundaryMode])
 
+  // Wrap saveNow for keyboard shortcut to pass notation style
+  const handleKeyboardSave = useCallback(async () => {
+    await saveNow(notationStyle)
+  }, [saveNow, notationStyle])
+
   // Keyboard shortcuts
   useKeyboardShortcuts({
-    onSave: saveNow,
+    onSave: handleKeyboardSave,
     onUndo: undo,
     onDeselect: handleDeselect,
     enabled: true,
@@ -434,7 +485,7 @@ function DFDEditorContent() {
 
           <Button
             size="sm"
-            onClick={saveNow}
+            onClick={() => saveNow(notationStyle)}
             disabled={isSaving || !hasUnsavedChanges}
           >
             <Save className="h-4 w-4 mr-2" />
@@ -463,54 +514,58 @@ function DFDEditorContent() {
         onOpenTemplates={() => setShowTemplates(true)}
         onOpenThreatAnalysis={async () => {
           if (hasUnsavedChanges) {
-            await saveNow()
+            await saveNow(notationStyle)
           }
           navigate(`/threat-models/${threatModelId}`)
         }}
+        notationStyle={notationStyle}
+        onNotationChange={handleNotationChange}
       />
 
       <div className="flex flex-1 overflow-hidden">
         {/* Canvas */}
         <div className="flex-1" ref={reactFlowWrapper} onMouseMove={handleMouseMove}>
-          <ReactFlow
-            nodes={nodes}
-            edges={edges}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
-            onConnect={handleConnect}
-            onNodeClick={handleNodeClick}
-            onEdgeClick={handleEdgeClick}
-            onPaneClick={handlePaneClick}
-            onNodeDragStop={handleNodeDragStop}
-            nodeTypes={nodeTypes}
-            edgeTypes={edgeTypes}
-            connectionMode={ConnectionMode.Loose}
-            defaultEdgeOptions={{
-              type: 'dataFlow',
-              animated: true,
-            }}
-            fitView
-            snapToGrid
-            snapGrid={[15, 15]}
-            minZoom={0.1}
-            maxZoom={4}
-            deleteKeyCode={null}
-          >
-            <CanvasOverlays
-              viewportX={viewportX}
-              viewportY={viewportY}
-              zoom={zoom}
-              connectionMode={connectionMode}
-              connectionSourceId={connectionSourceId}
-              connectionSourcePosition={connectionSourcePosition}
-              mousePosition={mousePosition}
-              boundaryMode={boundaryMode}
-              boundarySourceId={boundarySourceId}
-              boundarySourceZoneInfo={boundarySourceZoneInfo}
-            />
-            <Background gap={15} size={1} />
-            <Controls />
-          </ReactFlow>
+          <DFDNotationProvider notationStyle={notationStyle}>
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onConnect={handleConnect}
+              onNodeClick={handleNodeClick}
+              onEdgeClick={handleEdgeClick}
+              onPaneClick={handlePaneClick}
+              onNodeDragStop={handleNodeDragStop}
+              nodeTypes={nodeTypes}
+              edgeTypes={edgeTypes}
+              connectionMode={ConnectionMode.Loose}
+              defaultEdgeOptions={{
+                type: 'dataFlow',
+                animated: true,
+              }}
+              fitView
+              snapToGrid
+              snapGrid={[15, 15]}
+              minZoom={0.1}
+              maxZoom={4}
+              deleteKeyCode={null}
+            >
+              <CanvasOverlays
+                viewportX={viewportX}
+                viewportY={viewportY}
+                zoom={zoom}
+                connectionMode={connectionMode}
+                connectionSourceId={connectionSourceId}
+                connectionSourcePosition={connectionSourcePosition}
+                mousePosition={mousePosition}
+                boundaryMode={boundaryMode}
+                boundarySourceId={boundarySourceId}
+                boundarySourceZoneInfo={boundarySourceZoneInfo}
+              />
+              <Background gap={15} size={1} />
+              <Controls />
+            </ReactFlow>
+          </DFDNotationProvider>
         </div>
 
         {/* Edit Panel */}

--- a/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
+++ b/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
@@ -4,6 +4,13 @@ import { User, Server, Cog, Database, Shield, Box, ArrowRight, LayoutTemplate, S
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -11,6 +18,7 @@ import {
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { DiagramNodeType } from '../types'
+import { type DFDNotationStyle, NOTATION_NODE_SIZES } from '../types/notation'
 
 interface DiagramToolbarProps {
   connectionMode: boolean
@@ -22,6 +30,8 @@ interface DiagramToolbarProps {
   onOpenThreatAnalysis: () => void
   hideTemplates?: boolean
   hideAnalyzeThreats?: boolean
+  notationStyle?: DFDNotationStyle
+  onNotationChange?: (notation: DFDNotationStyle) => void
 }
 
 interface ToolbarButtonConfig {
@@ -77,15 +87,6 @@ const nodeButtons: ToolbarButtonConfig[] = [
   },
 ]
 
-const DEFAULT_NODE_SIZES: Record<DiagramNodeType, { width: number; height: number }> = {
-  humanActor: { width: 100, height: 100 },
-  systemActor: { width: 100, height: 90 },
-  process: { width: 120, height: 60 },
-  datastore: { width: 120, height: 80 },
-  trustZone: { width: 300, height: 200 },
-  systemScope: { width: 300, height: 200 },
-}
-
 export const DiagramToolbar = memo(function DiagramToolbar({
   connectionMode,
   onConnectionModeChange,
@@ -96,12 +97,15 @@ export const DiagramToolbar = memo(function DiagramToolbar({
   onOpenThreatAnalysis,
   hideTemplates,
   hideAnalyzeThreats,
+  notationStyle = 'dfd3',
+  onNotationChange,
 }: DiagramToolbarProps) {
   const { addNodes, getNodes } = useReactFlow()
+  const nodeSizes = NOTATION_NODE_SIZES[notationStyle]
 
   const handleAddNode = (type: DiagramNodeType) => {
     const center = getCanvasCenterPosition()
-    const nodeSize = DEFAULT_NODE_SIZES[type]
+    const nodeSize = nodeSizes[type] ?? { width: 120, height: 70 }
     const position = {
       x: center.x - nodeSize.width / 2,
       y: center.y - nodeSize.height / 2,
@@ -120,17 +124,12 @@ export const DiagramToolbar = memo(function DiagramToolbar({
       systemScope: { label: 'System Scope' },
     }
 
-    // Default style for boundary nodes
-    const defaultStyle = (type === 'trustZone' || type === 'systemScope')
-      ? { width: 300, height: 200 }
-      : undefined
-
     addNodes({
       id,
       type,
       position,
       data: { ...defaultData[type], isNewlyInserted: true },
-      style: defaultStyle,
+      style: { width: nodeSize.width, height: nodeSize.height },
     })
 
     // Remove the "newly inserted" highlight after 2 seconds
@@ -183,7 +182,7 @@ export const DiagramToolbar = memo(function DiagramToolbar({
               onClick={() => onConnectionModeChange(!connectionMode)}
             >
               <ArrowRight className="h-4 w-4" />
-              <span className="hidden sm:inline">Draw Connection</span>
+              <span className="hidden sm:inline">Flow</span>
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
@@ -214,6 +213,24 @@ export const DiagramToolbar = memo(function DiagramToolbar({
             </p>
           </TooltipContent>
         </Tooltip>
+
+        {onNotationChange && (
+          <>
+            <Separator orientation="vertical" className="h-8 mx-2" />
+            <Select
+              value={notationStyle}
+              onValueChange={(value) => onNotationChange(value as DFDNotationStyle)}
+            >
+              <SelectTrigger className="h-8 w-[140px] text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="dfd3">DFD3</SelectItem>
+                <SelectItem value="yourdon">Yourdon</SelectItem>
+              </SelectContent>
+            </Select>
+          </>
+        )}
 
         {!hideTemplates && (
           <>

--- a/frontend/src/features/dfd-editor/components/nodes/DataStoreNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/DataStoreNode.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import type { DataStoreNodeData } from '../../types'
 import { DATA_SENSITIVITY_CONFIG } from '../../types'
 import { useTechnologyDisplayName } from '../../api/component-library'
+import { useDFDNotation } from '../../context/DFDNotationContext'
 
 type DataStoreNodeType = Node<DataStoreNodeData, 'datastore'>
 
@@ -15,6 +16,7 @@ export const DataStoreNode = memo(function DataStoreNode({
   const isNewlyInserted = data.isNewlyInserted
   const technologyDisplayName = useTechnologyDisplayName(data.technology)
   const [showLockAnimation, setShowLockAnimation] = useState(false)
+  const { notationStyle } = useDFDNotation()
 
   // Trigger lock animation when lockAnimationKey changes (new timestamp = new animation)
   useEffect(() => {
@@ -25,15 +27,17 @@ export const DataStoreNode = memo(function DataStoreNode({
     }
   }, [data.lockAnimationKey])
 
+  const isYourdon = notationStyle === 'yourdon'
+
   return (
     <>
       <NodeResizer
-        minWidth={120}
-        minHeight={50}
+        minWidth={isYourdon ? 80 : 120}
+        minHeight={isYourdon ? 30 : 50}
         isVisible={selected}
-        lineClassName="!border-solid"
+        lineClassName={isYourdon ? '!border-none' : '!border-solid'}
         handleClassName="!w-2 !h-2 !rounded-sm"
-        lineStyle={{ borderColor: '#a855f7' }}
+        lineStyle={isYourdon ? { borderColor: 'transparent' } : { borderColor: '#a855f7' }}
         handleStyle={{ backgroundColor: '#a855f7', borderColor: '#a855f7' }}
       />
       {/* Handles on all 4 sides for flexible edge routing */}
@@ -52,52 +56,78 @@ export const DataStoreNode = memo(function DataStoreNode({
 
       <div
         className={cn(
-          'w-full h-full relative min-w-[120px] transition-all',
-          isNewlyInserted && 'ring-2 ring-green-400 ring-offset-2 rounded-lg',
-          showLockAnimation && 'animate-lock-pulse ring-2 ring-orange-400 ring-offset-2 rounded-lg'
+          'w-full h-full relative transition-all',
+          !isYourdon && isNewlyInserted && 'ring-2 ring-green-400 ring-offset-2 rounded-lg',
+          !isYourdon && showLockAnimation && 'animate-lock-pulse ring-2 ring-orange-400 ring-offset-2 rounded-lg'
         )}
       >
-        {/* Cylinder shape using CSS */}
-        <div
-          className={cn(
-            'w-full h-full relative bg-purple-50 border-2 rounded-lg overflow-hidden flex flex-col',
-            selected ? 'border-purple-500 shadow-md' : 'border-purple-200'
-          )}
-        >
-          {/* Top ellipse */}
-          <div className="h-3 bg-purple-100 border-b border-purple-200 rounded-t-lg flex-shrink-0" />
-
-          {/* Body */}
-          <div className="px-4 py-3 flex-1">
-            <div className="flex items-center gap-2">
-              <Database className="h-4 w-4 text-purple-600 flex-shrink-0" />
-              <div className="flex flex-col min-w-0">
-                <span className="font-medium text-sm text-purple-900 truncate">
+        {isYourdon ? (
+          /* Yourdon/DeMarco: two parallel horizontal lines */
+          <div
+            className={cn(
+              'w-full h-full relative bg-purple-50 flex items-center border-t-2 border-b-2',
+              selected ? 'border-purple-500 shadow-md' : 'border-purple-200',
+              isNewlyInserted && 'shadow-[0_-2px_0_0_#4ade80,0_2px_0_0_#4ade80]',
+              showLockAnimation && 'animate-lock-pulse shadow-[0_-2px_0_0_#fb923c,0_2px_0_0_#fb923c]'
+            )}
+          >
+            <div className="px-3 py-1 flex items-center gap-2 w-full">
+              <Database className="h-3.5 w-3.5 text-purple-600 flex-shrink-0" />
+              <div className="flex flex-col min-w-0 flex-1">
+                <span className="font-medium text-xs text-purple-900 truncate">
                   {data.label}
                 </span>
                 {data.technology && (
-                  <span className="text-xs text-purple-600 truncate">
+                  <span className="text-[10px] text-purple-600 truncate">
                     {technologyDisplayName}
                   </span>
                 )}
               </div>
             </div>
-            {data.dataSensitivity && DATA_SENSITIVITY_CONFIG[data.dataSensitivity] && (
-              <div
-                className="mt-2 text-xs px-1.5 py-0.5 rounded text-center"
-                style={{
-                  backgroundColor: `${DATA_SENSITIVITY_CONFIG[data.dataSensitivity].color}20`,
-                  color: DATA_SENSITIVITY_CONFIG[data.dataSensitivity].color,
-                }}
-              >
-                {DATA_SENSITIVITY_CONFIG[data.dataSensitivity].label}
-              </div>
-            )}
           </div>
+        ) : (
+          /* DFD3: Cylinder shape using CSS */
+          <div
+            className={cn(
+              'w-full h-full relative bg-purple-50 border-2 rounded-lg overflow-hidden flex flex-col min-w-[120px]',
+              selected ? 'border-purple-500 shadow-md' : 'border-purple-200'
+            )}
+          >
+            {/* Top ellipse */}
+            <div className="h-3 bg-purple-100 border-b border-purple-200 rounded-t-lg flex-shrink-0" />
 
-          {/* Bottom ellipse */}
-          <div className="h-3 bg-purple-100 border-t border-purple-200 rounded-b-lg flex-shrink-0" />
-        </div>
+            {/* Body */}
+            <div className="px-4 py-3 flex-1">
+              <div className="flex items-center gap-2">
+                <Database className="h-4 w-4 text-purple-600 flex-shrink-0" />
+                <div className="flex flex-col min-w-0">
+                  <span className="font-medium text-sm text-purple-900 truncate">
+                    {data.label}
+                  </span>
+                  {data.technology && (
+                    <span className="text-xs text-purple-600 truncate">
+                      {technologyDisplayName}
+                    </span>
+                  )}
+                </div>
+              </div>
+              {data.dataSensitivity && DATA_SENSITIVITY_CONFIG[data.dataSensitivity] && (
+                <div
+                  className="mt-2 text-xs px-1.5 py-0.5 rounded text-center"
+                  style={{
+                    backgroundColor: `${DATA_SENSITIVITY_CONFIG[data.dataSensitivity].color}20`,
+                    color: DATA_SENSITIVITY_CONFIG[data.dataSensitivity].color,
+                  }}
+                >
+                  {DATA_SENSITIVITY_CONFIG[data.dataSensitivity].label}
+                </div>
+              )}
+            </div>
+
+            {/* Bottom ellipse */}
+            <div className="h-3 bg-purple-100 border-t border-purple-200 rounded-b-lg flex-shrink-0" />
+          </div>
+        )}
       </div>
     </>
   )

--- a/frontend/src/features/dfd-editor/components/nodes/ProcessNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/ProcessNode.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import type { ProcessNodeData } from '../../types'
 import { DATA_SENSITIVITY_CONFIG } from '../../types'
 import { useTechnologyDisplayName } from '../../api/component-library'
+import { useDFDNotation } from '../../context/DFDNotationContext'
 
 type ProcessNodeType = Node<ProcessNodeData, 'process'>
 
@@ -42,6 +43,7 @@ export const ProcessNode = memo(function ProcessNode({
   const technologyDisplayName = useTechnologyDisplayName(data.technology)
   const [showLockAnimation, setShowLockAnimation] = useState(false)
   const [showReceiveAnimation, setShowReceiveAnimation] = useState(false)
+  const { notationStyle } = useDFDNotation()
 
   // Check if this process has children (makes it a container)
   const isContainer = useStore(
@@ -69,6 +71,8 @@ export const ProcessNode = memo(function ProcessNode({
     }
   }, [data.receiveChildAnimationKey])
 
+  const isYourdon = notationStyle === 'yourdon' && !isContainer
+
   // ── Unified render path ──
   // Always renders the same DOM structure (NodeResizer → Handles → div) regardless
   // of leaf/container mode. This mirrors TrustZoneNode's always-container pattern
@@ -76,8 +80,8 @@ export const ProcessNode = memo(function ProcessNode({
   return (
     <>
       <NodeResizer
-        minWidth={isContainer ? 250 : 120}
-        minHeight={isContainer ? 180 : 50}
+        minWidth={isContainer ? 250 : isYourdon ? 60 : 120}
+        minHeight={isContainer ? 180 : isYourdon ? 60 : 50}
         isVisible={selected}
         lineClassName="!border-solid"
         handleClassName="!w-2 !h-2 !rounded-sm"
@@ -87,18 +91,24 @@ export const ProcessNode = memo(function ProcessNode({
       <ProcessHandles />
       <div
         className={cn(
-          'w-full h-full rounded-lg border-2 transition-all',
+          'w-full h-full border-2 transition-all',
           isContainer
             ? cn(
-                'border-solid',
+                'rounded-lg border-solid',
                 selected ? 'border-blue-500 shadow-md' : 'border-blue-300',
                 showReceiveAnimation && 'animate-lock-pulse ring-2 ring-orange-400 ring-offset-2'
               )
-            : cn(
-                'px-4 py-3 bg-blue-50 min-w-[120px]',
-                selected ? 'border-blue-500 shadow-md' : 'border-blue-200',
-                showLockAnimation && 'animate-lock-pulse ring-2 ring-orange-400 ring-offset-2'
-              ),
+            : isYourdon
+              ? cn(
+                  'rounded-full bg-blue-50 flex flex-col items-center justify-center',
+                  selected ? 'border-blue-500 shadow-md' : 'border-blue-200',
+                  showLockAnimation && 'animate-lock-pulse ring-2 ring-orange-400 ring-offset-2'
+                )
+              : cn(
+                  'rounded-lg px-4 py-3 bg-blue-50 min-w-[120px] flex items-center',
+                  selected ? 'border-blue-500 shadow-md' : 'border-blue-200',
+                  showLockAnimation && 'animate-lock-pulse ring-2 ring-orange-400 ring-offset-2'
+                ),
           isNewlyInserted && 'ring-2 ring-green-400 ring-offset-2'
         )}
         style={isContainer ? { backgroundColor: 'rgba(219, 234, 254, 0.4)' } : undefined}
@@ -127,6 +137,18 @@ export const ProcessNode = memo(function ProcessNode({
               >
                 {DATA_SENSITIVITY_CONFIG[data.dataSensitivity].label}
               </div>
+            )}
+          </>
+        ) : isYourdon ? (
+          <>
+            <Cog className="h-4 w-4 text-blue-600 flex-shrink-0" />
+            <span className="font-medium text-xs text-blue-900 truncate max-w-[90%] text-center px-1">
+              {data.label}
+            </span>
+            {(data.technology || data.dataSensitivity) && (
+              <span className="text-[10px] text-blue-600 truncate max-w-[90%]" title={[technologyDisplayName, data.dataSensitivity && DATA_SENSITIVITY_CONFIG[data.dataSensitivity]?.label].filter(Boolean).join(' / ')}>
+                {technologyDisplayName || (data.dataSensitivity && DATA_SENSITIVITY_CONFIG[data.dataSensitivity]?.label) || ''}
+              </span>
             )}
           </>
         ) : (

--- a/frontend/src/features/dfd-editor/components/panels/NodeEditPanel.tsx
+++ b/frontend/src/features/dfd-editor/components/panels/NodeEditPanel.tsx
@@ -360,17 +360,29 @@ export const NodeEditPanel = memo(function NodeEditPanel({
           <>
             <div className="space-y-2">
               <Label>Technology</Label>
-              <TechnologyCombobox
-                value={(node.data as { technology?: string }).technology || ''}
-                onChange={handleTechnologyChange}
-                filterNodeType={node.type as 'process' | 'datastore'}
-                placeholder={
-                  node.type === 'datastore'
-                    ? 'Select storage/database...'
-                    : 'Select compute/backend...'
-                }
-                threatModelId={threatModelId}
-              />
+              {threatModelId ? (
+                <TechnologyCombobox
+                  value={(node.data as { technology?: string }).technology || ''}
+                  onChange={handleTechnologyChange}
+                  filterNodeType={node.type as 'process' | 'datastore'}
+                  placeholder={
+                    node.type === 'datastore'
+                      ? 'Select storage/database...'
+                      : 'Select compute/backend...'
+                  }
+                  threatModelId={threatModelId}
+                />
+              ) : (
+                <Input
+                  value={(node.data as { technology?: string }).technology || ''}
+                  onChange={(e) => updateNodeData({ technology: e.target.value })}
+                  placeholder={
+                    node.type === 'datastore'
+                      ? 'e.g., PostgreSQL, Redis...'
+                      : 'e.g., Node.js, Python...'
+                  }
+                />
+              )}
             </div>
 
             {node.type === 'datastore' && (
@@ -677,13 +689,21 @@ export const NodeEditPanel = memo(function NodeEditPanel({
 
             <div className="space-y-2">
               <Label>Technology</Label>
-              <TechnologyCombobox
-                value={(node.data as { technology?: string }).technology || ''}
-                onChange={(value) => updateNodeData({ technology: value })}
-                filterNodeType="trustZone"
-                placeholder="Select networking/security..."
-                threatModelId={threatModelId}
-              />
+              {threatModelId ? (
+                <TechnologyCombobox
+                  value={(node.data as { technology?: string }).technology || ''}
+                  onChange={(value) => updateNodeData({ technology: value })}
+                  filterNodeType="trustZone"
+                  placeholder="Select networking/security..."
+                  threatModelId={threatModelId}
+                />
+              ) : (
+                <Input
+                  value={(node.data as { technology?: string }).technology || ''}
+                  onChange={(e) => updateNodeData({ technology: e.target.value })}
+                  placeholder="e.g., AWS VPC, Firewall..."
+                />
+              )}
             </div>
 
             {/* Trust Boundaries (read-only) */}
@@ -770,13 +790,21 @@ export const NodeEditPanel = memo(function NodeEditPanel({
           <>
             <div className="space-y-2">
               <Label>Technology</Label>
-              <TechnologyCombobox
-                value={(node.data as { technology?: string }).technology || ''}
-                onChange={(value) => updateNodeData({ technology: value })}
-                filterNodeType="systemScope"
-                placeholder="Select infrastructure..."
-                threatModelId={threatModelId}
-              />
+              {threatModelId ? (
+                <TechnologyCombobox
+                  value={(node.data as { technology?: string }).technology || ''}
+                  onChange={(value) => updateNodeData({ technology: value })}
+                  filterNodeType="systemScope"
+                  placeholder="Select infrastructure..."
+                  threatModelId={threatModelId}
+                />
+              ) : (
+                <Input
+                  value={(node.data as { technology?: string }).technology || ''}
+                  onChange={(e) => updateNodeData({ technology: e.target.value })}
+                  placeholder="e.g., AWS, Kubernetes..."
+                />
+              )}
             </div>
 
             <div className="space-y-2">

--- a/frontend/src/features/dfd-editor/context/DFDNotationContext.tsx
+++ b/frontend/src/features/dfd-editor/context/DFDNotationContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import type { DFDNotationStyle } from '../types/notation'
+
+interface DFDNotationContextValue {
+  notationStyle: DFDNotationStyle
+}
+
+const DFDNotationContext = createContext<DFDNotationContextValue>({
+  notationStyle: 'dfd3',
+})
+
+export function DFDNotationProvider({
+  notationStyle,
+  children,
+}: {
+  notationStyle: DFDNotationStyle
+  children: ReactNode
+}) {
+  return (
+    <DFDNotationContext.Provider value={{ notationStyle }}>
+      {children}
+    </DFDNotationContext.Provider>
+  )
+}
+
+export function useDFDNotation(): DFDNotationContextValue {
+  return useContext(DFDNotationContext)
+}

--- a/frontend/src/features/dfd-editor/hooks/useDiagramState.ts
+++ b/frontend/src/features/dfd-editor/hooks/useDiagramState.ts
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { applyNodeChanges, applyEdgeChanges } from '@xyflow/react'
 import type { NodeChange, EdgeChange } from '@xyflow/react'
 import type { Diagram, DiagramNode, DiagramEdge } from '../types'
+import type { DFDNotationStyle } from '../types/notation'
 import { api } from '@/lib/api'
 // Undo feature - remove this import to disable undo functionality
 import { useUndoHistory } from './useUndoHistory'
@@ -17,6 +18,7 @@ interface UseDiagramStateReturn {
   diagram: Diagram | undefined
   nodes: DiagramNode[]
   edges: DiagramEdge[]
+  initialNotationStyle: DFDNotationStyle
 
   // Loading states
   isLoading: boolean
@@ -29,7 +31,7 @@ interface UseDiagramStateReturn {
   setEdges: React.Dispatch<React.SetStateAction<DiagramEdge[]>>
   onNodesChange: (changes: NodeChange<DiagramNode>[]) => void
   onEdgesChange: (changes: EdgeChange<DiagramEdge>[]) => void
-  saveNow: () => Promise<void>
+  saveNow: (notationStyle?: DFDNotationStyle) => Promise<void>
   updateTitle: (title: string) => Promise<void>
   // Undo feature - remove this line to disable undo functionality
   undo: () => void
@@ -47,12 +49,13 @@ async function fetchDiagram(diagramId: string): Promise<Diagram> {
 
 async function saveDiagram(
   diagramId: string,
-  data: { nodes: DiagramNode[]; edges: DiagramEdge[] }
+  data: { nodes: DiagramNode[]; edges: DiagramEdge[]; notationStyle?: DFDNotationStyle }
 ): Promise<Diagram> {
   return api.patch<Diagram>(`/diagrams/${diagramId}/`, {
     canvas_data: {
       nodes: data.nodes,
       edges: data.edges,
+      notationStyle: data.notationStyle,
     },
   })
 }
@@ -75,6 +78,8 @@ export function useDiagramState({
   const [edges, setEdgesInternal] = useState<DiagramEdge[]>([])
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
   const [lastSaved, setLastSaved] = useState<Date | null>(null)
+  const [initialNotationStyle, setInitialNotationStyle] = useState<DFDNotationStyle>('dfd3')
+  const notationStyleRef = useRef<DFDNotationStyle>('dfd3')
 
   // Track if initial data has been loaded
   const initialLoadRef = useRef(false)
@@ -125,7 +130,7 @@ export function useDiagramState({
 
   // Save mutation
   const saveMutation = useMutation({
-    mutationFn: (data: { nodes: DiagramNode[]; edges: DiagramEdge[] }) =>
+    mutationFn: (data: { nodes: DiagramNode[]; edges: DiagramEdge[]; notationStyle?: DFDNotationStyle }) =>
       saveDiagram(diagramId, data),
     onSuccess: (updatedDiagram) => {
       queryClient.setQueryData(['diagram', diagramId], updatedDiagram)
@@ -205,6 +210,9 @@ export function useDiagramState({
       // Use internal setters during initial load to avoid marking as changed
       setNodesInternal((canvasData?.nodes || []) as DiagramNode[])
       setEdgesInternal((canvasData?.edges || []) as DiagramEdge[])
+      const loadedNotation = canvasData?.notationStyle ?? 'dfd3'
+      setInitialNotationStyle(loadedNotation)
+      notationStyleRef.current = loadedNotation
       const updatedAt = diagram.updatedAt
       if (updatedAt) setLastSaved(new Date(updatedAt))
       initialLoadRef.current = true
@@ -253,15 +261,17 @@ export function useDiagramState({
     if (autoSaveInterval <= 0 || !hasUnsavedChanges) return
 
     const timer = setTimeout(() => {
-      saveMutation.mutate({ nodes, edges })
+      saveMutation.mutate({ nodes, edges, notationStyle: notationStyleRef.current })
     }, autoSaveInterval)
 
     return () => clearTimeout(timer)
   }, [nodes, edges, hasUnsavedChanges, autoSaveInterval, saveMutation])
 
-  // Save now function
-  const saveNow = useCallback(async () => {
-    await saveMutation.mutateAsync({ nodes, edges })
+  // Save now function — accepts optional notationStyle override to capture latest value
+  const saveNow = useCallback(async (currentNotationStyle?: DFDNotationStyle) => {
+    const styleToSave = currentNotationStyle ?? notationStyleRef.current
+    notationStyleRef.current = styleToSave
+    await saveMutation.mutateAsync({ nodes, edges, notationStyle: styleToSave })
   }, [nodes, edges, saveMutation])
 
   // Update title function
@@ -296,6 +306,7 @@ export function useDiagramState({
     diagram,
     nodes,
     edges,
+    initialNotationStyle,
     isLoading,
     isSaving: saveMutation.isPending,
     isError,

--- a/frontend/src/features/dfd-editor/types/diagram.ts
+++ b/frontend/src/features/dfd-editor/types/diagram.ts
@@ -1,4 +1,5 @@
 import type { Node, Edge } from '@xyflow/react'
+import type { DFDNotationStyle } from './notation'
 
 // Re-export domain types for convenience
 export {
@@ -160,6 +161,7 @@ export type DiagramEdge = DataFlowEdge | TrustBoundaryEdge
 export interface CanvasData {
   nodes: DiagramNode[]
   edges: DiagramEdge[]
+  notationStyle?: DFDNotationStyle
 }
 
 // Diagram entity

--- a/frontend/src/features/dfd-editor/types/index.ts
+++ b/frontend/src/features/dfd-editor/types/index.ts
@@ -1,2 +1,3 @@
 export * from './diagram'
 export * from './threat-analysis'
+export * from './notation'

--- a/frontend/src/features/dfd-editor/types/notation.ts
+++ b/frontend/src/features/dfd-editor/types/notation.ts
@@ -1,0 +1,21 @@
+export type DFDNotationStyle = 'dfd3' | 'yourdon'
+export const DEFAULT_NOTATION: DFDNotationStyle = 'dfd3'
+
+export const NOTATION_NODE_SIZES: Record<DFDNotationStyle, Record<string, { width: number; height: number }>> = {
+  dfd3: {
+    process: { width: 150, height: 70 },
+    datastore: { width: 170, height: 70 },
+    humanActor: { width: 100, height: 100 },
+    systemActor: { width: 100, height: 90 },
+    trustZone: { width: 300, height: 200 },
+    systemScope: { width: 300, height: 200 },
+  },
+  yourdon: {
+    process: { width: 100, height: 100 },
+    datastore: { width: 170, height: 40 },
+    humanActor: { width: 100, height: 100 },
+    systemActor: { width: 100, height: 90 },
+    trustZone: { width: 300, height: 200 },
+    systemScope: { width: 300, height: 200 },
+  },
+}

--- a/frontend/src/features/guest-editor/GuestDFDEditor.tsx
+++ b/frontend/src/features/guest-editor/GuestDFDEditor.tsx
@@ -18,6 +18,7 @@ import { DiagramToolbar } from '@/features/dfd-editor/components/DiagramToolbar'
 import { NodeEditPanel } from '@/features/dfd-editor/components/panels/NodeEditPanel'
 import { EdgeEditPanel } from '@/features/dfd-editor/components/panels/EdgeEditPanel'
 import { TrustBoundaryEdgeEditPanel } from '@/features/dfd-editor/components/panels/TrustBoundaryEdgeEditPanel'
+import { DFDNotationProvider } from '@/features/dfd-editor/context/DFDNotationContext'
 import { useParentRelationships } from '@/features/dfd-editor/hooks/useParentRelationships'
 import { useKeyboardShortcuts } from '@/features/dfd-editor/hooks/useKeyboardShortcuts'
 import { useConnectionMode } from '@/features/dfd-editor/hooks/useConnectionMode'
@@ -28,6 +29,7 @@ import type {
   DataFlowEdge,
   TrustBoundaryEdge,
 } from '@/features/dfd-editor/types'
+import { type DFDNotationStyle, NOTATION_NODE_SIZES } from '@/features/dfd-editor/types/notation'
 import { GuestThreatSection } from './components/GuestThreatSection'
 import { guestNodeTypes, guestEdgeTypes } from './components/GuestNodeWrapper'
 import type { GuestDiagramOutletContext } from './GuestLayout'
@@ -45,7 +47,43 @@ function GuestDFDEditorContent() {
     onNodesChange,
     onEdgesChange,
     undo,
+    notationStyle,
+    setNotationStyle,
   } = useOutletContext<GuestDiagramOutletContext>()
+
+  // Handle notation change — resize affected nodes
+  const handleNotationChange = useCallback(
+    (newNotation: DFDNotationStyle) => {
+      setNotationStyle(newNotation)
+      const newSizes = NOTATION_NODE_SIZES[newNotation]
+
+      setNodes((currentNodes) => {
+        const containerProcessIds = new Set(
+          currentNodes
+            .filter((n) => n.parentId)
+            .map((n) => n.parentId!)
+            .filter((parentId) => currentNodes.find((n) => n.id === parentId)?.type === 'process')
+        )
+
+        return currentNodes.map((node) => {
+          if (
+            (node.type === 'process' && !containerProcessIds.has(node.id)) ||
+            node.type === 'datastore'
+          ) {
+            const defaultSize = newSizes[node.type]
+            if (defaultSize) {
+              return {
+                ...node,
+                style: { ...node.style, width: defaultSize.width, height: defaultSize.height },
+              }
+            }
+          }
+          return node
+        })
+      })
+    },
+    [setNodes, setNotationStyle]
+  )
 
   // State for UI
   const [selectedNode, setSelectedNode] = useState<DiagramNode | null>(null)
@@ -212,50 +250,54 @@ function GuestDFDEditorContent() {
         onOpenTemplates={() => {}}
         onOpenThreatAnalysis={() => navigate('/guest/threats')}
         hideTemplates
+        notationStyle={notationStyle}
+        onNotationChange={handleNotationChange}
       />
 
       <div className="flex flex-1 overflow-hidden">
         {/* Canvas */}
         <div className="flex-1" ref={reactFlowWrapper} onMouseMove={handleMouseMove}>
-          <ReactFlow
-            nodes={nodes}
-            edges={edges}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
-            onConnect={handleConnect}
-            onNodeClick={handleNodeClick}
-            onEdgeClick={handleEdgeClick}
-            onPaneClick={handlePaneClick}
-            onNodeDragStop={handleNodeDragStop}
-            nodeTypes={guestNodeTypes}
-            edgeTypes={guestEdgeTypes}
-            connectionMode={ConnectionMode.Loose}
-            defaultEdgeOptions={{
-              type: 'dataFlow',
-              animated: true,
-            }}
-            fitView
-            snapToGrid
-            snapGrid={[15, 15]}
-            minZoom={0.1}
-            maxZoom={4}
-            deleteKeyCode={null}
-          >
-            <CanvasOverlays
-              viewportX={viewportX}
-              viewportY={viewportY}
-              zoom={zoom}
-              connectionMode={connectionMode}
-              connectionSourceId={connectionSourceId}
-              connectionSourcePosition={connectionSourcePosition}
-              mousePosition={mousePosition}
-              boundaryMode={boundaryMode}
-              boundarySourceId={boundarySourceId}
-              boundarySourceZoneInfo={boundarySourceZoneInfo}
-            />
-            <Background gap={15} size={1} />
-            <Controls />
-          </ReactFlow>
+          <DFDNotationProvider notationStyle={notationStyle}>
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onConnect={handleConnect}
+              onNodeClick={handleNodeClick}
+              onEdgeClick={handleEdgeClick}
+              onPaneClick={handlePaneClick}
+              onNodeDragStop={handleNodeDragStop}
+              nodeTypes={guestNodeTypes}
+              edgeTypes={guestEdgeTypes}
+              connectionMode={ConnectionMode.Loose}
+              defaultEdgeOptions={{
+                type: 'dataFlow',
+                animated: true,
+              }}
+              fitView
+              snapToGrid
+              snapGrid={[15, 15]}
+              minZoom={0.1}
+              maxZoom={4}
+              deleteKeyCode={null}
+            >
+              <CanvasOverlays
+                viewportX={viewportX}
+                viewportY={viewportY}
+                zoom={zoom}
+                connectionMode={connectionMode}
+                connectionSourceId={connectionSourceId}
+                connectionSourcePosition={connectionSourcePosition}
+                mousePosition={mousePosition}
+                boundaryMode={boundaryMode}
+                boundarySourceId={boundarySourceId}
+                boundarySourceZoneInfo={boundarySourceZoneInfo}
+              />
+              <Background gap={15} size={1} />
+              <Controls />
+            </ReactFlow>
+          </DFDNotationProvider>
         </div>
 
         {/* Edit Panels */}

--- a/frontend/src/features/guest-editor/GuestLayout.tsx
+++ b/frontend/src/features/guest-editor/GuestLayout.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import type { NodeChange, EdgeChange } from '@xyflow/react'
 import type { DiagramNode, DiagramEdge } from '@/features/dfd-editor/types'
+import type { DFDNotationStyle } from '@/features/dfd-editor/types/notation'
 import { useGuestDiagramState } from './hooks/useGuestDiagramState'
 import { useGuestThreats } from './hooks/useGuestThreats'
 import { useGuestCountermeasures } from './hooks/useGuestCountermeasures'
@@ -17,12 +18,15 @@ export interface GuestDiagramOutletContext {
   onEdgesChange: (changes: EdgeChange<DiagramEdge>[]) => void
   undo: () => void
   canUndo: boolean
+  notationStyle: DFDNotationStyle
+  setNotationStyle: (notation: DFDNotationStyle) => void
 }
 
 export function GuestLayout() {
   const diagramState = useGuestDiagramState()
   const threatOps = useGuestThreats()
   const countermeasureOps = useGuestCountermeasures()
+  const [notationStyle, setNotationStyle] = useState<DFDNotationStyle>('dfd3')
 
   // Wrap removeThreat to cascade-delete countermeasures
   const removeThreatWithCascade = useCallback(
@@ -89,6 +93,8 @@ export function GuestLayout() {
       onEdgesChange: diagramState.onEdgesChange,
       undo: diagramState.undo,
       canUndo: diagramState.canUndo,
+      notationStyle,
+      setNotationStyle,
     }),
     [
       diagramState.nodes,
@@ -99,7 +105,16 @@ export function GuestLayout() {
       diagramState.onEdgesChange,
       diagramState.undo,
       diagramState.canUndo,
+      notationStyle,
     ]
+  )
+
+  const handleLoadFromFile = useCallback(
+    (data: { title: string; nodes: DiagramNode[]; edges: DiagramEdge[]; notationStyle?: DFDNotationStyle }) => {
+      diagramState.loadFromFile(data)
+      setNotationStyle(data.notationStyle ?? 'dfd3')
+    },
+    [diagramState.loadFromFile]
   )
 
   return (
@@ -110,7 +125,8 @@ export function GuestLayout() {
           onTitleChange={diagramState.setTitle}
           hasUnsavedChanges={diagramState.hasUnsavedChanges}
           onMarkSaved={diagramState.markSaved}
-          onLoadFromFile={diagramState.loadFromFile}
+          onLoadFromFile={handleLoadFromFile}
+          notationStyle={notationStyle}
         />
         <Outlet context={outletContext} />
       </div>

--- a/frontend/src/features/guest-editor/components/GuestEditorHeader.tsx
+++ b/frontend/src/features/guest-editor/components/GuestEditorHeader.tsx
@@ -30,7 +30,8 @@ interface GuestEditorHeaderProps {
   onTitleChange: (title: string) => void
   hasUnsavedChanges: boolean
   onMarkSaved: () => void
-  onLoadFromFile: (data: { title: string; nodes: import('@/features/dfd-editor/types').DiagramNode[]; edges: import('@/features/dfd-editor/types').DiagramEdge[] }) => void
+  onLoadFromFile: (data: { title: string; nodes: import('@/features/dfd-editor/types').DiagramNode[]; edges: import('@/features/dfd-editor/types').DiagramEdge[]; notationStyle?: import('@/features/dfd-editor/types/notation').DFDNotationStyle }) => void
+  notationStyle?: import('@/features/dfd-editor/types/notation').DFDNotationStyle
 }
 
 export function GuestEditorHeader({
@@ -39,6 +40,7 @@ export function GuestEditorHeader({
   hasUnsavedChanges,
   onMarkSaved,
   onLoadFromFile,
+  notationStyle,
 }: GuestEditorHeaderProps) {
   const navigate = useNavigate()
   const guestEditor = useGuestEditor()
@@ -92,17 +94,18 @@ export function GuestEditorHeader({
       guestEditor.nodes,
       guestEditor.edges,
       threats,
-      countermeasures
+      countermeasures,
+      notationStyle
     )
     downloadTmLibraryFile(filename, content)
     onMarkSaved()
     setShowSaveDialog(false)
-  }, [saveFilename, title, guestEditor, onMarkSaved])
+  }, [saveFilename, title, guestEditor, onMarkSaved, notationStyle])
 
   const handleOpen = useCallback(async () => {
     try {
       const data = await openTmLibraryFile()
-      onLoadFromFile({ title: data.title, nodes: data.nodes, edges: data.edges })
+      onLoadFromFile({ title: data.title, nodes: data.nodes, edges: data.edges, notationStyle: data.notationStyle })
       if (guestEditor) {
         guestEditor.loadThreats(data.threats)
         guestEditor.loadCountermeasures(data.countermeasures)

--- a/frontend/src/features/guest-editor/hooks/useGuestDiagramState.ts
+++ b/frontend/src/features/guest-editor/hooks/useGuestDiagramState.ts
@@ -2,12 +2,14 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { applyNodeChanges, applyEdgeChanges } from '@xyflow/react'
 import type { NodeChange, EdgeChange } from '@xyflow/react'
 import type { DiagramNode, DiagramEdge } from '@/features/dfd-editor/types'
+import type { DFDNotationStyle } from '@/features/dfd-editor/types/notation'
 import { useUndoHistory } from '@/features/dfd-editor/hooks/useUndoHistory'
 
 interface LoadFromFileData {
   title: string
   nodes: DiagramNode[]
   edges: DiagramEdge[]
+  notationStyle?: DFDNotationStyle
 }
 
 interface UseGuestDiagramStateReturn {

--- a/frontend/src/features/guest-editor/lib/precogly-file.ts
+++ b/frontend/src/features/guest-editor/lib/precogly-file.ts
@@ -1,4 +1,5 @@
 import type { DiagramNode, DiagramEdge } from '@/features/dfd-editor/types'
+import type { DFDNotationStyle } from '@/features/dfd-editor/types/notation'
 import type {
   GuestThreat,
   GuestCountermeasure,
@@ -31,7 +32,8 @@ export function serializeToTmLibrary(
   nodes: DiagramNode[],
   edges: DiagramEdge[],
   threats: GuestThreat[],
-  countermeasures: GuestCountermeasure[]
+  countermeasures: GuestCountermeasure[],
+  notationStyle?: DFDNotationStyle
 ): string {
   const now = new Date().toISOString()
 
@@ -150,7 +152,7 @@ export function serializeToTmLibrary(
     controls: tmControls,
     risks: [],
     extensions: {
-      'precogly.org/canvas-data': { nodes, edges },
+      'precogly.org/canvas-data': { nodes, edges, notationStyle },
       'precogly.org/guest-metadata': {
         generator: 'precogly-guest',
         createdAt: now,
@@ -170,6 +172,7 @@ interface DeserializedFile {
   edges: DiagramEdge[]
   threats: GuestThreat[]
   countermeasures: GuestCountermeasure[]
+  notationStyle?: DFDNotationStyle
 }
 
 // --- Deserialization: TM-Library JSON → in-memory state ---
@@ -195,6 +198,7 @@ function deserializeTmLibrary(json: string): DeserializedFile {
   const title = parsed.scope?.title || 'Untitled Diagram'
   const nodes: DiagramNode[] = canvasData.nodes
   const edges: DiagramEdge[] = canvasData.edges
+  const notationStyleValue = canvasData.notationStyle as DFDNotationStyle | undefined
 
   // Reconstruct GuestThreat[] from threats[]
   const threats: GuestThreat[] = (parsed.threats || []).map(
@@ -244,7 +248,7 @@ function deserializeTmLibrary(json: string): DeserializedFile {
     })
   )
 
-  return { title, nodes, edges, threats, countermeasures }
+  return { title, nodes, edges, threats, countermeasures, notationStyle: notationStyleValue }
 }
 
 // --- Legacy .precogly format ---

--- a/frontend/src/features/guest-editor/types.ts
+++ b/frontend/src/features/guest-editor/types.ts
@@ -89,6 +89,7 @@ export interface TmLibraryControl {
 export interface CanvasDataExtension {
   nodes: DiagramNode[]
   edges: DiagramEdge[]
+  notationStyle?: import('@/features/dfd-editor/types/notation').DFDNotationStyle
 }
 
 export interface GuestMetadataExtension {


### PR DESCRIPTION
  Add per-diagram notation selection between DFD3 and Yourdon/DeMarco.
  Process nodes render as circles and data stores as parallel lines in
  Yourdon mode. Switching notation resizes affected nodes to the new
  defaults. Notation persists in canvasData for signed-in, guest export,
  and read-only views.

  Also standardizes default node dimensions, vertically centers process
  node labels, and replaces the technology pack selector with a free-text
  input in guest mode.

  Closes #83