### PR TITLE
Fixes #155 mouse wheel not scrolling CommandList inside Popover (#155)

### DIFF
--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -82,15 +82,34 @@ function CommandInput({
 
 function CommandList({
   className,
+  onWheel,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.List>) {
+  const listRef = React.useRef<React.ElementRef<typeof CommandPrimitive.List>>(null)
+
   return (
     <CommandPrimitive.List
+      ref={listRef}
       data-slot="command-list"
       className={cn(
         "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
         className
       )}
+      // Popover/Popper positions its content with `position: fixed` plus a CSS
+      // `transform` (see @radix-ui/react-popper). Nesting a native
+      // `overflow-y: auto` scroller inside that kind of ancestor is a known spot
+      // where some browsers (Chrome on Windows in particular) fail to deliver
+      // physical mouse-wheel deltas to the scroll container — trackpad scroll
+      // still works because it goes through a different code path. Scrolling
+      // the list manually sidesteps the broken native delegation entirely, so
+      // it behaves the same for every input device.
+      onWheel={(event) => {
+        onWheel?.(event)
+        if (listRef.current) {
+          event.preventDefault()
+          listRef.current.scrollTop += event.deltaY
+        }
+      }}
       {...props}
     />
   )


### PR DESCRIPTION
Fixes #155 Radix Popover positions its content with position: fixed plus a CSS transform. Nesting a native overflow-y: auto scroller inside that kind of ancestor is a known spot where some browsers (Chrome on Windows in particular) fail to deliver physical mouse-wheel deltas to the scroll container, while trackpad scroll still works since it goes through a different code path.

CommandList now handles onWheel manually and drives scrollTop directly, bypassing the broken native delegation. This is a shared primitive, so it fixes every Command-based dropdown in the app, not just the Data Sensitivity picker.

https://github.com/user-attachments/assets/641f546b-ee81-49f1-b26d-1e99d3a5b241

