### PR TITLE
Fix: Add skeletons to all the pages instead of bare spinners

### DIFF
--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/frontend/src/features/organization/pages/BusinessUnitsSettings.tsx
+++ b/frontend/src/features/organization/pages/BusinessUnitsSettings.tsx
@@ -38,7 +38,8 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog'
-import { Plus, Pencil, Trash2, Loader2 } from 'lucide-react'
+import { Plus, Pencil, Trash2, Loader2, AlertCircle } from 'lucide-react'
+import { Skeleton } from '@/components/ui/skeleton'
 
 export function BusinessUnitsSettings() {
   const { currentOrganization, isLoading: workspaceLoading, isSecurityTeam } = useWorkspace()
@@ -61,11 +62,66 @@ export function BusinessUnitsSettings() {
   const label = currentOrganization?.businessUnitLabel ?? 'Business Units'
 
   if (workspaceLoading || busLoading) {
-    return <div>Loading...</div>
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div>
+                <Skeleton className="h-6 w-36" />
+                <Skeleton className="h-4 w-64 mt-2" />
+              </div>
+              <Skeleton className="h-10 w-40" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Code</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead>Parent</TableHead>
+                  <TableHead className="w-24">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <TableRow key={i}>
+                    <TableCell><Skeleton className="h-4 w-28" /></TableCell>
+                    <TableCell><Skeleton className="h-4 w-16" /></TableCell>
+                    <TableCell><Skeleton className="h-4 w-40" /></TableCell>
+                    <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-1">
+                        <Skeleton className="h-8 w-8 rounded-md" />
+                        <Skeleton className="h-8 w-8 rounded-md" />
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    )
   }
 
   if (!currentOrganization) {
-    return <div>No organization selected.</div>
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+            <AlertCircle className="h-10 w-10 text-muted-foreground mb-3" />
+            <p className="text-lg font-medium">No organization selected</p>
+            <p className="text-sm text-muted-foreground mt-1">
+              Select an organization from the workspace switcher to manage business units.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
   }
 
   const handleCreate = () => {

--- a/frontend/src/features/organization/pages/MemberManagement.tsx
+++ b/frontend/src/features/organization/pages/MemberManagement.tsx
@@ -38,7 +38,9 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Trash2 } from 'lucide-react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Trash2, AlertCircle } from 'lucide-react'
+import type { ApiError } from '@/lib/api'
 
 const roleLabels: Record<string, string> = {
   security_team: 'Security Team',
@@ -75,11 +77,54 @@ export function MemberManagement() {
   )
 
   if (workspaceLoading || membersLoading) {
-    return <div>Loading...</div>
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-4 w-96 mt-2" />
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Joined</TableHead>
+                  <TableHead className="w-20">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <TableRow key={i}>
+                    <TableCell><Skeleton className="h-4 w-44" /></TableCell>
+                    <TableCell><Skeleton className="h-5 w-24 rounded-full" /></TableCell>
+                    <TableCell><Skeleton className="h-4 w-28" /></TableCell>
+                    <TableCell><Skeleton className="h-8 w-8 rounded-md" /></TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    )
   }
 
   if (!currentOrganization) {
-    return <div>No organization selected.</div>
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+            <AlertCircle className="h-10 w-10 text-muted-foreground mb-3" />
+            <p className="text-lg font-medium">No organization selected</p>
+            <p className="text-sm text-muted-foreground mt-1">
+              Select an organization from the workspace switcher to manage its members.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
   }
 
   const handleRemove = (userId: number, userEmail: string) => {
@@ -97,8 +142,10 @@ export function MemberManagement() {
         onSuccess: () => {
           toast.success('Member removed successfully.')
         },
-        onError: () => {
-          toast.error('Failed to remove member.')
+        onError: (error) => {
+          const errData = (error as ApiError)?.data as Record<string, unknown> | undefined
+          const message = (errData?.detail as string) || 'Failed to remove member.'
+          toast.error(message)
         },
         onSettled: () => setPendingRemoval(null),
       }
@@ -136,9 +183,10 @@ export function MemberManagement() {
           toast.success('Member role updated successfully.')
         },
         onError: (error) => {
+          const errData = (error as ApiError)?.data as Record<string, unknown> | undefined
           const message =
-            (error as any)?.response?.data?.role?.[0] ||
-            (error as any)?.response?.data?.detail ||
+            (errData?.role as string[])?.[0] ||
+            (errData?.detail as string) ||
             'Failed to update member role.'
           toast.error(message)
         },

--- a/frontend/src/features/organization/pages/OrganizationSettings.tsx
+++ b/frontend/src/features/organization/pages/OrganizationSettings.tsx
@@ -9,7 +9,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
-import { Loader2, Check } from 'lucide-react'
+import { Loader2, Check, AlertCircle } from 'lucide-react'
+import { Skeleton } from '@/components/ui/skeleton'
 
 export function OrganizationSettings() {
   const { currentOrganization, isLoading, refresh, isSecurityTeam } = useWorkspace()
@@ -28,11 +29,43 @@ export function OrganizationSettings() {
   }, [currentOrganization])
 
   if (isLoading) {
-    return <div>Loading...</div>
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-4 w-64 mt-2" />
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full max-w-md" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-full max-w-md" />
+            </div>
+            <Skeleton className="h-10 w-28 mt-2" />
+          </CardContent>
+        </Card>
+      </div>
+    )
   }
 
   if (!currentOrganization) {
-    return <div>No organization selected.</div>
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+            <AlertCircle className="h-10 w-10 text-muted-foreground mb-3" />
+            <p className="text-lg font-medium">No organization selected</p>
+            <p className="text-sm text-muted-foreground mt-1">
+              Select an organization from the workspace switcher to manage its settings.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
   }
 
   const hasChanges =

--- a/frontend/src/features/organization/pages/TeamManagement.tsx
+++ b/frontend/src/features/organization/pages/TeamManagement.tsx
@@ -55,7 +55,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { UserPlus, Trash2, Plus, Pencil, Loader2, Copy, Check } from 'lucide-react'
+import { UserPlus, Trash2, Plus, Pencil, Loader2, Copy, Check, AlertCircle } from 'lucide-react'
+import { Skeleton } from '@/components/ui/skeleton'
 import type { TeamListItem, TeamRole, InviteMemberResponse } from '@/features/organization/types/organization'
 
 export function TeamManagement() {
@@ -82,11 +83,65 @@ export function TeamManagement() {
   const [editDescription, setEditDescription] = useState('')
 
   if (workspaceLoading || teamsLoading) {
-    return <div>Loading...</div>
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div>
+                <Skeleton className="h-6 w-24" />
+                <Skeleton className="h-4 w-56 mt-2" />
+              </div>
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Team Name</TableHead>
+                  <TableHead>Business Unit</TableHead>
+                  <TableHead>Members</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <TableRow key={i}>
+                    <TableCell><Skeleton className="h-4 w-36" /></TableCell>
+                    <TableCell><Skeleton className="h-4 w-24" /></TableCell>
+                    <TableCell><Skeleton className="h-4 w-8" /></TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-1">
+                        <Skeleton className="h-8 w-16 rounded-md" />
+                        <Skeleton className="h-8 w-8 rounded-md" />
+                        <Skeleton className="h-8 w-8 rounded-md" />
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    )
   }
 
   if (!currentOrganization) {
-    return <div>No organization selected.</div>
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+            <AlertCircle className="h-10 w-10 text-muted-foreground mb-3" />
+            <p className="text-lg font-medium">No organization selected</p>
+            <p className="text-sm text-muted-foreground mt-1">
+              Select an organization from the workspace switcher to manage teams.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
   }
 
   const handleCreateTeam = () => {
@@ -528,7 +583,20 @@ function TeamMembersDialog({ team, open, onOpenChange }: TeamMembersDialogProps)
           <div className="space-y-2">
             <Label>Current Members</Label>
             {isLoading ? (
-              <p className="text-muted-foreground text-sm">Loading...</p>
+              <div className="border rounded-md divide-y">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="flex items-center justify-between p-2">
+                    <div className="space-y-1">
+                      <Skeleton className="h-4 w-32" />
+                      <Skeleton className="h-3 w-44" />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-8 w-28 rounded-md" />
+                      <Skeleton className="h-8 w-8 rounded-md" />
+                    </div>
+                  </div>
+                ))}
+              </div>
             ) : members.length === 0 ? (
               <p className="text-muted-foreground text-sm">No members yet.</p>
             ) : (


### PR DESCRIPTION
Fixes #198 

[Screencast From 2026-07-16 21-26-13.webm](https://github.com/user-attachments/assets/01a7b388-01bc-4c59-9b1c-ae9392b46a59)

## Summary
- Add reusable `Skeleton` UI component (shadcn/ui pattern)
- Replace bare `Loading...` text with skeleton loaders matching each page's layout (tables, forms) across all four Settings pages
- Replace bare `No organization selected.` text with styled card + icon + guidance message
- Fix Member Management error toast to read `ApiError.data` instead of `error.response.data`, so backend validation messages (e.g. last-security-team guard) actually surface

### Files changed
- `frontend/src/components/ui/skeleton.tsx` - new component
- `frontend/src/features/organization/pages/MemberManagement.tsx` - skeleton table, empty state, error shape fix
- `frontend/src/features/organization/pages/OrganizationSettings.tsx` - skeleton form, empty state
- `frontend/src/features/organization/pages/BusinessUnitsSettings.tsx` - skeleton table, empty state
- `frontend/src/features/organization/pages/TeamManagement.tsx` - skeleton table, empty state, skeleton member list in dialog