### PR TITLE
feat(dfd-editor): show threats on DFD canvas and improve deletion UX …

### DIFF
--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -24,10 +24,12 @@ import {
 } from '@/components/ui/tooltip'
 import { useThreatModel, useDeleteDFD } from '@/features/threat-models/api/threat-models'
 // DFD Editor internal imports
-import { nodeTypes, edgeTypes } from './components'
+import { canvasNodeTypes, canvasEdgeTypes } from './components/nodes/CanvasNodeWrapper'
 import { DiagramToolbar } from './components/DiagramToolbar'
 import { NodeEditPanel } from './components/panels/NodeEditPanel'
 import { EdgeEditPanel } from './components/panels/EdgeEditPanel'
+import { CanvasThreatSection } from './components/panels/CanvasThreatSection'
+import { useThreatModelThreats } from '@/features/threat-models/api/threats'
 import { TrustBoundaryEdgeEditPanel } from './components/panels/TrustBoundaryEdgeEditPanel'
 import { TemplateBrowser } from './components/TemplateBrowser'
 import { CanvasOverlays } from './components/CanvasOverlays'
@@ -131,6 +133,9 @@ function DFDEditorContent() {
 
   // Fetch threat model for name display
   const { data: threatModel } = useThreatModel(threatModelId || '')
+
+  // Fetch threat data for canvas badges and threat sections
+  const { data: threatData } = useThreatModelThreats(threatModelId)
 
   // Parent relationship detection
   const { updateParentRelationships } = useParentRelationships()
@@ -538,8 +543,8 @@ function DFDEditorContent() {
               onEdgeClick={handleEdgeClick}
               onPaneClick={handlePaneClick}
               onNodeDragStop={handleNodeDragStop}
-              nodeTypes={nodeTypes}
-              edgeTypes={edgeTypes}
+              nodeTypes={canvasNodeTypes}
+              edgeTypes={canvasEdgeTypes}
               connectionMode={ConnectionMode.Loose}
               defaultEdgeOptions={{
                 type: 'dataFlow',
@@ -577,6 +582,20 @@ function DFDEditorContent() {
             node={currentSelectedNode}
             onClose={() => setSelectedNode(null)}
             threatModelId={threatModelId}
+            renderExtra={
+              currentSelectedNode.type !== 'trustZone' ? (
+                <CanvasThreatSection
+                  threatModelId={threatModelId}
+                  canvasId={currentSelectedNode.id}
+                  targetType="component"
+                  targetName={currentSelectedNode.data.label || currentSelectedNode.type || 'Node'}
+                  backendId={
+                    (currentSelectedNode.data as { componentId?: number }).componentId ??
+                    threatData?.nodeComponentMap[currentSelectedNode.id]?.componentId
+                  }
+                />
+              ) : undefined
+            }
           />
         )}
         {currentSelectedEdge?.type === 'dataFlow' && (
@@ -584,6 +603,18 @@ function DFDEditorContent() {
             edge={currentSelectedEdge as DataFlowEdge}
             onClose={() => setSelectedEdge(null)}
             threatModelId={threatModelId}
+            renderExtra={
+              <CanvasThreatSection
+                threatModelId={threatModelId}
+                canvasId={currentSelectedEdge.id}
+                targetType="dataflow"
+                targetName={(currentSelectedEdge as DataFlowEdge).data?.label || 'Data Flow'}
+                backendId={
+                  (currentSelectedEdge as DataFlowEdge).data?.dataflowId ??
+                  threatData?.edgeDataflowMap[currentSelectedEdge.id]?.dataflowId
+                }
+              />
+            }
           />
         )}
         {currentSelectedEdge?.type === 'trustBoundary' && (

--- a/frontend/src/features/dfd-editor/components/nodes/CanvasNodeWrapper.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/CanvasNodeWrapper.tsx
@@ -1,0 +1,98 @@
+/* eslint-disable react-refresh/only-export-components */
+import { memo, type ComponentType } from 'react'
+import { useParams } from 'react-router-dom'
+import { EdgeLabelRenderer, type EdgeProps, type NodeProps } from '@xyflow/react'
+import { useThreatModelThreats } from '@/features/threat-models/api/threats'
+
+// Import original node components
+import { ProcessNode } from './ProcessNode'
+import { DataStoreNode } from './DataStoreNode'
+import { HumanActorNode } from './HumanActorNode'
+import { SystemActorNode } from './SystemActorNode'
+import { TrustZoneNode } from './TrustZoneNode'
+import { SystemScopeNode } from './SystemScopeNode'
+import { DataFlowEdge as DataFlowEdgeComponent } from '../edges/DataFlowEdge'
+import { TrustBoundaryEdge as TrustBoundaryEdgeComponent } from '../edges/TrustBoundaryEdge'
+
+function ThreatBadge({ count }: { count: number }) {
+  if (count === 0) return null
+  return (
+    <div
+      className="absolute -top-2 -right-2 z-10 flex items-center justify-center min-w-[20px] h-5 px-1 rounded-full bg-red-500 text-white text-xs font-bold shadow-sm"
+      style={{ pointerEvents: 'none' }}
+    >
+      {count}
+    </div>
+  )
+}
+
+function useThreatCount(canvasElementId: string): number {
+  const { id: threatModelId } = useParams<{ id: string }>()
+  const { data: threatData } = useThreatModelThreats(threatModelId)
+
+  if (!threatData?.componentThreats) return 0
+
+  return threatData.componentThreats.filter(
+    (t) => t.componentId === canvasElementId && !t.dismissed
+  ).length
+}
+
+function withThreatBadge<P extends NodeProps>(NodeComponent: ComponentType<P>) {
+  const WrappedNode = memo(function WrappedNode(props: P) {
+    const count = useThreatCount(props.id)
+
+    return (
+      <div className="relative w-full h-full">
+        <ThreatBadge count={count} />
+        <NodeComponent {...props} />
+      </div>
+    )
+  })
+  return WrappedNode
+}
+
+// Wrapped node types with threat badges
+export const canvasNodeTypes = {
+  process: withThreatBadge(ProcessNode),
+  datastore: withThreatBadge(DataStoreNode),
+  humanActor: withThreatBadge(HumanActorNode),
+  systemActor: withThreatBadge(SystemActorNode),
+  trustZone: withThreatBadge(TrustZoneNode),
+  systemScope: withThreatBadge(SystemScopeNode),
+} as const
+
+// Edge wrapper that adds a threat count badge
+function withEdgeThreatBadge<P extends EdgeProps>(EdgeComponent: ComponentType<P>) {
+  const WrappedEdge = memo(function WrappedEdge(props: P) {
+    const count = useThreatCount(props.id)
+
+    return (
+      <>
+        <EdgeComponent {...props} />
+        {count > 0 && (
+          <EdgeLabelRenderer>
+            <div
+              className="absolute pointer-events-none nodrag nopan"
+              style={{
+                left: (props.sourceX + props.targetX) / 2,
+                top: (props.sourceY + props.targetY) / 2 - 20,
+                transform: 'translate(-50%, -50%)',
+              }}
+            >
+              <div className="flex items-center justify-center min-w-[20px] h-5 px-1 rounded-full bg-red-500 text-white text-xs font-bold shadow-sm">
+                {count}
+              </div>
+            </div>
+          </EdgeLabelRenderer>
+        )}
+      </>
+    )
+  })
+  return WrappedEdge
+}
+
+// Wrapped edge types with threat badges
+export const canvasEdgeTypes = {
+  dataFlow: withEdgeThreatBadge(DataFlowEdgeComponent),
+  trustBoundary: TrustBoundaryEdgeComponent,
+} as const

--- a/frontend/src/features/dfd-editor/components/panels/CanvasThreatSection.tsx
+++ b/frontend/src/features/dfd-editor/components/panels/CanvasThreatSection.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, Plus, ShieldAlert } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import { TaxonomyBadges } from '@/components/shared/TaxonomyBadges'
+import { useThreatModelThreats } from '@/features/threat-models/api/threats'
+import { AddThreatDialog } from '../threat-analysis/AddThreatDialog'
+import {
+  deriveThreatStatus,
+  THREAT_STATUS_CONFIG,
+} from '../../types/threat-analysis'
+import type { ComponentThreat } from '../../types/threat-analysis'
+
+const SEVERITY_COLORS: Record<string, string> = {
+  low: 'bg-blue-100 text-blue-800',
+  medium: 'bg-yellow-100 text-yellow-800',
+  high: 'bg-orange-100 text-orange-800',
+  critical: 'bg-red-100 text-red-800',
+}
+
+interface CanvasThreatSectionProps {
+  threatModelId: string | undefined
+  canvasId: string
+  targetType: 'component' | 'dataflow'
+  targetName: string
+  backendId: number | undefined
+}
+
+export function CanvasThreatSection({
+  threatModelId,
+  canvasId,
+  targetType,
+  targetName,
+  backendId,
+}: CanvasThreatSectionProps) {
+  const [isOpen, setIsOpen] = useState(true)
+  const [showAddDialog, setShowAddDialog] = useState(false)
+
+  const { data: threatData } = useThreatModelThreats(threatModelId)
+
+  const threats: ComponentThreat[] = threatData?.componentThreats
+    ? threatData.componentThreats.filter(
+        (t) => t.componentId === canvasId && !t.dismissed
+      )
+    : []
+
+  const threatCount = threats.length
+
+  return (
+    <div className="space-y-2">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center justify-between w-full text-sm font-medium hover:text-foreground text-muted-foreground"
+      >
+        <div className="flex items-center gap-2">
+          {isOpen ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronRight className="h-4 w-4" />
+          )}
+          <ShieldAlert className="h-4 w-4" />
+          <span>Threats</span>
+          {threatCount > 0 && (
+            <Badge variant="secondary" className="h-5 px-1.5 text-xs">
+              {threatCount}
+            </Badge>
+          )}
+        </div>
+      </button>
+
+      {isOpen && (
+        <div className="space-y-2 pl-6">
+          {backendId === undefined ? (
+            <p className="text-xs text-muted-foreground">
+              Save the diagram to enable threat management.
+            </p>
+          ) : (
+            <>
+              {threats.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  No threats added yet.
+                </p>
+              ) : (
+                <div className="space-y-1.5">
+                  {threats.map((threat) => {
+                    const status = deriveThreatStatus(threat.countermeasures)
+                    const statusConfig = THREAT_STATUS_CONFIG[status]
+
+                    return (
+                      <div
+                        key={threat.id}
+                        className="flex flex-col gap-1.5 p-2 rounded-md border bg-card text-sm"
+                      >
+                        <span className="text-sm font-medium leading-snug">
+                          {threat.threatName || 'Unnamed threat'}
+                        </span>
+                        <div className="flex flex-wrap items-center gap-1">
+                          {threat.inherentSeverity && (
+                            <Badge
+                              variant="secondary"
+                              className={cn(
+                                'text-xs',
+                                SEVERITY_COLORS[threat.inherentSeverity] || ''
+                              )}
+                            >
+                              {threat.inherentSeverity}
+                            </Badge>
+                          )}
+                          <Badge
+                            variant="secondary"
+                            className={cn('text-xs', statusConfig.bgColor)}
+                          >
+                            {statusConfig.label}
+                          </Badge>
+                        </div>
+                        {threat.taxonomyEntries && threat.taxonomyEntries.length > 0 && (
+                          <TaxonomyBadges
+                            entries={threat.taxonomyEntries}
+                            maxVisible={3}
+                            size="sm"
+                          />
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full gap-1"
+                onClick={() => setShowAddDialog(true)}
+              >
+                <Plus className="h-3 w-3" />
+                Add Threat
+              </Button>
+
+              <AddThreatDialog
+                open={showAddDialog}
+                onOpenChange={setShowAddDialog}
+                targetId={backendId}
+                targetType={targetType}
+                targetName={targetName}
+                threatModelId={threatModelId}
+              />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/dfd-editor/components/threat-analysis/ComponentTreeItem.tsx
+++ b/frontend/src/features/dfd-editor/components/threat-analysis/ComponentTreeItem.tsx
@@ -1,6 +1,7 @@
 import { Cog, Database, User, ChevronRight, Building2, Trash2 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { ComponentThreat } from '../../types/threat-analysis'
 import { deriveThreatStatus } from '../../types/threat-analysis'
@@ -67,6 +68,7 @@ export function ComponentTreeItem({
   const hasChildren = children.length > 0
   const isCollapsed = collapsedNodes.has(node.id)
   const componentId = (node.data as { componentId?: number }).componentId
+  const isAnalysisOnly = (node.data as { isAnalysisOnly?: boolean }).isAnalysisOnly
 
   return (
     <>
@@ -124,7 +126,7 @@ export function ComponentTreeItem({
             </div>
           </div>
           <div className="flex items-center gap-1 ml-2 shrink-0">
-            {componentId !== undefined && (
+            {componentId !== undefined && isAnalysisOnly && (
               <Button
                 variant="ghost"
                 size="icon"
@@ -138,6 +140,26 @@ export function ComponentTreeItem({
               >
                 <Trash2 className="h-4 w-4" />
               </Button>
+            )}
+            {componentId !== undefined && !isAnalysisOnly && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="opacity-0 group-hover:opacity-100 transition-opacity">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-muted-foreground pointer-events-none opacity-50"
+                      disabled
+                      aria-label={`Cannot delete ${displayName}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="left">
+                  This component was created in the DFD editor. You can delete it only where you created it.
+                </TooltipContent>
+              </Tooltip>
             )}
             {summary.exposed > 0 ? (
               <Badge variant="outline" className="bg-red-100 text-red-700 text-xs shrink-0">

--- a/frontend/src/features/dfd-editor/components/threat-analysis/ComponentView.tsx
+++ b/frontend/src/features/dfd-editor/components/threat-analysis/ComponentView.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState, useMemo, useCallback, useRef } from 'react'
 import { toast } from 'sonner'
-import { Cog, Database, User, ChevronDown, ChevronUp, ChevronRight, X, Plus, ArrowRight, Shield, Building2, Lock, GripVertical, Loader2, Trash2 } from 'lucide-react'
+import { Cog, User, ChevronDown, ChevronUp, ChevronRight, X, Plus, ArrowRight, Shield, Lock, GripVertical, Loader2, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -62,7 +62,6 @@ import { WaiverReasonInput } from './WaiverReasonInput'
 import { ComplianceDetailSection } from './ComplianceDetailSection'
 import { CountermeasureStatusButtons } from './CountermeasureStatusButtons'
 import { ComponentTreeItem } from './ComponentTreeItem'
-import { ComponentDataAssetsDisplay } from './ComponentDataAssetsDisplay'
 import { useTechnologies } from '../../api/component-library'
 import { DataFlowAssetsDisplay } from './DataFlowAssetsDisplay'
 import { SortableList } from '@/components/shared/SortableList'
@@ -72,13 +71,6 @@ import { SuggestThreatsOwl } from '@/features/ai/components/SuggestThreatsOwl'
 export type Assignee = { type: 'member'; userId: number; email: string; name: string | null }
 
 // Icon map for node types
-const nodeTypeIcons: Record<string, React.ComponentType<{ className?: string }>> = {
-  process: Cog,
-  datastore: Database,
-  humanActor: User,
-  systemActor: Building2,
-}
-
 interface ComponentViewProps {
   threatModelId: string
   canvasData: CanvasData
@@ -86,7 +78,7 @@ interface ComponentViewProps {
   trustZones: DiagramNode[]
   dataFlows: DataFlowEdge[]
   componentThreats: ComponentThreat[]
-  selectedFrameworks: string[]
+
   selectedComponentId: string | null
   selectedThreatId: string | null
   selectedComponentThreat: ComponentThreat | null
@@ -176,7 +168,6 @@ export function ComponentView({
   trustZones,
   dataFlows,
   componentThreats,
-  selectedFrameworks: _selectedFrameworks,
   selectedComponentId,
   selectedThreatId,
   selectedComponentThreat,
@@ -344,19 +335,9 @@ export function ComponentView({
   )
 
   // Build component tree for the left panel
-  const { treeRoots, flatNonProcess } = useMemo(
+  const { treeRoots } = useMemo(
     () => buildComponentTree(analyzableComponents, canvasData.nodes),
     [analyzableComponents, canvasData.nodes]
-  )
-
-  const dataStoreNodes = useMemo(
-    () => flatNonProcess.filter((n) => n.type === 'datastore'),
-    [flatNonProcess]
-  )
-
-  const actorNodes = useMemo(
-    () => flatNonProcess.filter((n) => n.type === 'humanActor' || n.type === 'systemActor'),
-    [flatNonProcess]
   )
 
   const toggleNodeCollapsed = useCallback((nodeId: string) => {
@@ -542,90 +523,6 @@ export function ComponentView({
                 resolveTechName={resolveTechName}
                 onRequestDeleteComponent={(component) => setDeleteComponentConfirmFor(component)}
               />
-            ))}
-
-            {/* Data Stores and Actors as separate sections */}
-            {[
-              { label: 'Data Stores', nodes: dataStoreNodes },
-              { label: 'Actors', nodes: actorNodes },
-            ].map(({ label, nodes }) => nodes.length > 0 && (
-              <Fragment key={label}>
-                <div className="pt-3 pb-1 px-2 border-t mt-2">
-                  <span className="text-xs font-medium text-muted-foreground">{label}</span>
-                </div>
-                {nodes.map((node) => {
-                  const Icon = nodeTypeIcons[node.type as string] || Cog
-                  const summary = getComponentThreatSummary(node.id, componentThreats)
-                  const isSelected = node.id === selectedComponentId
-                  const technologySlug = (node.data as { technology?: string }).technology
-                  const technologyName = resolveTechName(technologySlug)
-                  const nodeLabel = String(node.data.label)
-                  const isDefaultLabel = nodeLabel.toLowerCase().includes('new ')
-                  const displayName = !isDefaultLabel ? nodeLabel : (technologyName || nodeLabel)
-                  const showSecondaryLabel = technologyName && !isDefaultLabel && nodeLabel !== technologyName
-
-                  return (
-                    <Fragment key={node.id}>
-                      <button
-                        onClick={() => onSelectComponent(node.id)}
-                        className={cn(
-                          'w-full text-left p-2 rounded-md transition-colors',
-                          isSelected
-                            ? 'bg-slate-100 border border-slate-300'
-                            : 'hover:bg-slate-50'
-                        )}
-                      >
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-2 min-w-0">
-                            <Icon className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                            <div className="min-w-0">
-                              <div className="font-medium text-sm truncate">
-                                {displayName}
-                              </div>
-                              {showSecondaryLabel && (
-                                <div className="text-xs text-muted-foreground truncate">
-                                  {technologyName}
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                          {summary.exposed > 0 ? (
-                            <Badge variant="outline" className="bg-red-100 text-red-700 text-xs ml-2 flex-shrink-0">
-                              {summary.exposed} exposed
-                            </Badge>
-                          ) : summary.addressable > 0 ? (
-                            <Badge variant="outline" className="bg-yellow-100 text-yellow-700 text-xs ml-2 flex-shrink-0">
-                              {summary.addressable} in progress
-                            </Badge>
-                          ) : summary.total > 0 ? (
-                            <span className="text-xs text-muted-foreground ml-2 flex-shrink-0">
-                              No threats
-                            </span>
-                          ) : null}
-                        </div>
-                        {summary.total > 0 && (
-                          <div className="flex items-center gap-1 mt-1 ml-6">
-                            <span
-                              className={cn(
-                                'w-2 h-2 rounded-full',
-                                summary.exposed > 0 ? 'bg-red-500' : 'bg-yellow-500'
-                              )}
-                            />
-                            <span className="text-xs text-muted-foreground">
-                              {summary.total}
-                            </span>
-                          </div>
-                        )}
-                      </button>
-                      {isSelected && (
-                        <ComponentDataAssetsDisplay
-                          componentId={(node.data as { componentId?: number }).componentId}
-                        />
-                      )}
-                    </Fragment>
-                  )
-                })}
-              </Fragment>
             ))}
 
             {/* Trust Boundaries section */}
@@ -898,7 +795,7 @@ export function ComponentView({
                       onReorderThreats(selectedComponentId, reordered)
                     }
                   }}
-                  renderItem={(ct, dragHandleRef, _isDragging) => {
+                  renderItem={(ct, dragHandleRef) => {
                     if (!ct.threatName) return null
 
                     const status = deriveThreatStatus(ct.countermeasures)
@@ -1137,7 +1034,7 @@ export function ComponentView({
                     onReorderCountermeasures(selectedComponentThreat.id, reordered)
                   }
                 }}
-                renderItem={(cm, dragHandleRef, _isDragging) => {
+                renderItem={(cm, dragHandleRef) => {
                   const cmName = cm.countermeasureName || cm.countermeasureId
                   const cmDescription = cm.countermeasureDescription
                   const canDelete = (() => {
@@ -1481,15 +1378,23 @@ export function ComponentView({
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleteCountermeasureMutation.isPending || unlinkCountermeasureMutation.isPending}>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={(e) => {
                 e.preventDefault()
                 handleConfirmDeleteCountermeasure()
               }}
+              disabled={deleteCountermeasureMutation.isPending || unlinkCountermeasureMutation.isPending}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              Delete
+              {deleteCountermeasureMutation.isPending || unlinkCountermeasureMutation.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                'Delete'
+              )}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -1510,15 +1415,23 @@ export function ComponentView({
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleteComponentMutation.isPending}>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={(e) => {
                 e.preventDefault()
                 handleConfirmDeleteComponent()
               }}
+              disabled={deleteComponentMutation.isPending}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              Delete
+              {deleteComponentMutation.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                'Delete'
+              )}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/features/dfd-editor/components/threat-analysis/hierarchy-utils.ts
+++ b/frontend/src/features/dfd-editor/components/threat-analysis/hierarchy-utils.ts
@@ -60,34 +60,44 @@ export function getDirectProcessChildren(
 }
 
 /**
+ * Returns the process-type parent of a component node (process, datastore, or actor).
+ * Datastores and actors can be children of processes on the canvas.
+ */
+export function getComponentParent(
+  node: DiagramNode,
+  nodesMap: Map<string, DiagramNode>
+): DiagramNode | null {
+  if (!node.parentId) return null
+  const parent = nodesMap.get(node.parentId)
+  if (!parent || parent.type !== 'process') return null
+  return parent
+}
+
+/**
  * Builds a tree of ComponentTreeNode objects for the left panel.
- * Returns { treeRoots, flatNonProcess } — process nodes in a tree,
- * non-process nodes (datastores, actors) as a flat list.
+ * All analyzable components (processes, datastores, actors) are included
+ * in the tree. Non-process nodes with a process parent appear as children;
+ * those without appear as top-level roots.
  */
 export function buildComponentTree(
   analyzableComponents: DiagramNode[],
   allNodes: DiagramNode[]
-): { treeRoots: ComponentTreeNode[]; flatNonProcess: DiagramNode[] } {
+): { treeRoots: ComponentTreeNode[] } {
   const nodesMap = new Map(allNodes.map((n) => [n.id, n]))
 
-  // Separate process nodes from non-process nodes
-  const processNodes = analyzableComponents.filter((n) => n.type === 'process')
-  const flatNonProcess = analyzableComponents.filter((n) => n.type !== 'process')
-
-  // Build tree nodes map
+  // Build tree nodes map for all analyzable components
   const treeNodeMap = new Map<string, ComponentTreeNode>()
-  for (const node of processNodes) {
+  for (const node of analyzableComponents) {
     treeNodeMap.set(node.id, { node, children: [], depth: 0 })
   }
 
   // Wire up parent-child relationships
   const treeRoots: ComponentTreeNode[] = []
-  for (const node of processNodes) {
-    const processParent = getProcessParent(node, nodesMap)
-    if (processParent && treeNodeMap.has(processParent.id)) {
-      treeNodeMap.get(processParent.id)!.children.push(treeNodeMap.get(node.id)!)
+  for (const node of analyzableComponents) {
+    const componentParent = getComponentParent(node, nodesMap)
+    if (componentParent && treeNodeMap.has(componentParent.id)) {
+      treeNodeMap.get(componentParent.id)!.children.push(treeNodeMap.get(node.id)!)
     } else {
-      // Root-level process (no process parent or parent not in analyzable set)
       treeRoots.push(treeNodeMap.get(node.id)!)
     }
   }
@@ -105,7 +115,7 @@ export function buildComponentTree(
   }
   setDepths(treeRoots, 0)
 
-  return { treeRoots, flatNonProcess }
+  return { treeRoots }
 }
 
 /**

--- a/frontend/src/features/threat-models/api/components.ts
+++ b/frontend/src/features/threat-models/api/components.ts
@@ -134,17 +134,3 @@ export function useCreateAnalysisComponent() {
   })
 }
 
-/**
- * Delete a component.
- */
-export function useDeleteComponent() {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    mutationFn: (componentId: number) => api.delete(`/components/${componentId}/`),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: componentKeys.all })
-      queryClient.invalidateQueries({ queryKey: ['threat-model-threats'] })
-    },
-  })
-}

--- a/frontend/src/features/threat-models/api/threats.ts
+++ b/frontend/src/features/threat-models/api/threats.ts
@@ -6,6 +6,7 @@ import { useQuery, useMutation, useQueryClient, skipToken } from '@tanstack/reac
 import { api } from '@/lib/api'
 import type { ComponentThreat, ComponentThreatCountermeasure, CountermeasureStatus } from '@/features/dfd-editor/types/threat-analysis'
 import type { TaxonomyEntry } from '@/types/domain'
+import { componentKeys } from './components'
 
 // Backend countermeasure status (aligned with frontend CountermeasureStatus)
 type BackendCountermeasureStatus = 'platform' | 'gap' | 'planned' | 'verified' | 'waived'
@@ -985,6 +986,7 @@ export function useDeleteComponent() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: threatKeys.all })
       queryClient.invalidateQueries({ queryKey: ['threat-model-threats'] })
+      queryClient.invalidateQueries({ queryKey: componentKeys.all })
     },
   })
 }

--- a/frontend/src/features/threat-models/components/DeleteDFDDialog.tsx
+++ b/frontend/src/features/threat-models/components/DeleteDFDDialog.tsx
@@ -180,7 +180,7 @@ export function DeleteDFDDialog({
               onConfirm(deleteOrphanedComponents)
             }}
             disabled={isDeleting || isLoadingPreview}
-            className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           >
             {isDeleting ? (
               <>

--- a/frontend/src/features/threat-models/components/DeleteThreatModelDialog.tsx
+++ b/frontend/src/features/threat-models/components/DeleteThreatModelDialog.tsx
@@ -113,7 +113,7 @@ export function DeleteThreatModelDialog({
               onConfirm()
             }}
             disabled={isDeleting || isLoadingPreview}
-            className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           >
             {isDeleting ? (
               <>

--- a/frontend/src/features/threat-models/pages/ThreatModelDetail.tsx
+++ b/frontend/src/features/threat-models/pages/ThreatModelDetail.tsx
@@ -168,7 +168,7 @@ export function ThreatModelDetail() {
 
   // Fetch threat model threats data (for nodeComponentMap)
   const { data: threatData, refetch: refetchThreats } = useThreatModelThreats(id)
-  const nodeComponentMap = threatData?.nodeComponentMap || {}
+  const nodeComponentMap = useMemo(() => threatData?.nodeComponentMap || {}, [threatData?.nodeComponentMap])
 
   // Create diagram mutation
   const createDiagramMutation = useMutation({
@@ -194,7 +194,7 @@ export function ThreatModelDetail() {
   // Aggregate canvas data from all diagrams or selected diagram
   const aggregatedCanvasData = useMemo((): CanvasData => {
     const diagramsToUse = selectedDiagramId
-      ? diagrams.filter((d) => d.id === selectedDiagramId)
+      ? diagrams.filter((d) => String(d.id) === selectedDiagramId)
       : diagrams.filter((d) => d.isPrimary)
 
     const nodes: DiagramNode[] = []
@@ -215,7 +215,7 @@ export function ThreatModelDetail() {
   const filteredComponentThreats = useMemo(() => {
     if (!selectedDiagramId) return componentThreats
     return componentThreats.filter(
-      (ct) => ct.sourceDiagramId === selectedDiagramId || ct.diagramId === selectedDiagramId
+      (ct) => String(ct.sourceDiagramId) === selectedDiagramId || String(ct.diagramId) === selectedDiagramId
     )
   }, [componentThreats, selectedDiagramId])
 
@@ -675,19 +675,29 @@ export function ThreatModelDetail() {
                   {/* DFD Filter - only show if DFDs exist */}
                   {diagrams.length > 0 && (
                     <div className="flex items-center gap-2">
-                      <span className="text-sm text-muted-foreground">Filter by DFD:</span>
                       <select
                         value={selectedDiagramId || ''}
                         onChange={(e) => setSelectedDiagramId(e.target.value || null)}
                         className="text-sm border rounded-md px-2 py-1 bg-background"
                       >
-                        <option value="">All DFDs</option>
+                        <option value="">All</option>
                         {diagrams.map((d) => (
                           <option key={d.id} value={d.id}>
                             {d.name}
                           </option>
                         ))}
                       </select>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => {
+                          const diagramId = selectedDiagramId || diagrams.find((d) => d.isPrimary)?.id || diagrams[0].id
+                          navigate(`/threat-models/${id}/diagrams/${diagramId}`)
+                        }}
+                      >
+                        DFD
+                      </Button>
                     </div>
                   )}
                   {/* Zone Protections Button */}
@@ -737,7 +747,6 @@ export function ThreatModelDetail() {
                     trustZones={trustZones}
                     dataFlows={dataFlows}
                     componentThreats={filteredComponentThreats}
-                    selectedFrameworks={(threatModel.frameworks || []).map(f => f.name)}
                     selectedComponentId={selectedComponentId}
                     selectedThreatId={selectedThreatId}
                     selectedComponentThreat={selectedComponentThreat}


### PR DESCRIPTION
 ## Summary                                                                                                                        
                                                                                                                                    
  Closes #2. Brings threat visibility into the DFD editor for signed-in users, matching the experience already available to guest   
  users.                                                                                                                            
                                                                                                                                    
  ### Threats on the DFD canvas
  - Red badge on each node/edge showing active (non-dismissed) threat count
  - Collapsible "Threats" section in the node/edge edit panel with severity, status, and taxonomy badges
  - "Add Threat" button directly from the canvas panel (requires saving the diagram first)

  ### Deletion safety in Threat Analysis sidebar
  - Canvas-originated components show a disabled trash icon with tooltip: "This component was created in the DFD editor. You can
  delete it only where you created it."
  - Analysis-only components remain deletable with confirmation dialog
  - Unified all component types (processes, datastores, actors) into a single tree — previously datastores and actors were rendered
  as a flat list

  ### Navigation and filtering fixes
  - Added "DFD" button next to the filter dropdown for one-click navigation back to the DFD editor
  - Fixed DFD filter showing 0 components (type mismatch: `number === string`)

  ### Code cleanup
  - Removed duplicate `useDeleteComponent` from `components.ts` (dead code)
  - Added loading spinners to component and countermeasure delete dialogs
  - Standardized destructive button styling (`bg-destructive`) across all delete dialogs
  - Fixed query invalidation so component create/delete updates the UI immediately
  - Removed unused `selectedFrameworks` prop and other lint issues