### PR TITLE
feat(guest-editor): embed DFD diagram image in guest Word report (#188)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "docx": "^9.0.3",
+        "html-to-image": "^1.11.11",
         "lucide-react": "^0.561.0",
         "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
@@ -6714,6 +6715,12 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==",
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "docx": "^9.0.3",
+    "html-to-image": "^1.11.11",
     "lucide-react": "^0.561.0",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",

--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -13,8 +13,14 @@ import {
   addEdge,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { ArrowLeft, Save, Clock, Loader2, Pencil, Trash2 } from 'lucide-react'
+import { ArrowLeft, Save, Clock, Loader2, Pencil, Trash2, ImageDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { DeleteDFDDialog } from '@/features/threat-models/components'
 import {
   Tooltip,
@@ -41,6 +47,7 @@ import { useConnectionMode } from './hooks/useConnectionMode'
 import { useBoundaryMode } from './hooks/useBoundaryMode'
 import type { DiagramNode, DiagramEdge, DataFlowEdge, TrustBoundaryEdge } from './types'
 import { type DFDNotationStyle, NOTATION_NODE_SIZES } from './types/notation'
+import { exportDiagramImage } from './lib/export-diagram-image'
 
 function DFDEditorContent() {
   const { diagramId, id: threatModelId } = useParams<{ id: string; diagramId: string }>()
@@ -54,7 +61,7 @@ function DFDEditorContent() {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
 
   // ReactFlow instance for coordinate conversion and edge queries
-  const { screenToFlowPosition, getEdges } = useReactFlow()
+  const { screenToFlowPosition, getEdges, getViewport, setViewport } = useReactFlow()
   const { x: viewportX, y: viewportY, zoom } = useViewport()
 
   // Delete DFD mutation
@@ -386,6 +393,19 @@ function DFDEditorContent() {
     [handleTitleSave]
   )
 
+  // Export diagram as image
+  const handleExportImage = useCallback(
+    (format: 'png' | 'svg') => {
+      if (!reactFlowWrapper.current) return
+      const filename = (diagramTitle || 'diagram')
+        .replace(/[^a-zA-Z0-9-_ ]/g, '')
+        .replace(/\s+/g, '-')
+        .toLowerCase()
+      exportDiagramImage(format, filename, reactFlowWrapper.current, nodes, getViewport, setViewport)
+    },
+    [diagramTitle, nodes, getViewport, setViewport]
+  )
+
   // Handle DFD deletion
   const handleConfirmDelete = useCallback(
     (deleteOrphanedComponents: boolean) => {
@@ -498,6 +518,23 @@ function DFDEditorContent() {
             <Save className="h-4 w-4 mr-2" />
             Save
           </Button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm">
+                <ImageDown className="h-4 w-4 mr-2" />
+                Export Image
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => handleExportImage('png')}>
+                Download as PNG
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleExportImage('svg')}>
+                Download as SVG
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
 
           <Button
             size="sm"

--- a/frontend/src/features/dfd-editor/lib/export-diagram-image.ts
+++ b/frontend/src/features/dfd-editor/lib/export-diagram-image.ts
@@ -1,0 +1,140 @@
+import { toPng, toSvg } from 'html-to-image'
+import { getNodesBounds, getViewportForBounds } from '@xyflow/react'
+import type { Node, Viewport } from '@xyflow/react'
+
+const PADDING = 50
+const IMAGE_SCALE = 2 // 2x resolution for crisp output
+
+/** Filter that excludes React Flow UI overlays from image capture. */
+function overlayFilter(node: HTMLElement): boolean {
+  if (!node.classList) return true
+  return (
+    !node.classList.contains('react-flow__minimap') &&
+    !node.classList.contains('react-flow__controls') &&
+    !node.classList.contains('react-flow__panel') &&
+    !node.classList.contains('react-flow__attribution') &&
+    !node.classList.contains('react-flow__background')
+  )
+}
+
+/**
+ * Shared helper: reposition viewport to frame the diagram, call the
+ * provided capture callback, then restore the original viewport.
+ */
+async function withExportViewport<T>(
+  wrapperElement: HTMLElement,
+  nodes: Node[],
+  getViewport: () => Viewport,
+  setViewport: (viewport: Viewport, options?: { duration?: number }) => void,
+  capture: (reactFlowElement: HTMLElement, paddedBounds: { width: number; height: number }) => Promise<T>,
+): Promise<T> {
+  if (nodes.length === 0) {
+    throw new Error('No nodes to export')
+  }
+
+  const reactFlowElement = wrapperElement.querySelector<HTMLElement>('.react-flow')
+  if (!reactFlowElement) {
+    throw new Error('Could not find React Flow container')
+  }
+
+  const nodeBounds = getNodesBounds(nodes)
+
+  const paddedBounds = {
+    x: nodeBounds.x - PADDING,
+    y: nodeBounds.y - PADDING,
+    width: nodeBounds.width + PADDING * 2,
+    height: nodeBounds.height + PADDING * 2,
+  }
+
+  const exportViewport = getViewportForBounds(
+    paddedBounds,
+    paddedBounds.width,
+    paddedBounds.height,
+    0.5,
+    2,
+    0,
+  )
+
+  const originalViewport = getViewport()
+  setViewport(exportViewport)
+
+  // Wait for the viewport transform to apply
+  await new Promise((resolve) => requestAnimationFrame(resolve))
+
+  try {
+    return await capture(reactFlowElement, paddedBounds)
+  } finally {
+    setViewport(originalViewport)
+  }
+}
+
+/**
+ * Exports the React Flow diagram as a PNG or SVG image and triggers a download.
+ */
+export async function exportDiagramImage(
+  format: 'png' | 'svg',
+  filename: string,
+  wrapperElement: HTMLElement,
+  nodes: Node[],
+  getViewport: () => Viewport,
+  setViewport: (viewport: Viewport, options?: { duration?: number }) => void,
+): Promise<void> {
+  await withExportViewport(wrapperElement, nodes, getViewport, setViewport, async (reactFlowElement, paddedBounds) => {
+    const imageWidth = paddedBounds.width * IMAGE_SCALE
+    const imageHeight = paddedBounds.height * IMAGE_SCALE
+
+    const convertFn = format === 'png' ? toPng : toSvg
+    const dataUrl = await convertFn(reactFlowElement, {
+      width: imageWidth,
+      height: imageHeight,
+      style: {
+        width: `${paddedBounds.width}px`,
+        height: `${paddedBounds.height}px`,
+      },
+      filter: overlayFilter,
+    })
+
+    const extension = format === 'png' ? 'png' : 'svg'
+    const anchor = document.createElement('a')
+    anchor.href = dataUrl
+    anchor.download = `${filename}.${extension}`
+    document.body.appendChild(anchor)
+    anchor.click()
+    document.body.removeChild(anchor)
+  })
+}
+
+/**
+ * Captures the React Flow diagram as a PNG and returns the raw bytes.
+ * Used for embedding the diagram image into Word documents.
+ */
+export async function captureDiagramImage(
+  wrapperElement: HTMLElement,
+  nodes: Node[],
+  getViewport: () => Viewport,
+  setViewport: (viewport: Viewport, options?: { duration?: number }) => void,
+): Promise<Uint8Array> {
+  return withExportViewport(wrapperElement, nodes, getViewport, setViewport, async (reactFlowElement, paddedBounds) => {
+    const imageWidth = paddedBounds.width * IMAGE_SCALE
+    const imageHeight = paddedBounds.height * IMAGE_SCALE
+
+    const dataUrl = await toPng(reactFlowElement, {
+      width: imageWidth,
+      height: imageHeight,
+      style: {
+        width: `${paddedBounds.width}px`,
+        height: `${paddedBounds.height}px`,
+      },
+      filter: overlayFilter,
+    })
+
+    // Convert data URL to Uint8Array
+    const base64 = dataUrl.split(',')[1]
+    const binaryString = atob(base64)
+    const bytes = new Uint8Array(binaryString.length)
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i)
+    }
+    return bytes
+  })
+}

--- a/frontend/src/features/guest-editor/GuestDFDEditor.tsx
+++ b/frontend/src/features/guest-editor/GuestDFDEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useState, useRef } from 'react'
 import {
   ReactFlow,
   Background,
@@ -23,6 +23,7 @@ import { useParentRelationships } from '@/features/dfd-editor/hooks/useParentRel
 import { useKeyboardShortcuts } from '@/features/dfd-editor/hooks/useKeyboardShortcuts'
 import { useConnectionMode } from '@/features/dfd-editor/hooks/useConnectionMode'
 import { useBoundaryMode } from '@/features/dfd-editor/hooks/useBoundaryMode'
+import { exportDiagramImage, captureDiagramImage } from '@/features/dfd-editor/lib/export-diagram-image'
 import type {
   DiagramNode,
   DiagramEdge,
@@ -40,6 +41,7 @@ function GuestDFDEditorContent() {
 
   // Consume diagram state from layout via outlet context
   const {
+    title,
     nodes,
     edges,
     setNodes,
@@ -49,6 +51,8 @@ function GuestDFDEditorContent() {
     undo,
     notationStyle,
     setNotationStyle,
+    exportImageRef,
+    captureImageRef,
   } = useOutletContext<GuestDiagramOutletContext>()
 
   // Handle notation change — resize affected nodes
@@ -90,7 +94,7 @@ function GuestDFDEditorContent() {
   const [selectedEdge, setSelectedEdge] = useState<DiagramEdge | null>(null)
 
   // ReactFlow instance
-  const { screenToFlowPosition, getEdges } = useReactFlow()
+  const { screenToFlowPosition, getEdges, getViewport, setViewport } = useReactFlow()
   const { x: viewportX, y: viewportY, zoom } = useViewport()
 
   // Parent relationship detection
@@ -143,6 +147,28 @@ function GuestDFDEditorContent() {
       y: bounds ? bounds.top + bounds.height / 2 : window.innerHeight / 2,
     })
   }, [screenToFlowPosition])
+
+  // Register export image handler so the header can call it
+  useEffect(() => {
+    exportImageRef.current = (format: 'png' | 'svg') => {
+      if (!reactFlowWrapper.current) return
+      const filename = (title || 'diagram')
+        .replace(/[^a-zA-Z0-9-_ ]/g, '')
+        .replace(/\s+/g, '-')
+        .toLowerCase()
+      exportDiagramImage(format, filename, reactFlowWrapper.current, nodes, getViewport, setViewport)
+    }
+    return () => { exportImageRef.current = null }
+  }, [exportImageRef, title, nodes, getViewport, setViewport])
+
+  // Register capture image handler so the header can capture PNG bytes for the Word report
+  useEffect(() => {
+    captureImageRef.current = async (): Promise<Uint8Array | null> => {
+      if (!reactFlowWrapper.current || nodes.length === 0) return null
+      return captureDiagramImage(reactFlowWrapper.current, nodes, getViewport, setViewport)
+    }
+    return () => { captureImageRef.current = null }
+  }, [captureImageRef, nodes, getViewport, setViewport])
 
   // Handle node click
   const handleNodeClick = useCallback(

--- a/frontend/src/features/guest-editor/GuestLayout.tsx
+++ b/frontend/src/features/guest-editor/GuestLayout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import type { NodeChange, EdgeChange } from '@xyflow/react'
 import type { DiagramNode, DiagramEdge } from '@/features/dfd-editor/types'
@@ -10,6 +10,7 @@ import { GuestEditorProvider } from './context/GuestEditorContext'
 import { GuestEditorHeader } from './components/GuestEditorHeader'
 
 export interface GuestDiagramOutletContext {
+  title: string
   nodes: DiagramNode[]
   edges: DiagramEdge[]
   setNodes: React.Dispatch<React.SetStateAction<DiagramNode[]>>
@@ -20,6 +21,8 @@ export interface GuestDiagramOutletContext {
   canUndo: boolean
   notationStyle: DFDNotationStyle
   setNotationStyle: (notation: DFDNotationStyle) => void
+  exportImageRef: React.MutableRefObject<((format: 'png' | 'svg') => void) | null>
+  captureImageRef: React.MutableRefObject<(() => Promise<Uint8Array | null>) | null>
 }
 
 export function GuestLayout() {
@@ -27,6 +30,8 @@ export function GuestLayout() {
   const threatOps = useGuestThreats()
   const countermeasureOps = useGuestCountermeasures()
   const [notationStyle, setNotationStyle] = useState<DFDNotationStyle>('dfd3')
+  const exportImageRef = useRef<((format: 'png' | 'svg') => void) | null>(null)
+  const captureImageRef = useRef<(() => Promise<Uint8Array | null>) | null>(null)
 
   // Wrap removeThreat to cascade-delete countermeasures
   const removeThreatWithCascade = useCallback(
@@ -85,6 +90,7 @@ export function GuestLayout() {
 
   const outletContext: GuestDiagramOutletContext = useMemo(
     () => ({
+      title: diagramState.title,
       nodes: diagramState.nodes,
       edges: diagramState.edges,
       setNodes: diagramState.setNodes,
@@ -95,8 +101,11 @@ export function GuestLayout() {
       canUndo: diagramState.canUndo,
       notationStyle,
       setNotationStyle,
+      exportImageRef,
+      captureImageRef,
     }),
     [
+      diagramState.title,
       diagramState.nodes,
       diagramState.edges,
       diagramState.setNodes,
@@ -127,6 +136,8 @@ export function GuestLayout() {
           onMarkSaved={diagramState.markSaved}
           onLoadFromFile={handleLoadFromFile}
           notationStyle={notationStyle}
+          onExportImage={(format) => exportImageRef.current?.(format)}
+          onCaptureImage={() => captureImageRef.current?.() ?? Promise.resolve(null)}
         />
         <Outlet context={outletContext} />
       </div>

--- a/frontend/src/features/guest-editor/components/GuestEditorHeader.tsx
+++ b/frontend/src/features/guest-editor/components/GuestEditorHeader.tsx
@@ -1,7 +1,13 @@
 import { useCallback, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Download, FileText, FolderOpen, Pencil, ArrowLeft } from 'lucide-react'
+import { Download, FileText, FolderOpen, Pencil, ArrowLeft, ImageDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -33,6 +39,8 @@ interface GuestEditorHeaderProps {
   onMarkSaved: () => void
   onLoadFromFile: (data: { title: string; nodes: import('@/features/dfd-editor/types').DiagramNode[]; edges: import('@/features/dfd-editor/types').DiagramEdge[]; notationStyle?: import('@/features/dfd-editor/types/notation').DFDNotationStyle }) => void
   notationStyle?: import('@/features/dfd-editor/types/notation').DFDNotationStyle
+  onExportImage: (format: 'png' | 'svg') => void
+  onCaptureImage: () => Promise<Uint8Array | null>
 }
 
 export function GuestEditorHeader({
@@ -42,6 +50,8 @@ export function GuestEditorHeader({
   onMarkSaved,
   onLoadFromFile,
   notationStyle,
+  onExportImage,
+  onCaptureImage,
 }: GuestEditorHeaderProps) {
   const navigate = useNavigate()
   const guestEditor = useGuestEditor()
@@ -118,14 +128,17 @@ export function GuestEditorHeader({
 
   const handleDownloadReport = useCallback(async () => {
     if (!guestEditor) return
+    // Capture the diagram image before generating the Word doc
+    const diagramImage = await onCaptureImage() ?? undefined
     await exportGuestWordDoc({
       title,
       nodes: guestEditor.nodes,
       edges: guestEditor.edges,
       threats: guestEditor.getAllThreats(),
       countermeasures: guestEditor.getAllCountermeasures(),
+      diagramImage,
     })
-  }, [title, guestEditor])
+  }, [title, guestEditor, onCaptureImage])
 
   return (
     <>
@@ -196,6 +209,28 @@ export function GuestEditorHeader({
               </TooltipTrigger>
               <TooltipContent>Download threat model report as Word document</TooltipContent>
             </Tooltip>
+
+            <DropdownMenu>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" size="sm">
+                      <ImageDown className="h-4 w-4 mr-2" />
+                      Export Image
+                    </Button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent>Download diagram as PNG or SVG</TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => onExportImage('png')}>
+                  Download as PNG
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onExportImage('svg')}>
+                  Download as SVG
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
 
             <Tooltip>
               <TooltipTrigger asChild>

--- a/frontend/src/features/guest-editor/lib/guestWordExport.ts
+++ b/frontend/src/features/guest-editor/lib/guestWordExport.ts
@@ -1,5 +1,6 @@
 import {
   Document,
+  ImageRun,
   Paragraph,
   Table,
   TextRun,
@@ -11,6 +12,7 @@ import type { GuestThreat, GuestCountermeasure } from '../types'
 import { STRIDE_CONFIG } from '@/types/domain'
 import type { STRIDECategory } from '@/types/domain'
 import {
+  CONTENT_WIDTH,
   h1,
   h2,
   para,
@@ -34,6 +36,7 @@ export interface GuestReportData {
   edges: DiagramEdge[]
   threats: GuestThreat[]
   countermeasures: GuestCountermeasure[]
+  diagramImage?: Uint8Array
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +94,41 @@ function buildOverviewSection(data: GuestReportData): (Paragraph | Table)[] {
         ['Countermeasures', String(data.countermeasures.length)],
       ],
     ),
+    spacer(),
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Diagram Image Section (between Overview and Component Inventory)
+// ---------------------------------------------------------------------------
+
+/** CONTENT_WIDTH in DXA = 6.5 inches at 1440 DXA/inch. Convert to pixels at 96 DPI. */
+const CONTENT_WIDTH_PX = (CONTENT_WIDTH / 1440) * 96 // ≈ 624 px
+
+function buildDiagramImageSection(diagramImage: Uint8Array): (Paragraph | Table)[] {
+  // Decode PNG header to read image dimensions (width × height at bytes 16–23)
+  const widthBytes = diagramImage.slice(16, 20)
+  const heightBytes = diagramImage.slice(20, 24)
+  const pngWidth = (widthBytes[0] << 24) | (widthBytes[1] << 16) | (widthBytes[2] << 8) | widthBytes[3]
+  const pngHeight = (heightBytes[0] << 24) | (heightBytes[1] << 16) | (heightBytes[2] << 8) | heightBytes[3]
+
+  // Scale to fit page content width while maintaining aspect ratio
+  const scale = Math.min(1, CONTENT_WIDTH_PX / pngWidth)
+  const displayWidth = Math.round(pngWidth * scale)
+  const displayHeight = Math.round(pngHeight * scale)
+
+  return [
+    h1('Data Flow Diagram'),
+    spacer(),
+    new Paragraph({
+      children: [
+        new ImageRun({
+          data: diagramImage,
+          transformation: { width: displayWidth, height: displayHeight },
+          type: 'png',
+        }),
+      ],
+    }),
     spacer(),
   ]
 }
@@ -389,7 +427,7 @@ export async function exportGuestWordDoc(data: GuestReportData): Promise<void> {
 
     // Sections
     ...buildOverviewSection(data),
-    pageBreak(),
+    ...(data.diagramImage ? [...buildDiagramImageSection(data.diagramImage), pageBreak()] : [pageBreak()]),
     ...buildComponentInventorySection(data),
     pageBreak(),
     ...buildThreatAnalysisSection(data),


### PR DESCRIPTION
  Capture the diagram as PNG from the canvas and embed it in the exported Word document, scaled to fit page width.

