### PR TITLE
feat(ai): redesign owl mark for clearer AI affordance (#179)

### DIFF
--- a/frontend/src/features/ai/components/OwlMark.tsx
+++ b/frontend/src/features/ai/components/OwlMark.tsx
@@ -7,6 +7,10 @@
  * hand-drawn SVG that follows lucide's conventions — 24x24 box, `currentColor`
  * stroke, round caps/joins — and therefore inherits text colour and sizes via
  * the same `className` utilities (`h-4 w-4`, …) as every other icon.
+ *
+ * An owl head tuned for legibility: two ear tufts, two big close-set eyes that
+ * dominate a small head, and a central beak — the cues that read as "owl" even
+ * at 16px, where a full-body silhouette collapsed into a blob.
  */
 
 import type { SVGProps } from 'react'
@@ -26,18 +30,15 @@ export function OwlMark(props: SVGProps<SVGSVGElement>) {
       aria-hidden="true"
       {...props}
     >
-      {/* Ear tufts */}
-      <path d="M8 3.5 9.5 6" />
-      <path d="M16 3.5 14.5 6" />
-      {/* Head and body — a single rounded owl silhouette */}
-      <path d="M12 4.5c-4 0-6.5 2.7-6.5 6.4 0 4.3 2.9 8.6 6.5 8.6s6.5-4.3 6.5-8.6c0-3.7-2.5-6.4-6.5-6.4Z" />
-      {/* The two big eyes */}
-      <circle cx="9.5" cy="10.5" r="1.6" />
-      <circle cx="14.5" cy="10.5" r="1.6" />
-      {/* Beak */}
-      <path d="M12 12.5 11 14h2z" />
-      {/* Belly seam between the wings */}
-      <path d="M12 14.5V19" />
+      {/* Small head with two ear tufts */}
+      <path d="M12 19C7.6 19 4.6 15.8 4.6 12 4.6 9.8 5.5 8 7.1 7.1L6.6 4.3 9.3 6.4C10.1 6.2 11 6.1 12 6.1 13 6.1 13.9 6.2 14.7 6.4L17.4 4.3 16.9 7.1C18.5 8 19.4 9.8 19.4 12 19.4 15.8 16.4 19 12 19Z" />
+      {/* Two big close-set eyes */}
+      <circle cx="8.8" cy="10.9" r="2.8" />
+      <circle cx="15.2" cy="10.9" r="2.8" />
+      <circle cx="8.8" cy="10.9" r="0.85" fill="currentColor" stroke="none" />
+      <circle cx="15.2" cy="10.9" r="0.85" fill="currentColor" stroke="none" />
+      {/* Central beak */}
+      <path d="M10.5 14.2 12 16.4 13.5 14.2Z" fill="currentColor" stroke="none" />
     </svg>
   )
 }


### PR DESCRIPTION
Closes #179.

## Problem
The owl mark signals "AI lives here", but the old full-body silhouette
collapsed into an indistinct blob at the 16px size it actually renders at
(the suggest-threats button, the AI Providers settings nav), so it did not
read as an owl — or as anything.

## Change
Redrawn as an owl *head* tuned for small-size legibility:
- two ear tufts
- two big close-set eyes that dominate a small head
- a central beak

These are the cues that still read as "owl" at 16px. It remains a single
`currentColor`, lucide-style 24×24 glyph, so every AI affordance
(`SuggestThreatsOwl`, the settings nav) inherits the new look with no other
changes.

## Notes
- Explored matching the proposed round-glasses concept exactly, but the
  glasses/disc detail muddied at 16px; landed on big-eyes-small-head as the
  most legible owl at that size.
- @vikram-s-narayan — flagging you since this is your proposal from #179;
  keen for your read on whether this captures the intent. Happy to iterate
  on tuft angle, eye size, or beak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)