### PR TITLE
Fix/show human actor

### DIFF
--- a/backend/apps/threat_models/report_service.py
+++ b/backend/apps/threat_models/report_service.py
@@ -244,6 +244,7 @@ def _build_components(component_ids):
             "name": comp.name,
             "category": comp.category,
             "component_type": comp.component_type,
+            "actor_type": comp.actor_type,
             "provider": comp.provider,
             "trust_zone": comp.trust_zone.name if comp.trust_zone else None,
             "description": comp.description,

--- a/frontend/src/features/guest-editor/lib/guestWordExport.ts
+++ b/frontend/src/features/guest-editor/lib/guestWordExport.ts
@@ -56,6 +56,19 @@ function formatNodeType(type: string | undefined): string {
   }
 }
 
+const ACTOR_TYPE_LABELS: Record<string, string> = {
+  user: 'User',
+  power_user: 'Power User',
+  administrator: 'Administrator',
+  engineer: 'Engineer',
+  third_party: 'Third Party',
+  customer: 'Customer',
+}
+
+function formatActorType(actorType: string): string {
+  return ACTOR_TYPE_LABELS[actorType] ?? actorType
+}
+
 /** Resolve a target name from its ID by searching nodes and edges. */
 function resolveTargetName(targetId: string, nodes: DiagramNode[], edges: DiagramEdge[]): string {
   const node = nodes.find((n) => n.id === targetId)
@@ -153,10 +166,14 @@ function buildComponentInventorySection(data: GuestReportData): (Paragraph | Tab
         [3120, 2160, 4080],
         ['Name', 'Type', 'Description'],
         componentNodes.map((node) => {
-          const nodeData = node.data as { label?: string; description?: string }
+          const nodeData = node.data as { label?: string; description?: string; actorType?: string }
+          const typeName = formatNodeType(node.type)
+          const displayType = node.type === 'humanActor' && nodeData.actorType
+            ? `${typeName}\n(${formatActorType(nodeData.actorType)})`
+            : typeName
           return [
             nodeData.label ?? '—',
-            formatNodeType(node.type),
+            displayType,
             nodeData.description ?? '—',
           ]
         }),

--- a/frontend/src/features/reports/types/report.ts
+++ b/frontend/src/features/reports/types/report.ts
@@ -93,6 +93,7 @@ export interface ReportComponent {
   name: string
   category: string
   componentType: string
+  actorType: string
   provider: string
   trustZone: string | null
   description: string

--- a/frontend/src/features/reports/utils/wordExport.ts
+++ b/frontend/src/features/reports/utils/wordExport.ts
@@ -28,6 +28,19 @@ import {
 
 type ThreatWithContext = { threat: ReportThreat; context: string }
 
+const ACTOR_TYPE_LABELS: Record<string, string> = {
+  user: 'User',
+  power_user: 'Power User',
+  administrator: 'Administrator',
+  engineer: 'Engineer',
+  third_party: 'Third Party',
+  customer: 'Customer',
+}
+
+function formatActorType(actorType: string): string {
+  return ACTOR_TYPE_LABELS[actorType] ?? actorType
+}
+
 function flattenThreats(data: ReportData): ThreatWithContext[] {
   const out: ThreatWithContext[] = []
   for (const [context, threats] of Object.entries(data.threatAnalysis.componentThreats)) {
@@ -294,13 +307,18 @@ function buildComponentsSection(data: ReportData): (Paragraph | Table)[] {
     buildTable(
       [2400, 1440, 1440, 1440, 2640],
       ['Name', 'Type', 'Category', 'Trust Zone', 'Description'],
-      allComponents.map((c) => [
-        c.name,
-        c._type,
-        c.category,
-        c.trustZone ?? '—',
-        c.description,
-      ]),
+      allComponents.map((c) => {
+        const displayType = c._type === 'Human Actor' && c.actorType
+          ? `${c._type}\n(${formatActorType(c.actorType)})`
+          : c._type
+        return [
+          c.name,
+          displayType,
+          c.category,
+          c.trustZone ?? '—',
+          c.description,
+        ]
+      }),
     ),
     spacer(),
   ]

--- a/frontend/src/features/reports/utils/wordHelpers.ts
+++ b/frontend/src/features/reports/utils/wordHelpers.ts
@@ -118,11 +118,15 @@ export function headerCell(text: string, width: number): TableCell {
 }
 
 export function dataCell(text: string, width: number): TableCell {
+  const parts = (text ?? '').split('\n')
+  const children: TextRun[] = parts.flatMap((part, i) =>
+    i === 0 ? [new TextRun(part)] : [new TextRun({ break: 1, text: part })]
+  )
   return new TableCell({
     borders: CELL_BORDERS,
     width: { size: width, type: WidthType.DXA },
     margins: CELL_MARGINS,
-    children: [new Paragraph({ children: [new TextRun(text ?? '')] })],
+    children: [new Paragraph({ children })],
   })
 }
 


### PR DESCRIPTION
  Closes #185                                                               
                                                                            
  ## Summary                                                                
                                                                            
  When a specific Actor Type (e.g., "Power User", "Administrator") is set on
   a Human Actor component in the DFD editor, that value was not included   
  anywhere in the generated Word report. This PR fixes that for both the
  guest editor and the signed-in report.

  ## Changes

  ### Guest editor (`guestWordExport.ts`)
  - The component inventory table now displays the actor type beneath the
  component type, e.g.:
    Human Actor
    (Power User)
  - Added `formatActorType()` to map stored value keys (e.g., `power_user`)
  to display labels (e.g., `Power User`). Falls back to the raw value for
  custom actor types.

  ### Signed-in report (`wordExport.ts`)
  - Same actor type display logic added to the component inventory section.
  - Added `formatActorType()` with the same label mapping.

  ### Backend (`report_service.py`)
  - `_build_components()` now includes `actor_type` in the component data
  sent to the frontend.

  ### Frontend types (`report.ts`)
  - Added `actorType` field to the `ReportComponent` interface.

  ### Shared (`wordHelpers.ts`)
  - `dataCell()` now supports `\n` in cell text, rendering line breaks
  within Word table cells. This is used by both export paths.

  ## Test plan
  - [ ] Guest editor: Add a Human Actor, set Actor Type to "Power User",
  download Word report — verify "Human Actor (Power User)" appears on two
  lines in the Type column
  - [ ] Guest editor: Human Actor with no actor type set — verify it still
  shows just "Human Actor"
  - [ ] Signed-in report: Same checks via the report tab Word export
  - [ ] Guest editor: Custom actor type (typed manually, not from
  suggestions) — verify it displays as-is
