### PR TITLE
docs: clarify workflows and local reset guidance

### DIFF
--- a/docs/concepts/completion-status.md
+++ b/docs/concepts/completion-status.md
@@ -25,6 +25,12 @@ The backend computes the checklist fresh on every request. Nothing is stored or 
 
 Dismissed threats do not count toward the "Threats linked" items. Only active, non-dismissed threats satisfy those checks.
 
+The checklist is a model-completeness signal, not a risk-acceptance or compliance signal. For example, "Countermeasures assigned" means that at least one countermeasure exists for in-scope components or flows. It does not mean every countermeasure is implemented, verified, or sufficient to satisfy a compliance requirement.
+
+Countermeasure status, threat mitigation status, residual risk, and compliance satisfaction are related but separate concepts. A countermeasure status describes implementation progress for a control. Threat mitigation status summarizes whether linked controls appear to address a threat. Residual risk estimates the remaining risk after considering available controls. Compliance satisfaction depends on mapped requirements and the statuses counted as satisfying evidence in reports.
+
+When interpreting a report, compare these signals together instead of treating any single checkbox as final evidence. A threat model can be structurally complete while still containing open risks, planned controls, unverified controls, or compliance gaps. Completion status answers "has this part of the model been filled in?" rather than "is this system fully mitigated?"
+
 ## Where it appears
 
 The checklist surfaces on the Overview tab, in magic link shared views, and in exported reports.

--- a/docs/concepts/roles-and-permissions.md
+++ b/docs/concepts/roles-and-permissions.md
@@ -11,6 +11,8 @@ Every organization member has one of two roles:
 
 Organization members are managed in **Settings > Members**. Only Security Team members can change roles or remove members.
 
+Organization roles are intended to be scoped to the organization where the membership exists. If a user belongs to multiple organizations, their Security Team role in one organization should not be treated as administrative authority in another organization. When reviewing API behavior or debugging permissions, always check both the user's organization membership and the organization that owns the object being modified.
+
 ![Organization members settings page](../assets/images/roles-and-permissions-settings.png)
 
 ## Team roles
@@ -26,6 +28,8 @@ Within a team, each member has a role that controls what they can do with that t
 | Change team member roles                  | Yes  | Yes    | No     |
 
 **Security Team** (org-level role) bypasses all team-level checks — they get unconditional write access across the entire organization regardless of team membership.
+
+Team roles apply only inside the team where they are assigned. A Lead in one team does not automatically manage another team unless they also hold the Security Team organization role. Member-management actions should be evaluated against the team being changed, while organization-level member actions should be evaluated against the organization being changed.
 
 ## Threat model visibility
 
@@ -51,6 +55,8 @@ The invite flow works by email:
 
 When an invited user signs up or logs in using the invite link, any pending invitations for their email are **automatically accepted** — they're added to the team and organization without needing to click an accept button.
 
+In local development, invitation email delivery may use Django's console backend. In that setup the application creates the invitation and prints or returns the link, but no real email is delivered to the recipient. Copy the generated invite link and share it manually when testing team onboarding locally.
+
 ### Organization members
 
 Organization membership is typically managed automatically:
@@ -69,3 +75,5 @@ Threat models can be shared externally using **magic links** — tokenized URLs 
 - If a logged-in user accesses a magic link, the threat model appears in their **Shared with Me** section on the Threat Models page.
 
 See [Magic Links](magic-links.md) for full details on creating and managing shared links.
+
+Magic links are intentionally different from organization and team membership. They grant read-only access to a single shared threat model and do not add the recipient to the owning organization or team. Use team invitations when the recipient should become a collaborator, and use magic links when the recipient only needs read-only review access.

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -84,6 +84,19 @@ docker compose down
 
 Use `docker compose down -v` only when you want to delete the local database volume and reseed from scratch on the next startup.
 
+## Reset Seeded Data
+
+Docker keeps PostgreSQL data in a named volume. That volume survives container rebuilds, so an older local database can drift from the current migrations or seed data after switching branches, pulling new changes, or testing schema-related fixes. When that happens, the app may fail during startup, seed commands may report unexpected constraint errors, or the UI may show stale demo data that does not match the current code.
+
+To reset the local database and reseed from the current branch:
+
+```bash
+docker compose down -v
+docker compose up --build
+```
+
+The `-v` flag deletes the PostgreSQL volume. Use it only for local development data you are comfortable losing.
+
 ## Frontend Workflow
 
 The frontend container runs Vite on port `5173`. API calls use `/api` in the browser and are proxied by Vite to the backend container through the `API_URL` value in `docker-compose.yml`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -98,6 +98,8 @@ docker compose up --build
 
 The `-v` flag removes the PostgreSQL data volume. On the next start, the database is recreated and re-seeded.
 
+Use this reset after pulling changes that alter migrations or seed data, or when local demo data no longer matches the current branch. A normal `docker compose down` stops containers but keeps the database volume, so old schema/data can survive rebuilds.
+
 ## Troubleshooting
 
 ### Port conflicts

--- a/docs/guides/importing-exporting.md
+++ b/docs/guides/importing-exporting.md
@@ -55,6 +55,10 @@ Data that has no equivalent in the TM-Library schema is preserved in an `extensi
 !!! tip
     When sharing with non-Precogly tools, the extensions block is safely ignored — the standard TM-Library fields carry the core threat model data. When re-importing into Precogly, the extensions restore the full analytical context.
 
+Some fields are preserved primarily for round-trip fidelity even when the current UI does not expose a dedicated editor for them. For example, risk metadata such as domains, target score, and target level can be imported from richer formats and retained by the backend, but day-to-day risk workflows may still focus on the visible score, level, owner, assignee, and response fields. Treat these preserved fields as interoperability data unless your workflow explicitly surfaces them.
+
+Status values can also come from external schemas whose vocabulary does not perfectly match Precogly's internal countermeasure statuses. During import, statuses are mapped into the closest local concept where possible. If an external status cannot be mapped cleanly, review the imported controls before relying on downstream mitigation, residual-risk, or compliance reports.
+
 ### What's not exported
 
 Some data is intentionally excluded because it is instance-specific or not meaningful outside the originating environment:
@@ -86,6 +90,8 @@ Precogly validates the file structure before importing. Issues are reported as e
 
 - **Errors** block the import entirely (missing required fields, invalid types, duplicate symbolic names).
 - **Warnings** allow the import to proceed (unresolved references, unknown extensions). Entities with unresolvable references are created without those associations.
+
+Validation focuses on whether the file can be converted into a coherent threat model. A syntactically valid file can still contain repeated references, unknown status values, or fields that are meaningful to the source tool but not directly editable in Precogly. After importing third-party files, review the generated threats, controls, risks, and warnings before using the result as audit evidence.
 
 ### What happens during import
 
@@ -123,6 +129,18 @@ Some structural differences between TM-Library and Precogly are resolved during 
 | **`inherent_severity`** | Imported directly onto threat instances (defaults to `medium` if absent). On export, both `inherent_severity` and `residual_severity` are included. |
 | **`event` (on threats)** | Mapped to the `impact_description` field on threat instances. |
 | **Actor `type`** | Stored in `format_metadata` for round-trip. Actor category is set to `null` on import; users classify post-import. |
+
+### Risk fields and round-trip metadata
+
+Imported risks may include additional planning fields such as domains, target score, or target level. These values are useful when moving models between tools or preserving TM-BOM-style context, but they may not all appear in the primary risk UI. The import process keeps this metadata so a later export can retain as much of the original model as possible.
+
+When reviewing an imported risk, use the visible risk score, level, response, owner, and assignee as the main operational fields. If your source file uses target risk or domain classifications for governance, verify those values through the API/export path until the UI exposes first-class editing for them.
+
+### Control status mapping
+
+External threat-model formats can contain control statuses that differ from Precogly's local lifecycle. Precogly maps known statuses during import, then uses the resulting local status for threat mitigation, residual scoring, and report generation. Because those downstream calculations depend on the mapped status, status warnings should be reviewed with the same care as unresolved component or taxonomy references.
+
+If an imported control appears with an unexpected status, update it in Precogly before relying on generated reports. This is especially important for statuses that sound final in the source tool but do not have an exact local equivalent.
 
 ### Restoring Precogly extensions
 


### PR DESCRIPTION
This PR updates several documentation pages to clarify behavior that can otherwise be confusing during local development, import/export workflows, permissions review, and report interpretation.

 - Clarify organization/team role scope and the difference between team invitations and magic links
  - Document import/export round-trip metadata, including risk planning fields and control-status mapping caveats
  - Clarify that completion status is separate from mitigation, residual risk, and compliance satisfaction
  - Add local Docker volume reset guidance for stale schema or seed data after branch changes