### PR TITLE
fix/CycloneDX import errors and scope IsSecurityTeam permission

### DIFF
--- a/backend/apps/core/permissions.py
+++ b/backend/apps/core/permissions.py
@@ -5,10 +5,50 @@ Core permission classes for RBAC.
 from rest_framework import permissions
 
 
+def _get_organization(obj):
+    """Walk FK paths to find the organization for an object."""
+    # Direct organization FK
+    if hasattr(obj, "organization_id") and obj.organization_id:
+        return obj.organization
+
+    # threat_model -> organization
+    if hasattr(obj, "threat_model_id") and obj.threat_model_id:
+        return obj.threat_model.organization
+
+    # component -> orgsystem -> organization
+    if hasattr(obj, "component_id"):
+        component = obj.component
+        if component and hasattr(component, "orgsystem") and component.orgsystem:
+            return component.orgsystem.organization
+
+    # data_flow -> source_component -> orgsystem -> organization
+    if hasattr(obj, "source_component_id"):
+        source = obj.source_component
+        if source and source.orgsystem:
+            return source.orgsystem.organization
+
+    # orgsystem -> organization
+    if hasattr(obj, "orgsystem_id") and obj.orgsystem_id:
+        return obj.orgsystem.organization
+
+    # orgsystem (the object itself IS an Orgsystem)
+    if hasattr(obj, "organization_id") and obj.__class__.__name__ == "Orgsystem":
+        return obj.organization
+
+    return None
+
+
 class IsSecurityTeam(permissions.BasePermission):
     """
     Restricts write operations to security team members.
     Read operations are allowed for all authenticated users.
+
+    has_permission: gates on security_team role in any org (covers
+    create/list where no object exists yet).
+    has_object_permission: gates on security_team role in the
+    *object's* org, preventing cross-org privilege escalation.
+    For global resources (org unresolvable), falls through since
+    has_permission already passed.
     """
 
     def has_permission(self, request, view):
@@ -17,6 +57,17 @@ class IsSecurityTeam(permissions.BasePermission):
         if not request.user.is_authenticated:
             return False
         return request.user.organization_memberships.filter(
+            role="security_team",
+        ).exists()
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        organization = _get_organization(obj)
+        if organization is None:
+            return True
+        return request.user.organization_memberships.filter(
+            organization=organization,
             role="security_team",
         ).exists()
 
@@ -38,7 +89,7 @@ class CanWrite(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        organization = self._get_organization(obj)
+        organization = _get_organization(obj)
         if organization is None:
             return True
 
@@ -107,38 +158,5 @@ class CanWrite(permissions.BasePermission):
 
         if threat_model and hasattr(threat_model, "owning_team"):
             return threat_model.owning_team
-
-        return None
-
-    @staticmethod
-    def _get_organization(obj):
-        """Walk FK paths to find the organization for an object."""
-        # Direct organization FK
-        if hasattr(obj, "organization_id") and obj.organization_id:
-            return obj.organization
-
-        # threat_model -> organization
-        if hasattr(obj, "threat_model_id") and obj.threat_model_id:
-            return obj.threat_model.organization
-
-        # component -> orgsystem -> organization
-        if hasattr(obj, "component_id"):
-            component = obj.component
-            if component and hasattr(component, "orgsystem") and component.orgsystem:
-                return component.orgsystem.organization
-
-        # data_flow -> source_component -> orgsystem -> organization
-        if hasattr(obj, "source_component_id"):
-            source = obj.source_component
-            if source and source.orgsystem:
-                return source.orgsystem.organization
-
-        # orgsystem -> organization
-        if hasattr(obj, "orgsystem_id") and obj.orgsystem_id:
-            return obj.orgsystem.organization
-
-        # orgsystem (the object itself IS an Orgsystem)
-        if hasattr(obj, "organization_id") and obj.__class__.__name__ == "Orgsystem":
-            return obj.organization
 
         return None

--- a/backend/apps/organizations/tests/test_permissions.py
+++ b/backend/apps/organizations/tests/test_permissions.py
@@ -1,0 +1,121 @@
+"""Tests for org-scoped IsSecurityTeam permission (R-02 fix)."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, RequestFactory
+
+from apps.core.permissions import IsSecurityTeam
+from apps.organizations.models import (
+    BusinessUnit,
+    Organization,
+    OrganizationMember,
+)
+
+User = get_user_model()
+
+
+class IsSecurityTeamObjectPermissionTests(TestCase):
+    """Verify IsSecurityTeam enforces org-scoped role checks at object level."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.factory = RequestFactory()
+        cls.permission = IsSecurityTeam()
+
+        cls.org_a = Organization.objects.create(name="Org A", domain="org-a.test")
+        cls.org_b = Organization.objects.create(name="Org B", domain="org-b.test")
+
+        cls.user_sec_a = User.objects.create_user(
+            username="sec_a", email="sec_a@example.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_a, user=cls.user_sec_a, role="security_team"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_b, user=cls.user_sec_a, role="member"
+        )
+
+        cls.user_sec_b = User.objects.create_user(
+            username="sec_b", email="sec_b@example.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_b, user=cls.user_sec_b, role="security_team"
+        )
+
+        cls.user_member = User.objects.create_user(
+            username="member", email="member@example.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_a, user=cls.user_member, role="member"
+        )
+
+        cls.bu_a = BusinessUnit.objects.create(
+            organization=cls.org_a, name="BU in Org A", code="bu-a"
+        )
+        cls.bu_b = BusinessUnit.objects.create(
+            organization=cls.org_b, name="BU in Org B", code="bu-b"
+        )
+
+    def _make_patch_request(self, user):
+        request = self.factory.patch("/fake/")
+        request.user = user
+        return request
+
+    def _make_get_request(self, user):
+        request = self.factory.get("/fake/")
+        request.user = user
+        return request
+
+    def test_has_permission_allows_security_team_in_any_org(self):
+        request = self._make_patch_request(self.user_sec_a)
+        self.assertTrue(self.permission.has_permission(request, None))
+
+    def test_has_permission_allows_member_with_personal_workspace(self):
+        """Users get a personal workspace with security_team role via signal,
+        so has_permission passes — org scoping happens at object level."""
+        request = self._make_patch_request(self.user_member)
+        self.assertTrue(self.permission.has_permission(request, None))
+
+    def test_has_permission_allows_safe_methods(self):
+        request = self._make_get_request(self.user_member)
+        self.assertTrue(self.permission.has_permission(request, None))
+
+    def test_object_permission_allows_security_team_in_same_org(self):
+        request = self._make_patch_request(self.user_sec_a)
+        self.assertTrue(
+            self.permission.has_object_permission(request, None, self.bu_a)
+        )
+
+    def test_object_permission_denies_security_team_in_different_org(self):
+        """R-02: security_team in Org A must NOT write to Org B objects."""
+        request = self._make_patch_request(self.user_sec_a)
+        self.assertFalse(
+            self.permission.has_object_permission(request, None, self.bu_b)
+        )
+
+    def test_object_permission_allows_security_team_in_target_org(self):
+        request = self._make_patch_request(self.user_sec_b)
+        self.assertTrue(
+            self.permission.has_object_permission(request, None, self.bu_b)
+        )
+
+    def test_object_permission_allows_safe_methods_for_anyone(self):
+        request = self._make_get_request(self.user_member)
+        self.assertTrue(
+            self.permission.has_object_permission(request, None, self.bu_b)
+        )
+
+    def test_object_permission_denies_plain_member_write(self):
+        request = self._make_patch_request(self.user_member)
+        self.assertFalse(
+            self.permission.has_object_permission(request, None, self.bu_a)
+        )
+
+    def test_cross_org_member_management_blocked(self):
+        """security_team in Org A cannot modify Org B's member records."""
+        member_b = OrganizationMember.objects.filter(
+            organization=self.org_b, user=self.user_sec_b
+        ).first()
+        request = self._make_patch_request(self.user_sec_a)
+        self.assertFalse(
+            self.permission.has_object_permission(request, None, member_b)
+        )

--- a/backend/apps/threat_models/adapters/cyclonedx.py
+++ b/backend/apps/threat_models/adapters/cyclonedx.py
@@ -972,7 +972,8 @@ class CycloneDxAdapter(BaseAdapter):
         }
         for threat_data in threats_block.get("threats", []):
             self._import_threat(
-                threat_data, threat_model, resolver, scenario_threat_refs
+                threat_data, threat_model, resolver, scenario_threat_refs,
+                warnings,
             )
             summary["threats"] += 1
 
@@ -1279,7 +1280,15 @@ class CycloneDxAdapter(BaseAdapter):
         bom_ref = control_data.get("bom-ref", "")
         name = control_data.get("name", bom_ref)
         cdx_status = control_data.get("status", "recommended")
+        valid_statuses = {c[0] for c in InstanceCountermeasure.Status.choices}
         status = CDX_STATUS_TO_CONTROL.get(cdx_status, "gap")
+        if status not in valid_statuses:
+            logger.warning(
+                "CycloneDX status '%s' mapped to invalid status '%s', defaulting to 'gap'.",
+                cdx_status,
+                status,
+            )
+            status = "gap"
 
         effectiveness = None
         eff_data = control_data.get("effectiveness", {})
@@ -1311,7 +1320,8 @@ class CycloneDxAdapter(BaseAdapter):
         return cm
 
     def _import_threat(
-        self, threat_data, threat_model, resolver, scenario_threat_refs
+        self, threat_data, threat_model, resolver, scenario_threat_refs,
+        warnings,
     ):
         from apps.threats.models import ThreatLibrary
 
@@ -1333,11 +1343,13 @@ class CycloneDxAdapter(BaseAdapter):
         if bom_ref not in scenario_threat_refs:
             for asset_ref in threat_data.get("affectedAssets", []):
                 self._create_instance_threat_from_abstract(
-                    threat_lib, asset_ref, threat_data, threat_model, resolver
+                    threat_lib, asset_ref, threat_data, threat_model, resolver,
+                    warnings,
                 )
 
     def _create_instance_threat_from_abstract(
-        self, threat_lib, asset_ref, threat_data, threat_model, resolver
+        self, threat_lib, asset_ref, threat_data, threat_model, resolver,
+        warnings,
     ):
         from apps.systems.models import DataFlow, OrgsystemComponent
         from apps.threats.models import (
@@ -1356,22 +1368,35 @@ class CycloneDxAdapter(BaseAdapter):
             )
             return
 
+        created = False
         if isinstance(target, OrgsystemComponent):
-            ComponentInstanceThreat.objects.create(
+            _, created = ComponentInstanceThreat.objects.get_or_create(
                 component=target,
                 threat_library=threat_lib,
-                threat_name=threat_lib.name,
-                threat_description=threat_lib.description,
-                inherent_severity="medium",
+                defaults={
+                    "threat_name": threat_lib.name,
+                    "threat_description": threat_lib.description,
+                    "inherent_severity": "medium",
+                },
             )
         elif isinstance(target, DataFlow):
-            DataFlowInstanceThreat.objects.create(
+            _, created = DataFlowInstanceThreat.objects.get_or_create(
                 data_flow=target,
                 threat_library=threat_lib,
-                threat_name=threat_lib.name,
-                threat_description=threat_lib.description,
-                inherent_severity="medium",
+                defaults={
+                    "threat_name": threat_lib.name,
+                    "threat_description": threat_lib.description,
+                    "inherent_severity": "medium",
+                },
             )
+
+        if not created and target:
+            msg = (
+                f"Duplicate threat-asset link skipped: "
+                f"threat '{threat_lib.name}' × asset '{target.name}'."
+            )
+            logger.warning(msg)
+            warnings.append(msg)
 
     def _import_scenario(self, scenario_data, threat_model, resolver):
         from apps.systems.models import DataFlow, OrgsystemComponent

--- a/backend/apps/threat_models/tests/test_cyclonedx_adapter.py
+++ b/backend/apps/threat_models/tests/test_cyclonedx_adapter.py
@@ -685,3 +685,69 @@ class TestCycloneDxEnumMappings(CycloneDxTestMixin, TestCase):
         tm, _ = self.adapter.import_data(json_data, self.org, self.user)
         risk = Risk.objects.get(threat_model=tm)
         self.assertEqual(risk.inherent_level, "low")
+
+    def test_invalid_control_status_defaults_to_gap(self):
+        """Unknown CDX status values must not persist as invalid choices."""
+        from apps.threat_models.adapters.cyclonedx_enum_maps import CDX_STATUS_TO_CONTROL
+
+        original = dict(CDX_STATUS_TO_CONTROL)
+        CDX_STATUS_TO_CONTROL["totally-bogus"] = "totally_bogus"
+        try:
+            json_data = {
+                "specFormat": "CycloneDX",
+                "specVersion": "2.0",
+                "blueprints": [{"name": "Test"}],
+                "controls": [
+                    {
+                        "bom-ref": "ctrl-bogus",
+                        "name": "Bogus Status Control",
+                        "status": "totally-bogus",
+                    }
+                ],
+            }
+            tm, _ = self.adapter.import_data(json_data, self.org, self.user)
+            control = InstanceCountermeasure.objects.get(threat_model=tm)
+            self.assertEqual(control.status, "gap")
+        finally:
+            CDX_STATUS_TO_CONTROL.clear()
+            CDX_STATUS_TO_CONTROL.update(original)
+
+    def test_duplicate_affected_asset_does_not_abort_import(self):
+        """Same asset listed twice in affectedAssets must not raise
+        IntegrityError on the (component, threat_library) unique constraint.
+        The duplicate should be skipped and surfaced as a warning."""
+        json_data = {
+            "specFormat": "CycloneDX",
+            "specVersion": "2.0",
+            "blueprints": [
+                {
+                    "name": "Test",
+                    "assets": [
+                        {
+                            "bom-ref": "asset-dup",
+                            "name": "Shared Component",
+                            "type": "component",
+                        }
+                    ],
+                }
+            ],
+            "threats": {
+                "threats": [
+                    {
+                        "bom-ref": "threat-dup",
+                        "name": "Duplicate Ref Threat",
+                        "affectedAssets": ["asset-dup", "asset-dup"],
+                    },
+                ],
+            },
+        }
+        tm, summary = self.adapter.import_data(json_data, self.org, self.user)
+        self.assertEqual(summary["threats"], 1)
+        instances = ComponentInstanceThreat.objects.filter(
+            component__threat_model=tm
+        )
+        self.assertEqual(instances.count(), 1)
+        warnings = summary.get("warnings", [])
+        dup_warnings = [w for w in warnings if "Duplicate threat-asset link" in w]
+        self.assertEqual(len(dup_warnings), 1)
+        self.assertIn("Shared Component", dup_warnings[0])


### PR DESCRIPTION
## Summary

Fixes #224 and #209

### CycloneDX Import Improvements

- CycloneDX import now validates mapped control statuses against `InstanceCountermeasure.Status.choices` before persisting. If a future CycloneDX status maps to an invalid local value, the import now defaults to `gap` and surfaces a warning instead of attempting to save an invalid choice to the database.
- CycloneDX abstract-threat import now uses `.get_or_create()` instead of `.create()` for `ComponentInstanceThreat` and `DataFlowInstanceThreat`. Previously, if a BOM listed the same asset multiple times in `affectedAssets`, the import would raise an `IntegrityError` due to the `(component, threat_library)` unique constraint, causing the entire import to fail with an opaque HTTP 400 response. Duplicate entries are now safely deduplicated, and a user-facing warning is included in the import summary (displayed in the existing yellow warning banner in the import dialog).

### Permission Fix

- `IsSecurityTeam` previously implemented only `has_permission`, which checked whether a user had the `security_team` role in *any* organization. As a result, a user who was `security_team` in **Organization A** but only a member in **Organization B** could still modify Organization B's business units, member records, and other organization-scoped resources.
- Added `has_object_permission`, which resolves the owning organization of the target object and verifies the user's role within that specific organization before allowing writes.
- Extracted `_get_organization` into a shared module-level helper so both `IsSecurityTeam` and `CanWrite` use the same organization resolution logic.
- Global catalog resources (where no owning organization can be resolved) continue to follow the existing behavior and are handled correctly.

<img width="1681" height="1038" alt="Screenshot From 2026-07-19 22-41-19" src="https://github.com/user-attachments/assets/07ec71eb-9d04-42dd-a4e0-9767d65dd580" />
