### PR TITLE
Fix team member self-escalation vulnerability

### DIFF
--- a/backend/apps/organizations/tests/test_team_membership.py
+++ b/backend/apps/organizations/tests/test_team_membership.py
@@ -1,0 +1,201 @@
+"""Tests for team membership management access controls (R-01 fix)."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.organizations.models import (
+    Organization,
+    OrganizationMember,
+    Team,
+    TeamMembership,
+)
+
+User = get_user_model()
+
+
+class TeamMembershipPermissionTests(TestCase):
+    """Verify that only team leads and org security_team can manage members."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org = Organization.objects.create(name="Test Org", domain="test.org")
+
+        cls.lead_user = User.objects.create_user(
+            username="lead", email="lead@test.org", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org, user=cls.lead_user, role="member"
+        )
+
+        cls.member_user = User.objects.create_user(
+            username="member", email="member@test.org", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org, user=cls.member_user, role="member"
+        )
+
+        cls.sec_user = User.objects.create_user(
+            username="sectm", email="sec@test.org", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org, user=cls.sec_user, role="security_team"
+        )
+
+        cls.viewer_user = User.objects.create_user(
+            username="viewer", email="viewer@test.org", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org, user=cls.viewer_user, role="member"
+        )
+
+        cls.extra_user = User.objects.create_user(
+            username="extra", email="extra@test.org", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org, user=cls.extra_user, role="member"
+        )
+
+        cls.team = Team.objects.create(
+            organization=cls.org, name="Test Team", code="test"
+        )
+        TeamMembership.objects.create(
+            team=cls.team, user=cls.lead_user, role="lead"
+        )
+        TeamMembership.objects.create(
+            team=cls.team, user=cls.member_user, role="member"
+        )
+        TeamMembership.objects.create(
+            team=cls.team, user=cls.viewer_user, role="viewer"
+        )
+
+    def setUp(self):
+        self.lead_client = APIClient()
+        self.lead_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.lead_user).access_token}"
+        )
+        self.member_client = APIClient()
+        self.member_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.member_user).access_token}"
+        )
+        self.sec_client = APIClient()
+        self.sec_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.sec_user).access_token}"
+        )
+
+    # --- add-member ---
+
+    def test_member_cannot_add_member(self):
+        resp = self.member_client.post(
+            f"/api/teams/{self.team.id}/add-member/",
+            {"user_id": self.extra_user.id},
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_lead_can_add_member(self):
+        resp = self.lead_client.post(
+            f"/api/teams/{self.team.id}/add-member/",
+            {"user_id": self.extra_user.id},
+        )
+        self.assertIn(resp.status_code, [200, 201])
+
+    def test_security_team_can_add_member(self):
+        resp = self.sec_client.post(
+            f"/api/teams/{self.team.id}/add-member/",
+            {"user_id": self.extra_user.id},
+        )
+        self.assertIn(resp.status_code, [200, 201])
+
+    # --- invite-member ---
+
+    def test_member_cannot_invite(self):
+        resp = self.member_client.post(
+            f"/api/teams/{self.team.id}/invite-member/",
+            {"email": "new@example.com"},
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_lead_can_invite(self):
+        resp = self.lead_client.post(
+            f"/api/teams/{self.team.id}/invite-member/",
+            {"email": "invited@example.com"},
+        )
+        self.assertIn(resp.status_code, [200, 201])
+
+    # --- change-member-role ---
+
+    def test_member_cannot_change_role(self):
+        resp = self.member_client.post(
+            f"/api/teams/{self.team.id}/change-member-role/",
+            {"user_id": self.viewer_user.id, "role": "lead"},
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_member_cannot_self_escalate(self):
+        """R-01 core bug: a plain member must not promote themselves to lead."""
+        resp = self.member_client.post(
+            f"/api/teams/{self.team.id}/change-member-role/",
+            {"user_id": self.member_user.id, "role": "lead"},
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_lead_can_change_role(self):
+        resp = self.lead_client.post(
+            f"/api/teams/{self.team.id}/change-member-role/",
+            {"user_id": self.viewer_user.id, "role": "member"},
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    def test_invalid_role_rejected(self):
+        resp = self.lead_client.post(
+            f"/api/teams/{self.team.id}/change-member-role/",
+            {"user_id": self.member_user.id, "role": "superadmin"},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Invalid role", resp.json().get("error", ""))
+
+    # --- remove-member ---
+
+    def test_member_cannot_remove_member(self):
+        resp = self.member_client.post(
+            f"/api/teams/{self.team.id}/remove-member/",
+            {"user_id": self.viewer_user.id},
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_lead_can_remove_member(self):
+        resp = self.lead_client.post(
+            f"/api/teams/{self.team.id}/remove-member/",
+            {"user_id": self.viewer_user.id},
+        )
+        self.assertEqual(resp.status_code, 204)
+
+    # --- last-lead guard ---
+
+    def test_cannot_demote_last_lead(self):
+        resp = self.lead_client.post(
+            f"/api/teams/{self.team.id}/change-member-role/",
+            {"user_id": self.lead_user.id, "role": "member"},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("only team lead", resp.json().get("error", ""))
+
+    def test_cannot_remove_last_lead(self):
+        resp = self.lead_client.post(
+            f"/api/teams/{self.team.id}/remove-member/",
+            {"user_id": self.lead_user.id},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("only team lead", resp.json().get("error", ""))
+
+    def test_can_demote_lead_when_another_exists(self):
+        """If there are two leads, demoting one is fine."""
+        TeamMembership.objects.create(
+            team=self.team, user=self.sec_user, role="lead"
+        )
+        resp = self.sec_client.post(
+            f"/api/teams/{self.team.id}/change-member-role/",
+            {"user_id": self.lead_user.id, "role": "member"},
+        )
+        self.assertEqual(resp.status_code, 200)

--- a/backend/apps/organizations/views.py
+++ b/backend/apps/organizations/views.py
@@ -254,16 +254,38 @@ class TeamViewSet(viewsets.ModelViewSet):
             role=TeamMembership.Role.LEAD,
         )
 
+    def _can_manage_team(self, team, user):
+        """Return True if user is team lead or org security_team."""
+        if team.organization.members.filter(
+            user=user, role="security_team"
+        ).exists():
+            return True
+        return team.memberships.filter(user=user, role="lead").exists()
+
     @action(detail=True, methods=["post"], url_path="change-member-role")
     def change_member_role(self, request, pk=None):
         """Change a team member's role."""
         team = self.get_object()
+
+        if not self._can_manage_team(team, request.user):
+            return Response(
+                {"detail": "Only team leads and security team members can manage roles."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         user_id = request.data.get("user_id")
         new_role = request.data.get("role")
 
         if not user_id or not new_role:
             return Response(
                 {"error": "user_id and role are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        valid_roles = {r[0] for r in TeamMembership.Role.choices}
+        if new_role not in valid_roles:
+            return Response(
+                {"error": f"Invalid role. Must be one of: {', '.join(sorted(valid_roles))}"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -274,6 +296,14 @@ class TeamViewSet(viewsets.ModelViewSet):
                 {"error": "Member not found"},
                 status=status.HTTP_404_NOT_FOUND,
             )
+
+        if membership.role == "lead" and new_role != "lead":
+            remaining_leads = team.memberships.filter(role="lead").exclude(user_id=user_id).count()
+            if remaining_leads == 0:
+                return Response(
+                    {"error": "Cannot change role: this is the only team lead."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         membership.role = new_role
         membership.save(update_fields=["role", "updated_at"])
@@ -294,6 +324,13 @@ class TeamViewSet(viewsets.ModelViewSet):
         For non-existent users, use invite_member instead.
         """
         team = self.get_object()
+
+        if not self._can_manage_team(team, request.user):
+            return Response(
+                {"detail": "Only team leads and security team members can add members."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         user_id = request.data.get("user_id")
         role = request.data.get("role", "member")
 
@@ -325,6 +362,13 @@ class TeamViewSet(viewsets.ModelViewSet):
         - If user doesn't exist: creates TeamInvitation (pending)
         """
         team = self.get_object()
+
+        if not self._can_manage_team(team, request.user):
+            return Response(
+                {"detail": "Only team leads and security team members can invite members."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         email = request.data.get("email")
         role = request.data.get("role", "member")
 
@@ -391,6 +435,13 @@ class TeamViewSet(viewsets.ModelViewSet):
     def remove_member(self, request, pk=None):
         """Remove a member from a team."""
         team = self.get_object()
+
+        if not self._can_manage_team(team, request.user):
+            return Response(
+                {"detail": "Only team leads and security team members can remove members."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         user_id = request.data.get("user_id")
 
         if not user_id:
@@ -401,13 +452,22 @@ class TeamViewSet(viewsets.ModelViewSet):
 
         try:
             membership = team.memberships.get(user_id=user_id)
-            membership.delete()
-            return Response(status=status.HTTP_204_NO_CONTENT)
         except TeamMembership.DoesNotExist:
             return Response(
                 {"error": "Member not found"},
                 status=status.HTTP_404_NOT_FOUND,
             )
+
+        if membership.role == "lead":
+            remaining_leads = team.memberships.filter(role="lead").exclude(user_id=user_id).count()
+            if remaining_leads == 0:
+                return Response(
+                    {"error": "Cannot remove the only team lead."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        membership.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=True, methods=["post"])
     def join(self, request, pk=None):


### PR DESCRIPTION
## Summary
- All 4 team management endpoints (`change-member-role`, `add-member`, `invite-member`, `remove-member`) were unguarded - any team member could promote themselves to lead, add/remove members, or invite outsiders
- Added `_can_manage_team()` authorization check: only **team leads** and **org security_team** members can perform management actions
- Added role validation against `TeamMembership.Role.choices` (rejects arbitrary strings like "superadmin")
- Added last-lead safety guard: cannot demote or remove the only team lead

Fixes #176 


<img width="734" height="727" alt="Screenshot From 2026-07-19 23-16-20" src="https://github.com/user-attachments/assets/028a183b-b227-4c58-beef-d3c39a9490fb" />
