### PR TITLE
Add magic link auth and cross tenant validation

### DIFF
--- a/backend/apps/diagrams/tests/test_dfd_cross_tenant.py
+++ b/backend/apps/diagrams/tests/test_dfd_cross_tenant.py
@@ -1,0 +1,84 @@
+"""Tests for DFD cross-tenant access control (SEC-02 fix)."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.organizations.models import Organization, OrganizationMember
+from apps.threat_models.models import ThreatModel
+
+User = get_user_model()
+
+
+class DFDCrossTenantTests(TestCase):
+    """Verify that DFDs cannot be created for another org's threat models."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org_a = Organization.objects.create(name="Org A", domain="a.com")
+        cls.org_b = Organization.objects.create(name="Org B", domain="b.com")
+
+        cls.user_a = User.objects.create_user(
+            username="user_a", email="a@a.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_a, user=cls.user_a, role="security_team"
+        )
+
+        cls.user_b = User.objects.create_user(
+            username="user_b", email="b@b.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_b, user=cls.user_b, role="security_team"
+        )
+
+        cls.tm_a = ThreatModel.objects.create(
+            name="TM A", organization=cls.org_a
+        )
+        cls.tm_b = ThreatModel.objects.create(
+            name="TM B", organization=cls.org_b
+        )
+
+    def setUp(self):
+        self.client_a = APIClient()
+        self.client_a.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user_a).access_token}"
+        )
+        self.client_b = APIClient()
+        self.client_b.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user_b).access_token}"
+        )
+
+    def test_cannot_create_dfd_for_other_orgs_tm(self):
+        """SEC-02 core bug: user in org B must not attach a DFD to org A's TM."""
+        resp = self.client_b.post(
+            "/api/diagrams/",
+            {"name": "Evil DFD", "threat_model_id": str(self.tm_a.id)},
+        )
+        self.assertEqual(resp.status_code, 404)
+        self.assertIn("not found", resp.data.get("error", "").lower())
+
+    def test_can_create_dfd_for_own_orgs_tm(self):
+        """User can create a DFD for their own org's threat model."""
+        resp = self.client_a.post(
+            "/api/diagrams/",
+            {"name": "Legit DFD", "threat_model_id": str(self.tm_a.id)},
+        )
+        self.assertEqual(resp.status_code, 201)
+
+    def test_cannot_create_dfd_without_threat_model(self):
+        """DFD creation requires a threat_model_id."""
+        resp = self.client_a.post(
+            "/api/diagrams/",
+            {"name": "Orphan DFD"},
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_nonexistent_threat_model_returns_404(self):
+        """A bogus threat_model_id returns 404."""
+        resp = self.client_a.post(
+            "/api/diagrams/",
+            {"name": "Ghost DFD", "threat_model_id": 999999},
+        )
+        self.assertEqual(resp.status_code, 404)

--- a/backend/apps/diagrams/views.py
+++ b/backend/apps/diagrams/views.py
@@ -62,8 +62,13 @@ class DFDViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        user_org_ids = request.user.organization_memberships.values_list(
+            "organization_id", flat=True
+        )
         try:
-            threat_model = ThreatModel.objects.get(id=threat_model_id)
+            threat_model = ThreatModel.objects.get(
+                id=threat_model_id, organization_id__in=user_org_ids
+            )
         except ThreatModel.DoesNotExist:
             return Response(
                 {"error": "Threat model not found"},

--- a/backend/apps/organizations/tests/test_magic_link_permissions.py
+++ b/backend/apps/organizations/tests/test_magic_link_permissions.py
@@ -1,0 +1,104 @@
+"""Tests for magic link cross-tenant access control (SEC-01 fix)."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.organizations.models import Organization, OrganizationMember
+from apps.threat_models.models import ThreatModel
+
+User = get_user_model()
+
+
+class MagicLinkCrossTenantTests(TestCase):
+    """Verify that magic links cannot be created for another org's threat models."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org_a = Organization.objects.create(name="Org A", domain="a.com")
+        cls.org_b = Organization.objects.create(name="Org B", domain="b.com")
+
+        cls.user_a = User.objects.create_user(
+            username="user_a", email="a@a.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_a, user=cls.user_a, role="security_team"
+        )
+
+        cls.user_b = User.objects.create_user(
+            username="user_b", email="b@b.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_b, user=cls.user_b, role="security_team"
+        )
+
+        cls.member_a = User.objects.create_user(
+            username="member_a", email="m@a.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_a, user=cls.member_a, role="member"
+        )
+
+        cls.tm_a = ThreatModel.objects.create(
+            name="TM A", organization=cls.org_a
+        )
+        cls.tm_b = ThreatModel.objects.create(
+            name="TM B", organization=cls.org_b
+        )
+
+    def setUp(self):
+        self.client_a = APIClient()
+        self.client_a.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user_a).access_token}"
+        )
+        self.client_b = APIClient()
+        self.client_b.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user_b).access_token}"
+        )
+        self.member_client = APIClient()
+        self.member_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.member_a).access_token}"
+        )
+
+    def test_cannot_create_magic_link_for_other_orgs_tm(self):
+        """SEC-01 core bug: user in org B must not mint a share link for org A's TM."""
+        resp = self.client_b.post(
+            "/api/magic-links/",
+            {"threat_model": str(self.tm_a.id)},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("do not have access", str(resp.data))
+
+    def test_can_create_magic_link_for_own_orgs_tm(self):
+        """Security team member can create magic link for own org's TM."""
+        resp = self.client_a.post(
+            "/api/magic-links/",
+            {"threat_model": str(self.tm_a.id)},
+        )
+        self.assertIn(resp.status_code, [200, 201])
+
+    def test_plain_member_blocked_by_org_ownership(self):
+        """Non-security-team member passes has_permission (personal workspace)
+        but is blocked by the org-ownership check in perform_create."""
+        resp = self.member_client.post(
+            "/api/magic-links/",
+            {"threat_model": str(self.tm_b.id)},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("do not have access", str(resp.data))
+
+    def test_list_only_shows_own_org_links(self):
+        """get_queryset already filters by org — verify no cross-org leakage."""
+        self.client_a.post(
+            "/api/magic-links/",
+            {"threat_model": str(self.tm_a.id)},
+        )
+        resp_b = self.client_b.get("/api/magic-links/")
+        self.assertEqual(resp_b.status_code, 200)
+        results = resp_b.data.get("results", resp_b.data)
+        for link in results:
+            self.assertNotEqual(
+                str(link["threat_model"]), str(self.tm_a.id),
+                "Org B should not see org A's magic links",
+            )

--- a/backend/apps/organizations/views.py
+++ b/backend/apps/organizations/views.py
@@ -11,6 +11,7 @@ from django.core.mail import send_mail
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, permissions, status, viewsets
+from rest_framework.exceptions import ValidationError
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -452,8 +453,24 @@ class MagicLinkViewSet(viewsets.ModelViewSet):
             threat_model__organization__members__user=user
         ).select_related("threat_model")
 
+    def get_permissions(self):
+        """Require IsSecurityTeam for create and revoke."""
+        if self.action in ["create", "revoke"]:
+            return [IsAuthenticated(), IsSecurityTeam()]
+        return [IsAuthenticated()]
+
     def perform_create(self, serializer):
         """Create magic link with token and expiration."""
+        threat_model = serializer.validated_data.get("threat_model")
+        user_org_ids = set(
+            self.request.user.organization_memberships.values_list(
+                "organization_id", flat=True
+            )
+        )
+        if threat_model.organization_id not in user_org_ids:
+            raise ValidationError(
+                {"threat_model": "You do not have access to this threat model."}
+            )
         serializer.save(
             token=secrets.token_urlsafe(32),
             created_by=self.request.user,


### PR DESCRIPTION
## Summary
- **Issue #162  (Critical)**: Any authenticated user could create a public share link for ANY org's threat model via `POST /api/magic-links/`. Added org-ownership validation in `perform_create` and `IsSecurityTeam` permission for create/revoke actions.
- **Issue #226  (High)**: DFD creation did an unscoped `ThreatModel.objects.get(id=...)` - any authenticated user could attach a DFD to any org's threat model. Scoped the lookup to the caller's org memberships.

## Changes
- `backend/apps/organizations/views.py` - Added `get_permissions()` requiring `IsSecurityTeam` for create/revoke; added org-ownership check in `perform_create`
- `backend/apps/diagrams/views.py` - Scoped `ThreatModel.objects.get()` to `organization_id__in=user_org_ids`
- `backend/apps/organizations/tests/test_magic_link_permissions.py` - 4 tests: cross-org denied, own-org allowed, member blocked by ownership check, list isolation
- `backend/apps/diagrams/tests/test_dfd_cross_tenant.py` - 4 tests: cross-org denied, own-org allowed, missing TM required, nonexistent TM 404

## Manual testing

Setup: admin (org "Demo Organization", TM id=1) vs attacker (org "Evil Corp", no demo org membership).

**Issue 1 - Attacker mints share link for victim's TM:**
POST /api/magic-links/  (as attacker)
{"threat_model": 1}

→ 400 {"threatModel": "You do not have access to this threat model."}

**issue 1 - Owner mints share link for own TM:**
POST /api/magic-links/  (as admin)
{"threat_model": 1}

→ 201 {token, url, ...}

**Second issue - Attacker creates DFD for victim's TM:**
POST /api/diagrams/  (as attacker)
{"name": "Evil DFD", "threat_model_id": 1}

→ 404 {"error": "Threat model not found"}

**Second issue - Owner creates DFD for own TM:**
POST /api/diagrams/  (as admin)
{"name": "Legit DFD", "threat_model_id": 1}

→ 201 {id, name, ...}


<img width="1371" height="407" alt="Screenshot From 2026-07-19 23-38-43" src="https://github.com/user-attachments/assets/294c4976-3106-4cd1-91f6-52f696de8d79" />
