### PR TITLE
Fix null-orgsystem cross-tenant leak and trust zone IDOR

### DIFF
--- a/backend/apps/systems/tests/test_cross_tenant.py
+++ b/backend/apps/systems/tests/test_cross_tenant.py
@@ -1,0 +1,141 @@
+"""Tests for cross-tenant isolation of null-orgsystem components (SEC-03, SEC-04)."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.organizations.models import Organization, OrganizationMember
+from apps.systems.models import OrgsystemComponent, TrustZone
+from apps.threat_models.models import ThreatModel
+
+User = get_user_model()
+
+
+class NullOrgsystemIsolationTests(TestCase):
+    """SEC-03: null-orgsystem components must not leak across tenants."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org_a = Organization.objects.create(name="Org A", domain="a.com")
+        cls.org_b = Organization.objects.create(name="Org B", domain="b.com")
+
+        cls.user_a = User.objects.create_user(
+            username="user_a", email="a@a.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_a, user=cls.user_a, role="security_team"
+        )
+
+        cls.user_b = User.objects.create_user(
+            username="user_b", email="b@b.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_b, user=cls.user_b, role="security_team"
+        )
+
+        cls.tm_a = ThreatModel.objects.create(name="TM A", organization=cls.org_a)
+        cls.tm_b = ThreatModel.objects.create(name="TM B", organization=cls.org_b)
+
+        cls.comp_a = OrgsystemComponent.objects.create(
+            name="Secret Component A",
+            orgsystem=None,
+            threat_model=cls.tm_a,
+        )
+        cls.comp_b = OrgsystemComponent.objects.create(
+            name="Secret Component B",
+            orgsystem=None,
+            threat_model=cls.tm_b,
+        )
+
+    def setUp(self):
+        self.client_a = APIClient()
+        self.client_a.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user_a).access_token}"
+        )
+        self.client_b = APIClient()
+        self.client_b.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user_b).access_token}"
+        )
+
+    def test_user_a_sees_only_own_null_orgsystem_components(self):
+        resp = self.client_a.get("/api/components/")
+        self.assertEqual(resp.status_code, 200)
+        results = resp.data.get("results", resp.data)
+        ids = [r["id"] for r in results]
+        self.assertIn(self.comp_a.id, ids)
+        self.assertNotIn(self.comp_b.id, ids)
+
+    def test_user_b_sees_only_own_null_orgsystem_components(self):
+        resp = self.client_b.get("/api/components/")
+        self.assertEqual(resp.status_code, 200)
+        results = resp.data.get("results", resp.data)
+        ids = [r["id"] for r in results]
+        self.assertIn(self.comp_b.id, ids)
+        self.assertNotIn(self.comp_a.id, ids)
+
+    def test_user_b_cannot_retrieve_org_a_component(self):
+        resp = self.client_b.get(f"/api/components/{self.comp_a.id}/")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_user_a_can_retrieve_own_component(self):
+        resp = self.client_a.get(f"/api/components/{self.comp_a.id}/")
+        self.assertEqual(resp.status_code, 200)
+
+
+class TrustZoneIDORTests(TestCase):
+    """SEC-04: trust zone query by threat_model must be org-scoped."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org_a = Organization.objects.create(name="Org A", domain="a.com")
+        cls.org_b = Organization.objects.create(name="Org B", domain="b.com")
+
+        cls.user_a = User.objects.create_user(
+            username="tz_a", email="tz_a@a.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_a, user=cls.user_a, role="security_team"
+        )
+
+        cls.user_b = User.objects.create_user(
+            username="tz_b", email="tz_b@b.com", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org_b, user=cls.user_b, role="security_team"
+        )
+
+        cls.tm_a = ThreatModel.objects.create(name="TM A", organization=cls.org_a)
+
+        cls.zone = TrustZone.objects.create(name="Secret Zone A")
+        cls.comp = OrgsystemComponent.objects.create(
+            name="Zoned Component",
+            orgsystem=None,
+            threat_model=cls.tm_a,
+            trust_zone=cls.zone,
+        )
+
+    def setUp(self):
+        self.client_b = APIClient()
+        self.client_b.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user_b).access_token}"
+        )
+        self.client_a = APIClient()
+        self.client_a.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user_a).access_token}"
+        )
+
+    def test_user_b_cannot_enumerate_org_a_zones_via_tm_param(self):
+        """SEC-04: ?threat_model=<victim_tm_id> must not leak zones."""
+        resp = self.client_b.get(f"/api/trust-zones/?threat_model={self.tm_a.id}")
+        self.assertEqual(resp.status_code, 200)
+        results = resp.data.get("results", resp.data)
+        zone_ids = [r["id"] for r in results]
+        self.assertNotIn(self.zone.id, zone_ids)
+
+    def test_user_a_can_see_own_zones_via_tm_param(self):
+        resp = self.client_a.get(f"/api/trust-zones/?threat_model={self.tm_a.id}")
+        self.assertEqual(resp.status_code, 200)
+        results = resp.data.get("results", resp.data)
+        zone_ids = [r["id"] for r in results]
+        self.assertIn(self.zone.id, zone_ids)

--- a/backend/apps/systems/views.py
+++ b/backend/apps/systems/views.py
@@ -81,9 +81,9 @@ class TrustZoneViewSet(viewsets.ModelViewSet):
         )
         threat_model_id = self.request.query_params.get("threat_model")
         if threat_model_id:
-            # Scoped: zones that have components belonging to this threat model
             return TrustZone.objects.filter(
-                components__threat_model_id=threat_model_id
+                components__threat_model_id=threat_model_id,
+                components__threat_model__organization_id__in=org_ids,
             ).distinct()
         # Default: zones reachable through any component in user's org
         return TrustZone.objects.filter(
@@ -175,7 +175,8 @@ class OrgsystemComponentViewSet(viewsets.ModelViewSet):
         user = self.request.user
         org_ids = user.organization_memberships.values_list("organization_id", flat=True)
         return OrgsystemComponent.objects.filter(
-            Q(orgsystem__organization_id__in=org_ids) | Q(orgsystem__isnull=True)
+            Q(orgsystem__organization_id__in=org_ids)
+            | Q(orgsystem__isnull=True, threat_model__organization_id__in=org_ids)
         ).select_related("component_library", "trust_zone")
 
     @action(detail=True, methods=["patch"])
@@ -310,7 +311,10 @@ class ComponentDataAssetViewSet(viewsets.ModelViewSet):
         org_ids = user.organization_memberships.values_list("organization_id", flat=True)
         return ComponentDataAsset.objects.filter(
             Q(component__orgsystem__organization_id__in=org_ids)
-            | Q(component__orgsystem__isnull=True)
+            | Q(
+                component__orgsystem__isnull=True,
+                component__threat_model__organization_id__in=org_ids,
+            )
         ).select_related("component", "data_asset")
 
 


### PR DESCRIPTION
# Summary

Fixes #227 

- **Security Issue 1 (High)**: Components/assets with `orgsystem=NULL` (analysis-only) were visible to all orgs via `Q(orgsystem__isnull=True)` with no org guard. Added `threat_model__organization_id__in=org_ids` to the null branch for both `OrgsystemComponentViewSet` and `ComponentDataAssetViewSet`.
- **Security Issue 2 (High)**: `TrustZoneViewSet` with the `?threat_model=<id>` parameter performed an unscoped query, leaking another organization's trust zones. Added `components__threat_model__organization_id__in=org_ids` to the filter.

# Changes

- `backend/apps/systems/views.py`
  - Scoped null-orgsystem queries to the caller's organization in three querysets (+8 lines).
- `backend/apps/systems/tests/test_cross_tenant.py`
  - Added six tests covering component list isolation, direct access denial, and trust zone IDOR protection.

<img width="1369" height="180" alt="Screenshot From 2026-07-19 23-59-06" src="https://github.com/user-attachments/assets/cb014da5-741b-4851-88d7-4bb63d45aab2" />
<img width="1387" height="184" alt="Screenshot From 2026-07-20 00-00-06" src="https://github.com/user-attachments/assets/5c78682c-2411-4f09-8bf9-d73d179a2e27" />


# Manual Testing

## Security Issue 1: Attacker lists null-orgsystem components

**Request (attacker):**

```http
GET /api/components/?search=Security%20Issue%201
```

**Response:**

```json
{"count":0,"results":[]}
```

**Request (owner):**

```http
GET /api/components/?search=Security%20Issue%201
```

**Response:**

```json
{"count":1,"results":[{"id":712,"name":"Security Issue 1 Secret Component",...}]}
```

## Security Issue 1: Attacker direct access

**Request:**

```http
GET /api/components/712/
```

**Response:**

```json
{"detail":"No OrgsystemComponent matches the given query."}
```

## Security Issue 2: Attacker enumerates trust zones

**Request:**

```http
GET /api/trust-zones/?threat_model=11
```

**Response:**

```json
{"count":0,"results":[]}
```
