### PR TITLE
Fix status/effectiveness mapping for in_progress and implemented coun…

### DIFF
--- a/backend/apps/threats/services.py
+++ b/backend/apps/threats/services.py
@@ -13,9 +13,12 @@ from .scoring.registry import get_scoring_methods, score_to_level
 STATUS_EFFECTIVENESS_FALLBACK = {
     "verified": 1.0,
     "platform": 1.0,
+    "implemented": 0.7,
+    "in_progress": 0.3,
     "planned": 0.5,
     "gap": 0.0,
     "waived": 0.0,
+    "decommissioned": 0.0,
 }
 
 
@@ -38,8 +41,8 @@ def recalculate_threat_status(instance_threat):
 
     Status logic:
         - EXPOSED: No countermeasures applied OR any countermeasure is a gap
-        - ADDRESSABLE: Some countermeasures are planned/waived (none are gaps)
-        - MITIGATED: All countermeasures are verified or platform
+        - ADDRESSABLE: Some countermeasures are planned/waived/in_progress/decommissioned
+        - MITIGATED: All countermeasures are implemented/verified/platform
     """
     countermeasures = get_countermeasures_for_threat(instance_threat)
 
@@ -51,10 +54,9 @@ def recalculate_threat_status(instance_threat):
 
         if has_gaps:
             new_status = "exposed"
-        elif any(s in ("planned", "waived") for s in statuses):
+        elif any(s in ("planned", "waived", "in_progress", "decommissioned") for s in statuses):
             new_status = "addressable"
         else:
-            # All verified/platform
             new_status = "mitigated"
 
     if instance_threat.status != new_status:
@@ -100,7 +102,7 @@ def compute_residual_score(risk):
 
     Effectiveness comes from:
       1. User-entered value on the countermeasure (if set)
-      2. Status-derived fallback: verified=1.0, planned=0.5, gap=0.0, waived=0.0
+      2. Status-derived fallback from STATUS_EFFECTIVENESS_FALLBACK
     """
     all_effectiveness = []
     seen_countermeasure_ids = set()

--- a/backend/apps/threats/tests/test_status_effectiveness.py
+++ b/backend/apps/threats/tests/test_status_effectiveness.py
@@ -1,0 +1,127 @@
+"""Tests for B-02: status/effectiveness mapping consistency."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from apps.organizations.models import Organization, OrganizationMember
+from apps.systems.models import OrgsystemComponent
+from apps.threat_models.models import ThreatModel
+from apps.threats.models import (
+    ComponentInstanceThreat,
+    CountermeasureThreatLink,
+    InstanceCountermeasure,
+)
+from apps.threats.services import (
+    STATUS_EFFECTIVENESS_FALLBACK,
+    recalculate_threat_status,
+)
+
+User = get_user_model()
+
+
+class StatusEffectivenessTestCase(TestCase):
+    """Base class that sets up a threat model with one component and one threat."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org = Organization.objects.create(name="Test Org", domain="test.org")
+        cls.user = User.objects.create_user(
+            username="testuser", email="test@test.org", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org, user=cls.user, role="security_team"
+        )
+        cls.tm = ThreatModel.objects.create(
+            name="Test TM", organization=cls.org
+        )
+        cls.component = OrgsystemComponent.objects.create(
+            threat_model=cls.tm, name="Test Component"
+        )
+        cls.threat = ComponentInstanceThreat.objects.create(
+            component=cls.component, inherent_severity="high"
+        )
+
+    def _add_countermeasure(self, status, effectiveness=None):
+        cm = InstanceCountermeasure.objects.create(
+            threat_model=self.tm,
+            status=status,
+            effectiveness=effectiveness,
+        )
+        CountermeasureThreatLink.objects.create(
+            countermeasure=cm, component_threat=self.threat
+        )
+        return cm
+
+
+class EffectivenessFallbackCoverageTests(StatusEffectivenessTestCase):
+    """Every InstanceCountermeasure.Status must have a fallback effectiveness value."""
+
+    def test_all_statuses_have_fallback_effectiveness(self):
+        missing = [
+            s.value
+            for s in InstanceCountermeasure.Status
+            if s.value not in STATUS_EFFECTIVENESS_FALLBACK
+        ]
+        self.assertEqual(
+            missing, [],
+            f"Statuses missing from STATUS_EFFECTIVENESS_FALLBACK: {missing}"
+        )
+
+    def test_in_progress_has_nonzero_effectiveness(self):
+        self.assertGreater(STATUS_EFFECTIVENESS_FALLBACK["in_progress"], 0.0)
+
+    def test_implemented_has_nonzero_effectiveness(self):
+        self.assertGreater(STATUS_EFFECTIVENESS_FALLBACK["implemented"], 0.0)
+
+    def test_implemented_greater_than_in_progress(self):
+        self.assertGreater(
+            STATUS_EFFECTIVENESS_FALLBACK["implemented"],
+            STATUS_EFFECTIVENESS_FALLBACK["in_progress"],
+        )
+
+
+class ThreatStatusDerivationTests(StatusEffectivenessTestCase):
+    """recalculate_threat_status must align with effectiveness values."""
+
+    def test_in_progress_countermeasure_gives_addressable(self):
+        self._add_countermeasure("in_progress")
+        status = recalculate_threat_status(self.threat)
+        self.assertEqual(status, "addressable")
+
+    def test_implemented_countermeasure_gives_mitigated(self):
+        self._add_countermeasure("implemented")
+        status = recalculate_threat_status(self.threat)
+        self.assertEqual(status, "mitigated")
+
+    def test_verified_countermeasure_gives_mitigated(self):
+        self._add_countermeasure("verified")
+        status = recalculate_threat_status(self.threat)
+        self.assertEqual(status, "mitigated")
+
+    def test_decommissioned_countermeasure_gives_addressable(self):
+        self._add_countermeasure("decommissioned")
+        status = recalculate_threat_status(self.threat)
+        self.assertEqual(status, "addressable")
+
+    def test_gap_countermeasure_gives_exposed(self):
+        self._add_countermeasure("gap")
+        status = recalculate_threat_status(self.threat)
+        self.assertEqual(status, "exposed")
+
+    def test_gap_plus_verified_gives_exposed(self):
+        self._add_countermeasure("gap")
+        self._add_countermeasure("verified")
+        status = recalculate_threat_status(self.threat)
+        self.assertEqual(status, "exposed")
+
+    def test_planned_plus_verified_gives_addressable(self):
+        self._add_countermeasure("planned")
+        self._add_countermeasure("verified")
+        status = recalculate_threat_status(self.threat)
+        self.assertEqual(status, "addressable")
+
+    def test_in_progress_plus_implemented_gives_addressable(self):
+        self._add_countermeasure("in_progress")
+        self._add_countermeasure("implemented")
+        status = recalculate_threat_status(self.threat)
+        self.assertEqual(status, "addressable")


### PR DESCRIPTION
## Summary

- `in_progress` and `implemented` countermeasures were missing from `STATUS_EFFECTIVENESS_FALLBACK`, defaulting to `0.0` — meaning they provided **zero risk reduction** in residual score calculations despite marking threats as "mitigated"
- `recalculate_threat_status()` treated `in_progress` and `decommissioned` as fully mitigated (same bucket as `verified`/`platform`), which contradicts their partial/zero effectiveness
- Added missing statuses to the fallback map: `in_progress: 0.3`, `implemented: 0.7`, `decommissioned: 0.0`
- Fixed status derivation: `in_progress` and `decommissioned` now correctly produce `addressable`, not `mitigated`

## What changed

| Status | Before (effectiveness → threat status) | After |
|--------|---------------------------------------|-------|
| `in_progress` | 0.0 → mitigated | 0.3 → addressable |
| `implemented` | 0.0 → mitigated | 0.7 → mitigated |
| `decommissioned` | 0.0 → mitigated | 0.0 → addressable |

Fixes #207 