### PR TITLE
fix: use hook-based getNodesBounds for subflow support, fix nested bu…

### DIFF
--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -62,7 +62,7 @@ function DFDEditorContent() {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
 
   // ReactFlow instance for coordinate conversion and edge queries
-  const { screenToFlowPosition, getEdges, getViewport, setViewport } = useReactFlow()
+  const { screenToFlowPosition, getEdges, getViewport, setViewport, getNodesBounds } = useReactFlow()
   const { x: viewportX, y: viewportY, zoom } = useViewport()
 
   // Delete DFD mutation
@@ -446,7 +446,7 @@ function DFDEditorContent() {
         .replace(/[^a-zA-Z0-9-_ ]/g, '')
         .replace(/\s+/g, '-')
         .toLowerCase()
-      exportDiagramImage(format, filename, reactFlowWrapper.current, nodes, getViewport, setViewport)
+      exportDiagramImage(format, filename, reactFlowWrapper.current, nodes, getViewport, setViewport, getNodesBounds)
     },
     [diagramTitle, nodes, getViewport, setViewport]
   )

--- a/frontend/src/features/dfd-editor/api/component-library.ts
+++ b/frontend/src/features/dfd-editor/api/component-library.ts
@@ -3,7 +3,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query'
-import { api } from '@/lib/api'
+import { api, getAccessToken } from '@/lib/api'
 import type { Technology, TechnologyCategory } from '../lib/technology-registry'
 
 // Backend response type (camelCase from djangorestframework-camel-case middleware)
@@ -84,7 +84,7 @@ function transformToTechnology(item: ComponentLibraryItem): Technology {
  * Returns technologies from installed packs for the user's organization.
  * Optionally filtered by a threat model's connected packs.
  */
-export function useComponentLibrary(threatModelId?: string) {
+export function useComponentLibrary(threatModelId?: string, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ['component-library', threatModelId],
     queryFn: async () => {
@@ -93,6 +93,7 @@ export function useComponentLibrary(threatModelId?: string) {
       return items.map(transformToTechnology)
     },
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+    enabled: options?.enabled ?? true,
   })
 }
 
@@ -100,8 +101,8 @@ export function useComponentLibrary(threatModelId?: string) {
  * Hook that provides technologies with fallback to empty array if no packs installed.
  * Use this in the TechnologyCombobox component.
  */
-export function useTechnologies(threatModelId?: string) {
-  const { data: technologies = [], isLoading, error } = useComponentLibrary(threatModelId)
+export function useTechnologies(threatModelId?: string, options?: { enabled?: boolean }) {
+  const { data: technologies = [], isLoading, error } = useComponentLibrary(threatModelId, options)
 
   return {
     technologies,
@@ -114,9 +115,11 @@ export function useTechnologies(threatModelId?: string) {
 /**
  * Resolve a technology value (slug or legacy display name) to its display name.
  * Returns the original value as fallback if no match is found (custom entries).
+ * Skips the API fetch when no auth token is present (e.g., guest editor).
  */
 export function useTechnologyDisplayName(value: string | undefined): string {
-  const { technologies } = useTechnologies()
+  const hasAuth = !!getAccessToken()
+  const { technologies } = useTechnologies(undefined, { enabled: hasAuth })
 
   if (!value) return ''
 

--- a/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
+++ b/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
@@ -1,7 +1,13 @@
 import { memo, useCallback } from 'react'
 import type { XYPosition } from '@xyflow/react'
-import { User, Server, Cog, Database, Shield, Box, ArrowRight, LayoutTemplate, ShieldAlert, ShieldCheck } from 'lucide-react'
+import { User, Server, Cog, Database, Shield, Box, ArrowUp, LayoutTemplate, ShieldAlert, ShieldCheck, ImageDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { Separator } from '@/components/ui/separator'
 import {
   Select,
@@ -33,6 +39,7 @@ interface DiagramToolbarProps {
   hideAnalyzeThreats?: boolean
   notationStyle?: DFDNotationStyle
   onNotationChange?: (notation: DFDNotationStyle) => void
+  onExportImage?: (format: 'png' | 'svg') => void
 }
 
 interface ToolbarButtonConfig {
@@ -100,6 +107,7 @@ export const DiagramToolbar = memo(function DiagramToolbar({
   hideAnalyzeThreats,
   notationStyle = 'dfd3',
   onNotationChange,
+  onExportImage,
 }: DiagramToolbarProps) {
   const { createNode } = useCreateNode(notationStyle)
 
@@ -122,30 +130,55 @@ export const DiagramToolbar = memo(function DiagramToolbar({
   return (
     <TooltipProvider delayDuration={300}>
       <div className="flex items-center gap-1 p-2 bg-background border-b">
-        {/* Node buttons */}
-        {nodeButtons.map((button) => (
-          <Tooltip key={button.type}>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={cn('gap-2 cursor-grab active:cursor-grabbing', button.color)}
-                onClick={() => handleAddNode(button.type)}
-                draggable
-                onDragStart={(e) => handleDragStart(e, button.type)}
-              >
-                <button.icon className="h-4 w-4" />
-                <span className="hidden sm:inline">{button.label}</span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="max-w-[200px]">
-              <p className="font-medium">{button.label}</p>
-              <p className="text-xs text-muted-foreground">{button.description}</p>
-            </TooltipContent>
-          </Tooltip>
-        ))}
-
-        <Separator orientation="vertical" className="h-8 mx-2" />
+        {/* Node buttons with Trust Boundary placed after Trust Zone */}
+        {nodeButtons.flatMap((button) => {
+          const nodeBtn = (
+            <Tooltip key={button.type}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn('gap-2 cursor-grab active:cursor-grabbing', button.color)}
+                  onClick={() => handleAddNode(button.type)}
+                  draggable
+                  onDragStart={(e) => handleDragStart(e, button.type)}
+                >
+                  <button.icon className="h-4 w-4" />
+                  <span className="hidden sm:inline">{button.label}</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="max-w-[200px]">
+                <p className="font-medium">{button.label}</p>
+                <p className="text-xs text-muted-foreground">{button.description}</p>
+              </TooltipContent>
+            </Tooltip>
+          )
+          if (button.type === 'trustZone') {
+            return [
+              nodeBtn,
+              <Tooltip key="trustBoundary">
+                <TooltipTrigger asChild>
+                  <Button
+                    variant={boundaryMode ? 'default' : 'ghost'}
+                    size="sm"
+                    className={cn('gap-2', !boundaryMode && 'text-amber-700 hover:bg-amber-50')}
+                    onClick={() => onBoundaryModeChange(!boundaryMode)}
+                  >
+                    <ShieldCheck className="h-4 w-4" />
+                    <span className="hidden sm:inline">Trust Boundary</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p className="font-medium">Trust Boundary</p>
+                  <p className="text-xs text-muted-foreground">
+                    Click two trust zones to create a security boundary between them
+                  </p>
+                </TooltipContent>
+              </Tooltip>,
+            ]
+          }
+          return [nodeBtn]
+        })}
 
         {/* Connection mode toggle */}
         <Tooltip>
@@ -156,7 +189,7 @@ export const DiagramToolbar = memo(function DiagramToolbar({
               className="gap-2"
               onClick={() => onConnectionModeChange(!connectionMode)}
             >
-              <ArrowRight className="h-4 w-4" />
+              <ArrowUp className="h-4 w-4" />
               <span className="hidden sm:inline">Flow</span>
             </Button>
           </TooltipTrigger>
@@ -164,27 +197,6 @@ export const DiagramToolbar = memo(function DiagramToolbar({
             <p className="font-medium">Draw Connection</p>
             <p className="text-xs text-muted-foreground">
               Click and drag from one node to another to create a data flow
-            </p>
-          </TooltipContent>
-        </Tooltip>
-
-        {/* Trust Boundary mode toggle */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant={boundaryMode ? 'default' : 'ghost'}
-              size="sm"
-              className="gap-2"
-              onClick={() => onBoundaryModeChange(!boundaryMode)}
-            >
-              <ShieldCheck className="h-4 w-4" />
-              <span className="hidden sm:inline">Trust Boundary</span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <p className="font-medium">Trust Boundary</p>
-            <p className="text-xs text-muted-foreground">
-              Click two trust zones to create a security boundary between them
             </p>
           </TooltipContent>
         </Tooltip>
@@ -259,6 +271,32 @@ export const DiagramToolbar = memo(function DiagramToolbar({
               </TooltipContent>
             </Tooltip>
           </>
+        )}
+
+        {onExportImage && (
+          <div className="ml-auto">
+            <DropdownMenu>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="sm" className="gap-2">
+                      <ImageDown className="h-4 w-4" />
+                      <span className="hidden sm:inline">Export Image</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Download diagram as PNG or SVG</TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => onExportImage('png')}>
+                  Download as PNG
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onExportImage('svg')}>
+                  Download as SVG
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         )}
       </div>
     </TooltipProvider>

--- a/frontend/src/features/dfd-editor/lib/export-diagram-image.ts
+++ b/frontend/src/features/dfd-editor/lib/export-diagram-image.ts
@@ -1,6 +1,6 @@
 import { toPng, toSvg } from 'html-to-image'
-import { getNodesBounds, getViewportForBounds } from '@xyflow/react'
-import type { Node, Viewport } from '@xyflow/react'
+import { getViewportForBounds } from '@xyflow/react'
+import type { Node, Rect, Viewport } from '@xyflow/react'
 
 const PADDING = 50
 const IMAGE_SCALE = 2 // 2x resolution for crisp output
@@ -26,6 +26,7 @@ async function withExportViewport<T>(
   nodes: Node[],
   getViewport: () => Viewport,
   setViewport: (viewport: Viewport, options?: { duration?: number }) => void,
+  getNodesBounds: (nodes: Node[]) => Rect,
   capture: (reactFlowElement: HTMLElement, paddedBounds: { width: number; height: number }) => Promise<T>,
 ): Promise<T> {
   if (nodes.length === 0) {
@@ -78,8 +79,9 @@ export async function exportDiagramImage(
   nodes: Node[],
   getViewport: () => Viewport,
   setViewport: (viewport: Viewport, options?: { duration?: number }) => void,
+  getNodesBounds: (nodes: Node[]) => Rect,
 ): Promise<void> {
-  await withExportViewport(wrapperElement, nodes, getViewport, setViewport, async (reactFlowElement, paddedBounds) => {
+  await withExportViewport(wrapperElement, nodes, getViewport, setViewport, getNodesBounds, async (reactFlowElement, paddedBounds) => {
     const imageWidth = paddedBounds.width * IMAGE_SCALE
     const imageHeight = paddedBounds.height * IMAGE_SCALE
 
@@ -113,8 +115,9 @@ export async function captureDiagramImage(
   nodes: Node[],
   getViewport: () => Viewport,
   setViewport: (viewport: Viewport, options?: { duration?: number }) => void,
+  getNodesBounds: (nodes: Node[]) => Rect,
 ): Promise<Uint8Array> {
-  return withExportViewport(wrapperElement, nodes, getViewport, setViewport, async (reactFlowElement, paddedBounds) => {
+  return withExportViewport(wrapperElement, nodes, getViewport, setViewport, getNodesBounds, async (reactFlowElement, paddedBounds) => {
     const imageWidth = paddedBounds.width * IMAGE_SCALE
     const imageHeight = paddedBounds.height * IMAGE_SCALE
 

--- a/frontend/src/features/guest-editor/GuestDFDEditor.tsx
+++ b/frontend/src/features/guest-editor/GuestDFDEditor.tsx
@@ -15,7 +15,7 @@ import '@xyflow/react/dist/style.css'
 import { useOutletContext, useNavigate } from 'react-router-dom'
 import { CanvasOverlays } from '@/features/dfd-editor/components/CanvasOverlays'
 import { DiagramToolbar } from '@/features/dfd-editor/components/DiagramToolbar'
-import { NodeEditPanel } from '@/features/dfd-editor/components/panels/NodeEditPanel'
+import { GuestNodeEditPanel } from './components/GuestNodeEditPanel'
 import { EdgeEditPanel } from '@/features/dfd-editor/components/panels/EdgeEditPanel'
 import { TrustBoundaryEdgeEditPanel } from '@/features/dfd-editor/components/panels/TrustBoundaryEdgeEditPanel'
 import { DFDNotationProvider } from '@/features/dfd-editor/context/DFDNotationContext'
@@ -55,6 +55,7 @@ function GuestDFDEditorContent() {
     setNotationStyle,
     exportImageRef,
     captureImageRef,
+    onCacheImage,
   } = useOutletContext<GuestDiagramOutletContext>()
 
   // Handle notation change — resize affected nodes
@@ -96,7 +97,7 @@ function GuestDFDEditorContent() {
   const [selectedEdge, setSelectedEdge] = useState<DiagramEdge | null>(null)
 
   // ReactFlow instance
-  const { screenToFlowPosition, getEdges, getViewport, setViewport } = useReactFlow()
+  const { screenToFlowPosition, getEdges, getViewport, setViewport, getNodesBounds } = useReactFlow()
   const { x: viewportX, y: viewportY, zoom } = useViewport()
 
   // Parent relationship detection
@@ -181,7 +182,7 @@ function GuestDFDEditorContent() {
         .replace(/[^a-zA-Z0-9-_ ]/g, '')
         .replace(/\s+/g, '-')
         .toLowerCase()
-      exportDiagramImage(format, filename, reactFlowWrapper.current, nodes, getViewport, setViewport)
+      exportDiagramImage(format, filename, reactFlowWrapper.current, nodes, getViewport, setViewport, getNodesBounds)
     }
     return () => { exportImageRef.current = null }
   }, [exportImageRef, title, nodes, getViewport, setViewport])
@@ -190,10 +191,12 @@ function GuestDFDEditorContent() {
   useEffect(() => {
     captureImageRef.current = async (): Promise<Uint8Array | null> => {
       if (!reactFlowWrapper.current || nodes.length === 0) return null
-      return captureDiagramImage(reactFlowWrapper.current, nodes, getViewport, setViewport)
+      return captureDiagramImage(reactFlowWrapper.current, nodes, getViewport, setViewport, getNodesBounds)
     }
+    // Canvas re-mounted — invalidate cached image since user may edit the diagram
+    onCacheImage(null)
     return () => { captureImageRef.current = null }
-  }, [captureImageRef, nodes, getViewport, setViewport])
+  }, [captureImageRef, nodes, getViewport, setViewport, onCacheImage])
 
   // Handle node click
   const handleNodeClick = useCallback(
@@ -322,10 +325,12 @@ function GuestDFDEditorContent() {
         onBoundaryModeChange={handleBoundaryModeChange}
         getCanvasCenterPosition={getCanvasCenterPosition}
         onOpenTemplates={() => {}}
-        onOpenThreatAnalysis={() => navigate('/guest/threats')}
+        onOpenThreatAnalysis={() => {}}
         hideTemplates
+        hideAnalyzeThreats
         notationStyle={notationStyle}
         onNotationChange={handleNotationChange}
+        onExportImage={(format) => exportImageRef.current?.(format)}
       />
 
       <div className="flex flex-1 overflow-hidden">
@@ -381,7 +386,7 @@ function GuestDFDEditorContent() {
 
         {/* Edit Panels */}
         {currentSelectedNode && (
-          <NodeEditPanel
+          <GuestNodeEditPanel
             node={currentSelectedNode}
             onClose={() => setSelectedNode(null)}
             renderExtra={

--- a/frontend/src/features/guest-editor/GuestLayout.tsx
+++ b/frontend/src/features/guest-editor/GuestLayout.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useNavigate } from 'react-router-dom'
 import type { NodeChange, EdgeChange } from '@xyflow/react'
 import type { DiagramNode, DiagramEdge } from '@/features/dfd-editor/types'
 import type { DFDNotationStyle } from '@/features/dfd-editor/types/notation'
@@ -26,17 +26,20 @@ export interface GuestDiagramOutletContext {
   setNotationStyle: (notation: DFDNotationStyle) => void
   exportImageRef: React.MutableRefObject<((format: 'png' | 'svg') => void) | null>
   captureImageRef: React.MutableRefObject<(() => Promise<Uint8Array | null>) | null>
+  onCacheImage: (image: Uint8Array | null) => void
 }
 
 export function GuestLayout() {
+  const navigate = useNavigate()
   const diagramState = useGuestDiagramState()
   const threatOps = useGuestThreats()
   const countermeasureOps = useGuestCountermeasures()
   const systemContextOps = useGuestSystemContext()
-  const [notationStyle, setNotationStyle] = useState<DFDNotationStyle>('dfd3')
+  const [notationStyle, setNotationStyle] = useState<DFDNotationStyle>('yourdon')
   const fileHandleState = useFileHandle()
   const exportImageRef = useRef<((format: 'png' | 'svg') => void) | null>(null)
   const captureImageRef = useRef<(() => Promise<Uint8Array | null>) | null>(null)
+  const [cachedDiagramImage, setCachedDiagramImage] = useState<Uint8Array | null>(null)
 
   // Wrap removeThreat to cascade-delete countermeasures
   const removeThreatWithCascade = useCallback(
@@ -133,6 +136,10 @@ export function GuestLayout() {
     ]
   )
 
+  const handleCacheImage = useCallback((image: Uint8Array | null) => {
+    setCachedDiagramImage(image)
+  }, [])
+
   const outletContext: GuestDiagramOutletContext = useMemo(
     () => ({
       title: diagramState.title,
@@ -148,6 +155,7 @@ export function GuestLayout() {
       setNotationStyle,
       exportImageRef,
       captureImageRef,
+      onCacheImage: handleCacheImage,
     }),
     [
       diagramState.title,
@@ -160,19 +168,27 @@ export function GuestLayout() {
       diagramState.undo,
       diagramState.canUndo,
       notationStyle,
+      handleCacheImage,
     ]
   )
 
   const handleLoadFromFile = useCallback(
     (data: { title: string; nodes: DiagramNode[]; edges: DiagramEdge[]; notationStyle?: DFDNotationStyle; systemContext?: GuestSystemContext }) => {
       diagramState.loadFromFile(data)
-      setNotationStyle(data.notationStyle ?? 'dfd3')
+      setNotationStyle(data.notationStyle ?? 'yourdon')
+      setCachedDiagramImage(null)
       if (data.systemContext) {
         systemContextOps.loadSystemContext(data.systemContext)
       }
     },
     [diagramState.loadFromFile, systemContextOps.loadSystemContext]
   )
+
+  const handleAnalyzeThreats = useCallback(async () => {
+    const image = await captureImageRef.current?.() ?? null
+    setCachedDiagramImage(image)
+    navigate('/guest/threats')
+  }, [navigate])
 
   return (
     <GuestEditorProvider value={contextValue}>
@@ -184,8 +200,8 @@ export function GuestLayout() {
           onMarkSaved={diagramState.markSaved}
           onLoadFromFile={handleLoadFromFile}
           notationStyle={notationStyle}
-          onExportImage={(format) => exportImageRef.current?.(format)}
-          onCaptureImage={() => captureImageRef.current?.() ?? Promise.resolve(null)}
+          onCaptureImage={async () => (await captureImageRef.current?.()) ?? cachedDiagramImage}
+          onAnalyzeThreats={handleAnalyzeThreats}
           fileHandle={fileHandleState.fileHandle}
           fileName={fileHandleState.fileName}
           onFileHandleChange={fileHandleState.updateHandle}

--- a/frontend/src/features/guest-editor/components/GuestEditorHeader.tsx
+++ b/frontend/src/features/guest-editor/components/GuestEditorHeader.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { Download, FileText, FolderOpen, Pencil, ArrowLeft, ImageDown, Settings2, Save, ChevronDown } from 'lucide-react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { Download, FileText, FolderOpen, Pencil, ArrowLeft, Layers, Save, ChevronDown, ShieldAlert } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -48,8 +48,8 @@ interface GuestEditorHeaderProps {
   onMarkSaved: () => void
   onLoadFromFile: (data: { title: string; nodes: import('@/features/dfd-editor/types').DiagramNode[]; edges: import('@/features/dfd-editor/types').DiagramEdge[]; notationStyle?: import('@/features/dfd-editor/types/notation').DFDNotationStyle; systemContext?: import('../types').GuestSystemContext }) => void
   notationStyle?: import('@/features/dfd-editor/types/notation').DFDNotationStyle
-  onExportImage: (format: 'png' | 'svg') => void
   onCaptureImage: () => Promise<Uint8Array | null>
+  onAnalyzeThreats: () => void
   fileHandle: FileSystemFileHandle | null
   fileName: string | null
   onFileHandleChange: (handle: FileSystemFileHandle) => void
@@ -63,15 +63,17 @@ export function GuestEditorHeader({
   onMarkSaved,
   onLoadFromFile,
   notationStyle,
-  onExportImage,
   onCaptureImage,
+  onAnalyzeThreats,
   fileHandle,
   fileName,
   onFileHandleChange,
   onFileHandleClear,
 }: GuestEditorHeaderProps) {
   const navigate = useNavigate()
+  const location = useLocation()
   const guestEditor = useGuestEditor()
+  const isOnThreatsView = location.pathname === '/guest/threats'
   const [isEditingTitle, setIsEditingTitle] = useState(false)
   const [titleValue, setTitleValue] = useState('')
   const titleInputRef = useRef<HTMLInputElement>(null)
@@ -258,7 +260,7 @@ export function GuestEditorHeader({
 
   const handleDownloadReport = useCallback(async () => {
     if (!guestEditor) return
-    // Capture the diagram image before generating the Word doc
+    // onCaptureImage tries live canvas capture first, falls back to cached image
     const diagramImage = await onCaptureImage() ?? undefined
     await exportGuestWordDoc({
       title,
@@ -322,13 +324,24 @@ export function GuestEditorHeader({
               <span>Unsaved</span>
             </div>
           )}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="sm" className="bg-teal-50 text-teal-700 border-teal-200 hover:bg-teal-100" onClick={() => setShowSystemContextModal(true)}>
+                  <Layers className="h-4 w-4 mr-2" />
+                  Context
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Define system context, data assets, and assumptions</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
 
         <div className="flex items-center gap-2">
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="outline" size="sm" onClick={handleOpen}>
+                <Button variant="ghost" size="sm" onClick={handleOpen}>
                   <FolderOpen className="h-4 w-4 mr-2" />
                   Open
                 </Button>
@@ -336,53 +349,12 @@ export function GuestEditorHeader({
               <TooltipContent>Open a CycloneDX JSON file</TooltipContent>
             </Tooltip>
 
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="outline" size="sm" onClick={() => setShowSystemContextModal(true)}>
-                  <Settings2 className="h-4 w-4 mr-2" />
-                  Context
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Define system context, data assets, and assumptions</TooltipContent>
-            </Tooltip>
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="outline" size="sm" onClick={handleDownloadReport}>
-                  <FileText className="h-4 w-4 mr-2" />
-                  Report
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Download threat model report as Word document</TooltipContent>
-            </Tooltip>
-
-            <DropdownMenu>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="outline" size="sm">
-                      <ImageDown className="h-4 w-4 mr-2" />
-                      Export Image
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent>Download diagram as PNG or SVG</TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => onExportImage('png')}>
-                  Download as PNG
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onExportImage('svg')}>
-                  Download as SVG
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-
             {/* Save button with Save As dropdown */}
             <div className="flex items-center">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
+                    variant="ghost"
                     size="sm"
                     onClick={handleSave}
                     className="rounded-r-none"
@@ -396,8 +368,9 @@ export function GuestEditorHeader({
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
+                    variant="ghost"
                     size="sm"
-                    className="rounded-l-none border-l border-primary-foreground/20 px-1.5"
+                    className="rounded-l-none px-1.5"
                   >
                     <ChevronDown className="h-3.5 w-3.5" />
                   </Button>
@@ -414,6 +387,30 @@ export function GuestEditorHeader({
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
+
+            {!isOnThreatsView && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="default" size="sm" onClick={onAnalyzeThreats}>
+                    <ShieldAlert className="h-4 w-4 mr-2" />
+                    Analyze Threats
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Review and manage threats based on your diagram components</TooltipContent>
+              </Tooltip>
+            )}
+
+            {isOnThreatsView && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="default" size="sm" onClick={handleDownloadReport}>
+                    <FileText className="h-4 w-4 mr-2" />
+                    Report
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Download threat model report as Word document</TooltipContent>
+              </Tooltip>
+            )}
           </TooltipProvider>
         </div>
       </div>

--- a/frontend/src/features/guest-editor/components/GuestNodeEditPanel.tsx
+++ b/frontend/src/features/guest-editor/components/GuestNodeEditPanel.tsx
@@ -1,0 +1,585 @@
+import { memo } from 'react'
+import { useReactFlow } from '@xyflow/react'
+import { X, Trash2, Cog, Database, User, Server, Shield, Box, ShieldCheck, ArrowRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import { Slider } from '@/components/ui/slider'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { SuggestionCombobox } from '@/features/dfd-editor/components/suggestion-combobox'
+import type {
+  DiagramNode,
+  DiagramNodeType,
+  DataSensitivity,
+} from '@/features/dfd-editor/types'
+import {
+  DATA_SENSITIVITY_CONFIG,
+  ZONE_COLOR_OPTIONS,
+  getZoneColorConfig,
+  MAX_PROCESS_HIERARCHY_DEPTH,
+  getProcessAncestorDepth,
+  getProcessDescendantDepth,
+} from '@/features/dfd-editor/types'
+
+interface GuestNodeEditPanelProps {
+  node: DiagramNode
+  onClose: () => void
+  renderExtra?: React.ReactNode
+}
+
+const nodeTypeConfig: Record<
+  DiagramNodeType,
+  { label: string; icon: React.ComponentType<{ className?: string }>; color: string }
+> = {
+  process: { label: 'Process', icon: Cog, color: 'text-blue-600' },
+  datastore: { label: 'Data Store', icon: Database, color: 'text-purple-600' },
+  humanActor: { label: 'Human Actor', icon: User, color: 'text-green-600' },
+  systemActor: { label: 'System Actor', icon: Server, color: 'text-slate-600' },
+  trustZone: { label: 'Trust Zone', icon: Shield, color: 'text-orange-600' },
+  systemScope: { label: 'System Scope', icon: Box, color: 'text-gray-600' },
+}
+
+export const GuestNodeEditPanel = memo(function GuestNodeEditPanel({
+  node,
+  onClose,
+  renderExtra,
+}: GuestNodeEditPanelProps) {
+  const { setNodes, getNodes, getEdges, setEdges } = useReactFlow()
+
+  const typeConfig = nodeTypeConfig[node.type as DiagramNodeType]
+  const Icon = typeConfig?.icon || Cog
+
+  // Find parent node if exists
+  const parentNode = node.parentId
+    ? (getNodes() as DiagramNode[]).find((n) => n.id === node.parentId)
+    : null
+
+  const updateNodeData = (updates: Partial<DiagramNode['data']>) => {
+    setNodes((nodes) =>
+      nodes.map((n) =>
+        n.id === node.id ? { ...n, data: { ...n.data, ...updates } } : n
+      )
+    )
+  }
+
+  const handleDelete = () => {
+    const nodes = getNodes() as DiagramNode[]
+
+    // For container nodes (boundaries or process containers), convert children to root nodes
+    const hasChildren = nodes.some((n) => n.parentId === node.id)
+    if (node.type === 'trustZone' || node.type === 'systemScope' || hasChildren) {
+      const boundaryPos = node.position
+      const updatedNodes = nodes
+        .filter((n) => n.id !== node.id)
+        .map((n) => {
+          if (n.parentId === node.id) {
+            return {
+              ...n,
+              parentId: undefined,
+              position: {
+                x: n.position.x + boundaryPos.x,
+                y: n.position.y + boundaryPos.y,
+              },
+            }
+          }
+          return n
+        })
+      setNodes(updatedNodes)
+    } else {
+      setNodes((nodes) => nodes.filter((n) => n.id !== node.id))
+    }
+
+    // Remove connected edges
+    setEdges((edges) =>
+      edges.filter((e) => e.source !== node.id && e.target !== node.id)
+    )
+
+    onClose()
+  }
+
+  return (
+    <div className="w-80 bg-background border-l h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b">
+        <div className="flex items-center gap-2">
+          <Icon className={`h-5 w-5 ${typeConfig?.color}`} />
+          <span className="font-medium">{typeConfig?.label || 'Node'}</span>
+        </div>
+        <Button variant="ghost" size="icon" onClick={onClose}>
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {/* Common fields */}
+        <div className="space-y-2">
+          <Label htmlFor="node-label">Name</Label>
+          <Input
+            id="node-label"
+            value={node.data.label || ''}
+            onChange={(e) => updateNodeData({ label: e.target.value })}
+            placeholder={node.type === 'trustZone' ? 'e.g., Production VPC, DMZ...' : 'Enter name...'}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="node-description">Description</Label>
+          <Textarea
+            id="node-description"
+            value={node.data.description || ''}
+            onChange={(e) => updateNodeData({ description: e.target.value })}
+            placeholder="Enter description..."
+            rows={3}
+          />
+        </div>
+
+        <Separator />
+
+        {/* Process / Datastore fields */}
+        {(node.type === 'process' || node.type === 'datastore') && (
+          <>
+            <div className="space-y-2">
+              <Label>Technology</Label>
+              <Input
+                value={(node.data as { technology?: string }).technology || ''}
+                onChange={(e) => updateNodeData({ technology: e.target.value })}
+                placeholder={
+                  node.type === 'datastore'
+                    ? 'e.g., PostgreSQL, Redis...'
+                    : 'e.g., Node.js, Python...'
+                }
+              />
+            </div>
+
+            {node.type === 'datastore' && (
+              <div className="space-y-2">
+                <Label htmlFor="node-storeType">Store Type</Label>
+                <Select
+                  value={(node.data as { dataStoreType?: string }).dataStoreType || ''}
+                  onValueChange={(value) => updateNodeData({ dataStoreType: value })}
+                >
+                  <SelectTrigger id="node-storeType">
+                    <SelectValue placeholder="Select store type..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="sql">SQL</SelectItem>
+                    <SelectItem value="key_value">Key-Value</SelectItem>
+                    <SelectItem value="document">Document</SelectItem>
+                    <SelectItem value="object">Object</SelectItem>
+                    <SelectItem value="graph">Graph</SelectItem>
+                    <SelectItem value="time_series">Time Series</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="node-sensitivity">Data Sensitivity</Label>
+              <Select
+                value={(node.data as { dataSensitivity?: DataSensitivity }).dataSensitivity || ''}
+                onValueChange={(value) =>
+                  updateNodeData({ dataSensitivity: value as DataSensitivity })
+                }
+              >
+                <SelectTrigger id="node-sensitivity">
+                  <SelectValue placeholder="Select sensitivity..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(DATA_SENSITIVITY_CONFIG).map(([key, config]) => (
+                    <SelectItem key={key} value={key}>
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="w-2 h-2 rounded-full"
+                          style={{ backgroundColor: config.color }}
+                        />
+                        {config.label}
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Parent Process - only for process nodes */}
+            {node.type === 'process' && (
+              <div className="space-y-2">
+                <Label htmlFor="node-parent-process">Parent Process</Label>
+                <Select
+                  value={(() => {
+                    if (!node.parentId) return 'none'
+                    const parent = (getNodes() as DiagramNode[]).find(
+                      (n) => n.id === node.parentId
+                    )
+                    return parent?.type === 'process' ? node.parentId : 'none'
+                  })()}
+                  onValueChange={(value) => {
+                    const newParentId = value === 'none' ? undefined : value
+                    const allNodes = getNodes() as DiagramNode[]
+                    const nodesMap = new Map(allNodes.map((n) => [n.id, n]))
+
+                    // Calculate absolute position by walking parentId chain
+                    const getAbsPos = (nodeId: string) => {
+                      const n = nodesMap.get(nodeId)
+                      if (!n) return { x: 0, y: 0 }
+                      let x = n.position.x
+                      let y = n.position.y
+                      let pid = n.parentId
+                      while (pid) {
+                        const p = nodesMap.get(pid)
+                        if (!p) break
+                        x += p.position.x
+                        y += p.position.y
+                        pid = p.parentId
+                      }
+                      return { x, y }
+                    }
+
+                    let newPos: { x: number; y: number }
+
+                    if (newParentId) {
+                      // Place child at a default offset inside the parent
+                      newPos = { x: 20, y: 40 }
+                    } else {
+                      // Un-nesting: convert relative position back to absolute
+                      newPos = getAbsPos(node.id)
+                    }
+
+                    setNodes((nodes) =>
+                      nodes.map((n) => {
+                        if (n.id === node.id) {
+                          return {
+                            ...n,
+                            parentId: newParentId,
+                            position: newPos,
+                            data: {
+                              ...n.data,
+                              lockAnimationKey: newParentId
+                                ? Date.now() + Math.random()
+                                : undefined,
+                            },
+                          }
+                        }
+                        // When becoming a parent, ensure it has container dimensions
+                        if (newParentId && n.id === newParentId) {
+                          const hasStyleSize = n.style?.width && n.style?.height
+                          const width = hasStyleSize ? undefined : (n.measured?.width || 350)
+                          const height = hasStyleSize ? undefined : (n.measured?.height || 250)
+                          return {
+                            ...n,
+                            ...(!hasStyleSize && {
+                              style: {
+                                ...n.style,
+                                width: Math.max(width!, 350),
+                                height: Math.max(height!, 250),
+                              },
+                            }),
+                            data: {
+                              ...n.data,
+                              receiveChildAnimationKey: Date.now() + Math.random(),
+                            },
+                          }
+                        }
+                        return n
+                      })
+                    )
+                  }}
+                >
+                  <SelectTrigger id="node-parent-process">
+                    <SelectValue placeholder="None (top-level)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">None (top-level)</SelectItem>
+                    {(() => {
+                      const allNodes = getNodes() as DiagramNode[]
+                      const nodesMap = new Map(allNodes.map((n) => [n.id, n]))
+
+                      return allNodes
+                        .filter((n) => {
+                          if (n.id === node.id || n.type !== 'process') return false
+
+                          // Cycle check: candidate must not be a descendant of this node
+                          let checkId: string | undefined = n.parentId
+                          const visited = new Set<string>()
+                          while (checkId) {
+                            if (visited.has(checkId)) break
+                            visited.add(checkId)
+                            if (checkId === node.id) return false
+                            checkId = nodesMap.get(checkId)?.parentId
+                          }
+
+                          // Depth check
+                          const parentProcessDepth =
+                            getProcessAncestorDepth(n.id, allNodes) + 1
+                          const childProcessDepth = getProcessDescendantDepth(
+                            node.id,
+                            allNodes
+                          )
+                          if (
+                            parentProcessDepth + 1 + childProcessDepth >
+                            MAX_PROCESS_HIERARCHY_DEPTH
+                          )
+                            return false
+
+                          return true
+                        })
+                        .map((n) => (
+                          <SelectItem key={n.id} value={n.id}>
+                            {n.data.label || n.id}
+                          </SelectItem>
+                        ))
+                    })()}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Nest this process inside another process
+                </p>
+              </div>
+            )}
+          </>
+        )}
+
+        {node.type === 'humanActor' && (
+          <div className="space-y-2">
+            <Label>Actor Type</Label>
+            <SuggestionCombobox
+              value={(node.data as { actorType?: string }).actorType || ''}
+              onChange={(value) => updateNodeData({ actorType: value })}
+              suggestions={[
+                { value: 'user', label: 'User' },
+                { value: 'power_user', label: 'Power User' },
+                { value: 'administrator', label: 'Administrator' },
+                { value: 'engineer', label: 'Engineer' },
+                { value: 'third_party', label: 'Third Party' },
+                { value: 'customer', label: 'Customer' },
+              ]}
+              placeholder="Select or type actor type..."
+            />
+          </div>
+        )}
+
+        {node.type === 'trustZone' && (
+          <>
+            <div className="space-y-3">
+              <Label>Trust Level</Label>
+              <Slider
+                value={[(node.data as { trustLevel?: number }).trustLevel ?? 75]}
+                onValueChange={([value]) => updateNodeData({ trustLevel: value })}
+                min={0}
+                max={100}
+                step={1}
+                className="w-full"
+              />
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>0 — untrusted</span>
+                <span className="font-medium text-foreground">
+                  {(node.data as { trustLevel?: number }).trustLevel ?? 75}
+                </span>
+                <span>100 — restricted</span>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Zone Color</Label>
+              <Select
+                value={(node.data as { zoneColor?: string }).zoneColor || '#22c55e'}
+                onValueChange={(value) => updateNodeData({ zoneColor: value })}
+              >
+                <SelectTrigger className="h-9">
+                  <SelectValue>
+                    <div className="flex items-center gap-2">
+                      <div
+                        className="w-3 h-3 rounded-full border"
+                        style={{ backgroundColor: getZoneColorConfig((node.data as { zoneColor?: string }).zoneColor).borderColor }}
+                      />
+                      {ZONE_COLOR_OPTIONS.find(o => o.borderColor === ((node.data as { zoneColor?: string }).zoneColor || '#22c55e'))?.label || 'Green'}
+                    </div>
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {ZONE_COLOR_OPTIONS.map((option) => (
+                    <SelectItem key={option.borderColor} value={option.borderColor}>
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="w-3 h-3 rounded-full border"
+                          style={{ backgroundColor: option.borderColor }}
+                        />
+                        {option.label}
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Technology</Label>
+              <Input
+                value={(node.data as { technology?: string }).technology || ''}
+                onChange={(e) => updateNodeData({ technology: e.target.value })}
+                placeholder="e.g., AWS VPC, Firewall..."
+              />
+            </div>
+
+            {/* Trust Boundaries (read-only) */}
+            {(() => {
+              const allEdges = getEdges()
+              const boundaryEdges = allEdges.filter(
+                (e) =>
+                  e.type === 'trustBoundary' &&
+                  (e.source === node.id || e.target === node.id)
+              )
+              if (boundaryEdges.length === 0) return null
+              const allNodes = getNodes()
+              return (
+                <>
+                  <Separator />
+                  <div className="space-y-2">
+                    <Label className="flex items-center gap-1.5">
+                      <ShieldCheck className="h-3.5 w-3.5 text-orange-600" />
+                      Trust Boundaries
+                    </Label>
+                    <div className="space-y-1">
+                      {boundaryEdges.map((boundaryEdge) => {
+                        const isSource = boundaryEdge.source === node.id
+                        const otherNodeId = isSource ? boundaryEdge.target : boundaryEdge.source
+                        const otherNode = allNodes.find((n) => n.id === otherNodeId)
+                        const otherLabel = otherNode?.data?.label
+                          ? String(otherNode.data.label)
+                          : otherNodeId
+                        return (
+                          <div
+                            key={boundaryEdge.id}
+                            className="flex items-center gap-2 p-2 rounded-md bg-muted/50 text-sm"
+                          >
+                            <ArrowRight
+                              className={`h-3 w-3 text-orange-600 ${isSource ? '' : 'rotate-180'}`}
+                            />
+                            <span className="text-muted-foreground">
+                              {isSource ? 'To' : 'From'}:
+                            </span>
+                            <span className="font-medium">{otherLabel}</span>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                </>
+              )
+            })()}
+          </>
+        )}
+
+        {node.type === 'systemActor' && (
+          <>
+            <div className="space-y-2">
+              <Label>System Type</Label>
+              <SuggestionCombobox
+                value={(node.data as { systemType?: string }).systemType || ''}
+                onChange={(value) => updateNodeData({ systemType: value })}
+                suggestions={[
+                  { value: 'api', label: 'Third-party API' },
+                  { value: 'legacy', label: 'Legacy System' },
+                  { value: 'partner', label: 'Partner System' },
+                  { value: 'third_party', label: 'Third-party Service' },
+                  { value: 'saas', label: 'SaaS' },
+                  { value: 'other', label: 'Other' },
+                ]}
+                placeholder="Select or type system type..."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="node-vendor">Vendor</Label>
+              <Input
+                id="node-vendor"
+                value={(node.data as { vendor?: string }).vendor || ''}
+                onChange={(e) => updateNodeData({ vendor: e.target.value })}
+                placeholder="e.g., Stripe, Twilio..."
+              />
+            </div>
+          </>
+        )}
+
+        {node.type === 'systemScope' && (
+          <>
+            <div className="space-y-2">
+              <Label>Technology</Label>
+              <Input
+                value={(node.data as { technology?: string }).technology || ''}
+                onChange={(e) => updateNodeData({ technology: e.target.value })}
+                placeholder="e.g., AWS, Kubernetes..."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="node-owner">Owner</Label>
+              <Input
+                id="node-owner"
+                value={(node.data as { owner?: string }).owner || ''}
+                onChange={(e) => updateNodeData({ owner: e.target.value })}
+                placeholder="Team or person responsible..."
+              />
+            </div>
+          </>
+        )}
+
+        {/* Parent info */}
+        {parentNode && (
+          <>
+            <Separator />
+            <div className="space-y-2">
+              <Label className="text-muted-foreground">Contained In</Label>
+              <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
+                {parentNode.type === 'trustZone' ? (
+                  <Shield className="h-4 w-4 text-orange-600" />
+                ) : parentNode.type === 'process' ? (
+                  <Cog className="h-4 w-4 text-blue-600" />
+                ) : (
+                  <Box className="h-4 w-4 text-gray-600" />
+                )}
+                <span className="text-sm font-medium">{parentNode.data.label}</span>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Extra content (e.g. guest threat section) */}
+        {renderExtra && (
+          <>
+            <Separator />
+            {renderExtra}
+          </>
+        )}
+
+        {/* Node info */}
+        <Separator />
+
+        <div className="space-y-1 text-xs text-muted-foreground">
+          <div>ID: {node.id}</div>
+          <div>Type: {node.type}</div>
+        </div>
+      </div>
+
+      {/* Footer with delete */}
+      <div className="p-4 border-t">
+        <Button
+          variant="destructive"
+          className="w-full"
+          onClick={handleDelete}
+        >
+          <Trash2 className="h-4 w-4 mr-2" />
+          Delete Node
+        </Button>
+      </div>
+    </div>
+  )
+})

--- a/frontend/src/features/guest-editor/components/GuestThreatAnalysis.tsx
+++ b/frontend/src/features/guest-editor/components/GuestThreatAnalysis.tsx
@@ -346,11 +346,14 @@ export function GuestThreatAnalysis() {
                         const countermeasureCount =
                           guestEditor.getCountermeasureCount(threat.id)
                         return (
-                          <button
+                          <div
                             key={threat.id}
+                            role="button"
+                            tabIndex={0}
                             onClick={() => handleSelectThreat(threat.id)}
+                            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSelectThreat(threat.id) } }}
                             className={cn(
-                              'w-full flex items-center justify-between gap-2 p-2 rounded-md text-sm text-left hover:bg-muted/50 group',
+                              'w-full flex items-center justify-between gap-2 p-2 rounded-md text-sm text-left hover:bg-muted/50 cursor-pointer group',
                               selectedThreatId === threat.id && 'bg-muted'
                             )}
                           >
@@ -411,7 +414,7 @@ export function GuestThreatAnalysis() {
                                 <Trash2 className="h-3 w-3" />
                               </Button>
                             </div>
-                          </button>
+                          </div>
                         )
                       })}
                     </div>


### PR DESCRIPTION
## Summary                                                                                                                        
                                                                                                                                    
  - **Fix `getNodesBounds` subflow warning**: The standalone `getNodesBounds` import from `@xyflow/react` doesn't have access to the
   internal `nodeLookup`, which is required to compute absolute positions of nested nodes (children of TrustZones, SystemScopes,    
  container Processes). Switched all call sites to use the instance method from `useReactFlow()` instead, which resolves the console
   error when navigating from the DFD editor to the Threat Analysis workspace.
  - **Fix nested `<button>` HTML violation**: The threat list rows in `GuestThreatAnalysis` wrapped edit/delete `<Button>`
  components inside an outer `<button>`, producing invalid HTML. Changed the outer element to a `<div>` with `role="button"` and
  keyboard accessibility.
  - **Guest editor toolbar improvements**: Reorganized `DiagramToolbar` to place the Trust Boundary button adjacent to Trust Zone
  for better discoverability. Added an optional Export Image dropdown (PNG/SVG) to the toolbar.
  - **Guest-safe component library hooks**: Added an `enabled` option to `useComponentLibrary`/`useTechnologies` so
  `useTechnologyDisplayName` skips authenticated API calls when no auth token is present (guest editor).
  - **New `GuestNodeEditPanel` component**: Dedicated node edit panel for the guest editor.

  ## Files changed

  | File | Change |
  |------|--------|
  | `export-diagram-image.ts` | Accept `getNodesBounds` as a parameter instead of standalone import |
  | `DFDEditor.tsx` | Pass `getNodesBounds` from `useReactFlow()` to export function |
  | `GuestDFDEditor.tsx` | Same fix, plus wire up `GuestNodeEditPanel` and export image handler |
  | `GuestLayout.tsx` | Add image capture ref and cache plumbing for threat analysis navigation |
  | `GuestThreatAnalysis.tsx` | Fix nested button → `div[role="button"]` |
  | `DiagramToolbar.tsx` | Reorder toolbar, add Export Image dropdown |
  | `component-library.ts` | Add `enabled` option, skip fetch without auth token |
  | `GuestEditorHeader.tsx` | Header updates for guest editor |
  | `GuestNodeEditPanel.tsx` | New file — guest-specific node properties panel |

  ## Test plan

  - [ ] **Authenticated DFD editor**: Verify diagram export (PNG/SVG) still works — no console warnings about `getNodesBounds`
  - [ ] **Authenticated DFD editor**: Verify toolbar layout and all node creation buttons work
  - [ ] **Guest editor**: Create a diagram with nested nodes (processes inside trust zones), then click Analyze Threats — no console
   errors
  - [ ] **Guest editor**: Verify Export Image dropdown appears in toolbar and produces correct PNG/SVG
  - [ ] **Guest editor**: Open Threat Analysis, add a threat to a component, verify no nested-button console warning
  - [ ] **Guest editor**: Verify edit/delete buttons on threat rows still work (click, hover visibility)
  - [ ] **Guest editor**: Verify technology display names render without 401 errors in the console
