### PR TITLE
feat: align signed-in DFD editor with guest editor UX (export, CTA, notation)

### DIFF
--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -13,14 +13,8 @@ import {
   addEdge,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { ArrowLeft, Save, Clock, Loader2, Pencil, Trash2, ImageDown } from 'lucide-react'
+import { ArrowLeft, Save, Clock, Loader2, Pencil, Trash2, ShieldAlert } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import { DeleteDFDDialog } from '@/features/threat-models/components'
 import {
   Tooltip,
@@ -92,7 +86,7 @@ function DFDEditorContent() {
   })
 
   // Notation style state
-  const [notationStyle, setNotationStyle] = useState<DFDNotationStyle>('dfd3')
+  const [notationStyle, setNotationStyle] = useState<DFDNotationStyle>('yourdon')
 
   // Sync notationStyle from loaded diagram data
   useEffect(() => {
@@ -557,6 +551,7 @@ function DFDEditorContent() {
 
           <Button
             size="sm"
+            variant="outline"
             onClick={() => saveNow(notationStyle)}
             disabled={isSaving || !hasUnsavedChanges}
           >
@@ -564,22 +559,18 @@ function DFDEditorContent() {
             Save
           </Button>
 
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm">
-                <ImageDown className="h-4 w-4 mr-2" />
-                Export Image
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => handleExportImage('png')}>
-                Download as PNG
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => handleExportImage('svg')}>
-                Download as SVG
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <Button
+            size="sm"
+            onClick={async () => {
+              if (hasUnsavedChanges) {
+                await saveNow(notationStyle)
+              }
+              navigate(`/threat-models/${threatModelId}`)
+            }}
+          >
+            <ShieldAlert className="h-4 w-4 mr-2" />
+            Analyze Threats
+          </Button>
 
           <Button
             size="sm"
@@ -601,14 +592,11 @@ function DFDEditorContent() {
         onBoundaryModeChange={handleBoundaryModeChange}
         getCanvasCenterPosition={getCanvasCenterPosition}
         onOpenTemplates={() => setShowTemplates(true)}
-        onOpenThreatAnalysis={async () => {
-          if (hasUnsavedChanges) {
-            await saveNow(notationStyle)
-          }
-          navigate(`/threat-models/${threatModelId}`)
-        }}
+        onOpenThreatAnalysis={() => {}}
+        hideAnalyzeThreats
         notationStyle={notationStyle}
         onNotationChange={handleNotationChange}
+        onExportImage={handleExportImage}
       />
 
       <div className="flex flex-1 overflow-hidden">

--- a/frontend/src/features/dfd-editor/hooks/useDiagramState.ts
+++ b/frontend/src/features/dfd-editor/hooks/useDiagramState.ts
@@ -88,8 +88,8 @@ export function useDiagramState({
   const [edges, setEdgesInternal] = useState<DiagramEdge[]>([])
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
   const [lastSaved, setLastSaved] = useState<Date | null>(null)
-  const [initialNotationStyle, setInitialNotationStyle] = useState<DFDNotationStyle>('dfd3')
-  const notationStyleRef = useRef<DFDNotationStyle>('dfd3')
+  const [initialNotationStyle, setInitialNotationStyle] = useState<DFDNotationStyle>('yourdon')
+  const notationStyleRef = useRef<DFDNotationStyle>('yourdon')
 
   // Track if initial data has been loaded
   const initialLoadRef = useRef(false)
@@ -220,7 +220,7 @@ export function useDiagramState({
       // Use internal setters during initial load to avoid marking as changed
       setNodesInternal((canvasData?.nodes || []) as DiagramNode[])
       setEdgesInternal((canvasData?.edges || []) as DiagramEdge[])
-      const loadedNotation = canvasData?.notationStyle ?? 'dfd3'
+      const loadedNotation = canvasData?.notationStyle ?? 'yourdon'
       setInitialNotationStyle(loadedNotation)
       notationStyleRef.current = loadedNotation
       const updatedAt = diagram.updatedAt


### PR DESCRIPTION
## Summary                                                

  - **Move Export Image from header to toolbar**: Passes `onExportImage` to `DiagramToolbar` to match the guest editor layout.
  Removes the dropdown from the header and cleans up unused `DropdownMenu` and `ImageDown` imports.
  - **Move Analyze Threats from toolbar to header as primary CTA**: "Analyze Threats" is now a filled button in the header (primary
  action), and "Save" is demoted to outline (secondary). This reflects the intended workflow: build diagram → analyze threats.
  - **Default notation changed to Yourdon**: New diagrams now default to Yourdon notation instead of DFD3, matching the guest
  editor. Existing diagrams that already saved a notation style are unaffected — they load their saved value from the backend.

  ## Files changed

  | File | Change |
  |------|--------|
  | `DFDEditor.tsx` | Moved Export Image to toolbar, Analyze Threats to header, swapped button variants, updated imports, changed
  default notation |
  | `useDiagramState.ts` | Changed three `'dfd3'` defaults/fallbacks to `'yourdon'` (state init, ref init, backend fallback) |

  ## Test plan

  - [ ] Open an existing diagram that was saved with DFD3 — verify it still loads as DFD3
  - [ ] Create a new diagram — verify it defaults to Yourdon notation
  - [ ] Verify "Analyze Threats" appears as the primary (filled) button in the header
  - [ ] Verify "Save" appears as secondary (outline) button
  - [ ] Verify Export Image dropdown appears in the toolbar (right side), not in the header
  - [ ] Click Analyze Threats with unsaved changes — verify it auto-saves before navigating
  - [ ] Verify no regressions in the guest editor (no guest files were modified)
