### PR TITLE
DFD editor UX improvements: readability, discoverability, and workflow 

### DIFF
--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -40,7 +40,7 @@ import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useConnectionMode } from './hooks/useConnectionMode'
 import { useBoundaryMode } from './hooks/useBoundaryMode'
 import type { DiagramNode, DiagramNodeType, DiagramEdge, DataFlowEdge, TrustBoundaryEdge } from './types'
-import { useCreateNode } from './hooks/useCreateNode'
+import { useCreateNode, useHandleDrop } from './hooks/useCreateNode'
 import { type DFDNotationStyle, NOTATION_NODE_SIZES } from './types/notation'
 import { exportDiagramImage } from './lib/export-diagram-image'
 
@@ -194,25 +194,14 @@ function DFDEditorContent() {
   // Drag-and-drop from toolbar
   const { createNode } = useCreateNode(notationStyle)
 
-  const handleDragOver = useCallback((event: React.DragEvent) => {
-    event.preventDefault()
-    event.dataTransfer.dropEffect = 'move'
-  }, [])
-
-  const handleDrop = useCallback(
-    (event: React.DragEvent) => {
-      event.preventDefault()
-      const nodeType = event.dataTransfer.getData('application/reactflow-node-type') as DiagramNodeType
-      if (!nodeType) return
-      const dropPosition = screenToFlowPosition({ x: event.clientX, y: event.clientY })
-      createNode(nodeType, dropPosition)
-      // Let ReactFlow render the new node, then check parent relationships
-      requestAnimationFrame(() => {
-        updateParentRelationships(nodes, setNodes)
-      })
-    },
-    [screenToFlowPosition, createNode, nodes, setNodes, updateParentRelationships]
-  )
+  const { handleDragOver, handleDrop } = useHandleDrop({
+    screenToFlowPosition,
+    createNode,
+    nodes,
+    setNodes,
+    updateParentRelationships,
+    setSelectedNode,
+  })
 
   // Handle node click - delegates to mode hooks then falls through to selection
   const handleNodeClick = useCallback(

--- a/frontend/src/features/dfd-editor/components/edges/DataFlowEdge.tsx
+++ b/frontend/src/features/dfd-editor/components/edges/DataFlowEdge.tsx
@@ -62,7 +62,7 @@ export const DataFlowEdge = memo(function DataFlowEdge({
           className={cn(
             'absolute pointer-events-auto nodrag nopan flex flex-col items-center gap-1',
             'transform -translate-x-1/2 -translate-y-1/2 transition-opacity',
-            selected ? 'opacity-100' : 'opacity-70 hover:opacity-100'
+            selected ? 'opacity-100' : 'opacity-100'
           )}
           style={{
             left: labelX,
@@ -71,7 +71,7 @@ export const DataFlowEdge = memo(function DataFlowEdge({
         >
           {/* Main label */}
           {data?.label && (
-            <div className="px-2 py-0.5 rounded text-xs bg-gray-100 text-gray-700 border border-gray-200 whitespace-nowrap">
+            <div className="px-2 py-0.5 rounded text-xs bg-white text-gray-950 border border-gray-300 shadow-sm whitespace-nowrap font-medium">
               {data.label}
             </div>
           )}

--- a/frontend/src/features/dfd-editor/components/panels/CanvasThreatSection.tsx
+++ b/frontend/src/features/dfd-editor/components/panels/CanvasThreatSection.tsx
@@ -95,6 +95,11 @@ export function CanvasThreatSection({
                         <span className="text-sm font-medium leading-snug">
                           {threat.threatName || 'Unnamed threat'}
                         </span>
+                        {threat.threatDescription && (
+                          <p className="text-xs text-muted-foreground leading-snug line-clamp-2">
+                            {threat.threatDescription}
+                          </p>
+                        )}
                         <div className="flex flex-wrap items-center gap-1">
                           {threat.inherentSeverity && (
                             <Badge

--- a/frontend/src/features/dfd-editor/hooks/useCreateNode.ts
+++ b/frontend/src/features/dfd-editor/hooks/useCreateNode.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useReactFlow, type XYPosition } from '@xyflow/react'
-import type { DiagramNodeType } from '../types'
+import type { DiagramNode, DiagramNodeType } from '../types'
 import { type DFDNotationStyle, NOTATION_NODE_SIZES } from '../types/notation'
 
 const defaultData: Record<DiagramNodeType, Record<string, unknown>> = {
@@ -31,7 +31,7 @@ export function useCreateNode(notationStyle: DFDNotationStyle) {
         id,
         type,
         position,
-        data: { ...defaultData[type], isNewlyInserted: true, isInlineEditing: true },
+        data: { ...defaultData[type], isNewlyInserted: true },
         style: { width: nodeSize.width, height: nodeSize.height },
       })
 
@@ -49,4 +49,60 @@ export function useCreateNode(notationStyle: DFDNotationStyle) {
   )
 
   return { createNode }
+}
+
+/**
+ * Shared drop handler for both signed-in and guest DFD editors.
+ * Creates the node, resolves parent relationships, then selects the node
+ * and enters inline editing mode so the user can start typing immediately.
+ */
+export function useHandleDrop({
+  screenToFlowPosition,
+  createNode,
+  nodes,
+  setNodes,
+  updateParentRelationships,
+  setSelectedNode,
+}: {
+  screenToFlowPosition: (position: { x: number; y: number }) => XYPosition
+  createNode: (type: DiagramNodeType, dropPosition: XYPosition) => string
+  nodes: DiagramNode[]
+  setNodes: React.Dispatch<React.SetStateAction<DiagramNode[]>>
+  updateParentRelationships: (nodes: DiagramNode[], setNodes: React.Dispatch<React.SetStateAction<DiagramNode[]>>) => void
+  setSelectedNode: (node: DiagramNode | null) => void
+}) {
+  const handleDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+  }, [])
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault()
+      const nodeType = event.dataTransfer.getData('application/reactflow-node-type') as DiagramNodeType
+      if (!nodeType) return
+      const dropPosition = screenToFlowPosition({ x: event.clientX, y: event.clientY })
+      const newNodeId = createNode(nodeType, dropPosition)
+      // Let ReactFlow render the new node, then check parent relationships
+      requestAnimationFrame(() => {
+        updateParentRelationships(nodes, setNodes)
+      })
+      // After the node is fully rendered and parent relationships resolved,
+      // select it and enter inline editing mode so the user can start typing immediately
+      setTimeout(() => {
+        setNodes((currentNodes) => {
+          const newNode = currentNodes.find((n) => n.id === newNodeId)
+          if (newNode) setSelectedNode(newNode)
+          return currentNodes.map((n) =>
+            n.id === newNodeId
+              ? { ...n, data: { ...n.data, isInlineEditing: true } }
+              : n
+          )
+        })
+      }, 100)
+    },
+    [screenToFlowPosition, createNode, nodes, setNodes, updateParentRelationships, setSelectedNode]
+  )
+
+  return { handleDragOver, handleDrop }
 }

--- a/frontend/src/features/guest-editor/GuestDFDEditor.tsx
+++ b/frontend/src/features/guest-editor/GuestDFDEditor.tsx
@@ -31,7 +31,7 @@ import type {
   DataFlowEdge,
   TrustBoundaryEdge,
 } from '@/features/dfd-editor/types'
-import { useCreateNode } from '@/features/dfd-editor/hooks/useCreateNode'
+import { useCreateNode, useHandleDrop } from '@/features/dfd-editor/hooks/useCreateNode'
 import { type DFDNotationStyle, NOTATION_NODE_SIZES } from '@/features/dfd-editor/types/notation'
 import { GuestThreatSection } from './components/GuestThreatSection'
 import { guestNodeTypes, guestEdgeTypes } from './components/GuestNodeWrapper'
@@ -153,25 +153,14 @@ function GuestDFDEditorContent() {
   // Drag-and-drop from toolbar
   const { createNode } = useCreateNode(notationStyle)
 
-  const handleDragOver = useCallback((event: React.DragEvent) => {
-    event.preventDefault()
-    event.dataTransfer.dropEffect = 'move'
-  }, [])
-
-  const handleDrop = useCallback(
-    (event: React.DragEvent) => {
-      event.preventDefault()
-      const nodeType = event.dataTransfer.getData('application/reactflow-node-type') as DiagramNodeType
-      if (!nodeType) return
-      const dropPosition = screenToFlowPosition({ x: event.clientX, y: event.clientY })
-      createNode(nodeType, dropPosition)
-      // Let ReactFlow render the new node, then check parent relationships
-      requestAnimationFrame(() => {
-        updateParentRelationships(nodes, setNodes)
-      })
-    },
-    [screenToFlowPosition, createNode, nodes, setNodes, updateParentRelationships]
-  )
+  const { handleDragOver, handleDrop } = useHandleDrop({
+    screenToFlowPosition,
+    createNode,
+    nodes,
+    setNodes,
+    updateParentRelationships,
+    setSelectedNode,
+  })
 
   // Register export image handler so the header can call it
   useEffect(() => {

--- a/frontend/src/features/guest-editor/components/GuestEditorHeader.tsx
+++ b/frontend/src/features/guest-editor/components/GuestEditorHeader.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { Download, FileText, FolderOpen, Pencil, ArrowLeft, Layers, Save, ChevronDown, ShieldAlert } from 'lucide-react'
+import { Download, FileText, FolderOpen, Pencil, ArrowLeft, Save, ChevronDown, ShieldAlert } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -328,8 +328,8 @@ export function GuestEditorHeader({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="outline" size="sm" className="bg-teal-50 text-teal-700 border-teal-200 hover:bg-teal-100" onClick={() => setShowSystemContextModal(true)}>
-                  <Layers className="h-4 w-4 mr-2" />
-                  Context
+                  <Pencil className="h-3.5 w-3.5 mr-1.5" />
+                  Add / Edit Context
                 </Button>
               </TooltipTrigger>
               <TooltipContent>Define system context, data assets, and assumptions</TooltipContent>

--- a/frontend/src/features/guest-editor/components/GuestThreatSection.tsx
+++ b/frontend/src/features/guest-editor/components/GuestThreatSection.tsx
@@ -77,10 +77,29 @@ export function GuestThreatSection({
               {threats.map((threat) => (
                 <div
                   key={threat.id}
-                  className="flex items-center justify-between gap-2 p-2 rounded-md border bg-card text-sm cursor-pointer hover:bg-muted/50"
+                  className="flex flex-col gap-1.5 p-2 rounded-md border bg-card text-sm cursor-pointer hover:bg-muted/50"
                   onClick={() => handleEdit(threat)}
                 >
-                  <div className="flex items-center gap-2 min-w-0">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium leading-snug truncate">{threat.name}</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 w-6 p-0 shrink-0 text-muted-foreground hover:text-red-600"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        guestEditor.removeThreat(threat.id)
+                      }}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
+                  </div>
+                  {threat.description && (
+                    <p className="text-xs text-muted-foreground leading-snug line-clamp-2">
+                      {threat.description}
+                    </p>
+                  )}
+                  <div className="flex flex-wrap items-center gap-1">
                     <Badge
                       variant="secondary"
                       className={cn('shrink-0 text-xs', SEVERITY_COLORS[threat.severity])}
@@ -99,19 +118,7 @@ export function GuestThreatSection({
                         {STRIDE_CONFIG[threat.category].label}
                       </Badge>
                     )}
-                    <span className="truncate">{threat.name}</span>
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 w-6 p-0 shrink-0 text-muted-foreground hover:text-red-600"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      guestEditor.removeThreat(threat.id)
-                    }}
-                  >
-                    <Trash2 className="h-3 w-3" />
-                  </Button>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
 - Darker data flow edge labels — changed text color to near-black, removed opacity fade, and added subtle shadow so labels are    
  readable at a glance (Closes #246)
  - Show threat description in properties panel — threat cards now display the description text below the name, and badges are moved
   below for a cleaner layout in both signed-in and guest editors (Closes #245)
  - Make context button more discoverable — renamed "Context" to "Add / Edit Context" with a pencil icon in the guest editor header
  (Closes #244)
  - Auto-edit node name on drop — dropping an element on the canvas now automatically selects it and enters inline editing mode so
  users can start typing immediately, matching draw.io behavior. Extracted shared useHandleDrop hook used by both editors (Closes
  #243)