### PR TITLE
fix: add rate limiting to login, registration, and password reset endpoints

### DIFF
--- a/backend/apps/core/auth_views.py
+++ b/backend/apps/core/auth_views.py
@@ -1,0 +1,20 @@
+from dj_rest_auth.registration.views import RegisterView
+from dj_rest_auth.views import LoginView, PasswordResetView
+
+from apps.core.throttles import (
+    LoginRateThrottle,
+    PasswordResetRateThrottle,
+    RegistrationRateThrottle,
+)
+
+
+class ThrottledLoginView(LoginView):
+    throttle_classes = [LoginRateThrottle]
+
+
+class ThrottledRegisterView(RegisterView):
+    throttle_classes = [RegistrationRateThrottle]
+
+
+class ThrottledPasswordResetView(PasswordResetView):
+    throttle_classes = [PasswordResetRateThrottle]

--- a/backend/apps/core/tests/test_auth_throttles.py
+++ b/backend/apps/core/tests/test_auth_throttles.py
@@ -1,0 +1,123 @@
+"""Tests for authentication rate limiting.
+
+Verifies that login, registration, and password reset endpoints enforce
+per-IP request limits to prevent credential stuffing, registration
+flooding, and password reset abuse.
+
+Uses the production throttle rates from settings (login: 5/min,
+registration: 3/min, password_reset: 3/min).
+"""
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+class LoginThrottleTests(TestCase):
+    """Login endpoint must lock out after repeated failures (5/min)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            username="throttle_test",
+            email="throttle@test.org",
+            password="correctpassword",
+        )
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def _login(self, password="wrong"):
+        return self.client.post(
+            "/api/auth/login/",
+            {"email": "throttle@test.org", "password": password},
+            format="json",
+        )
+
+    def test_blocks_after_limit_exceeded(self):
+        for _ in range(5):
+            resp = self._login()
+            self.assertIn(
+                resp.status_code,
+                (status.HTTP_400_BAD_REQUEST, status.HTTP_200_OK),
+            )
+
+        resp = self._login()
+        self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_correct_password_also_blocked_after_limit(self):
+        for _ in range(5):
+            self._login()
+
+        resp = self._login(password="correctpassword")
+        self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_throttle_response_contains_retry_after(self):
+        for _ in range(5):
+            self._login()
+
+        resp = self._login()
+        self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertIn("Retry-After", resp.headers)
+
+
+class RegistrationThrottleTests(TestCase):
+    """Registration endpoint must limit account creation rate (3/min)."""
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def _register(self, n=0):
+        return self.client.post(
+            "/api/auth/registration/",
+            {
+                "email": f"newuser{n}@test.org",
+                "username": f"newuser{n}",
+                "password1": "strongpass123!",
+                "password2": "strongpass123!",
+            },
+            format="json",
+        )
+
+    def test_blocks_after_limit_exceeded(self):
+        for i in range(3):
+            self._register(n=i)
+
+        resp = self._register(n=99)
+        self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+
+class PasswordResetThrottleTests(TestCase):
+    """Password reset endpoint must limit reset request rate (3/min)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            username="resetuser",
+            email="reset@test.org",
+            password="testpass123",
+        )
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def _reset(self):
+        return self.client.post(
+            "/api/auth/password/reset/",
+            {"email": "reset@test.org"},
+            format="json",
+        )
+
+    def test_blocks_after_limit_exceeded(self):
+        for _ in range(3):
+            self._reset()
+
+        resp = self._reset()
+        self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)

--- a/backend/apps/core/throttles.py
+++ b/backend/apps/core/throttles.py
@@ -1,0 +1,19 @@
+from rest_framework.throttling import AnonRateThrottle
+
+
+class LoginRateThrottle(AnonRateThrottle):
+    """Limits login attempts per IP to prevent credential stuffing."""
+
+    scope = "login"
+
+
+class RegistrationRateThrottle(AnonRateThrottle):
+    """Limits account creation per IP to prevent registration flooding."""
+
+    scope = "registration"
+
+
+class PasswordResetRateThrottle(AnonRateThrottle):
+    """Limits password reset requests per IP to prevent email flooding."""
+
+    scope = "password_reset"

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -192,6 +192,11 @@ REST_FRAMEWORK = {
         "djangorestframework_camel_case.parser.CamelCaseFormParser",
         "djangorestframework_camel_case.parser.CamelCaseMultiPartParser",
     ),
+    "DEFAULT_THROTTLE_RATES": {
+        "login": "5/min",
+        "registration": "3/min",
+        "password_reset": "3/min",
+    },
 }
 
 # CamelCase parser settings - ignore auth fields used by dj-rest-auth

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -12,12 +12,29 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
+from apps.core.auth_views import (
+    ThrottledLoginView,
+    ThrottledPasswordResetView,
+    ThrottledRegisterView,
+)
+
 urlpatterns = [
     # Admin
     path("admin/", admin.site.urls),
     # Core API (health check, dashboard stats)
     path("api/", include("apps.core.urls")),
-    # Authentication
+    # Authentication — throttled overrides before the dj-rest-auth includes
+    path("api/auth/login/", ThrottledLoginView.as_view(), name="rest_login"),
+    path(
+        "api/auth/password/reset/",
+        ThrottledPasswordResetView.as_view(),
+        name="rest_password_reset",
+    ),
+    path(
+        "api/auth/registration/",
+        ThrottledRegisterView.as_view(),
+        name="rest_register",
+    ),
     path("api/auth/", include("dj_rest_auth.urls")),
     path("api/auth/registration/", include("dj_rest_auth.registration.urls")),
     # App APIs


### PR DESCRIPTION
## Summary

- Add per-IP rate limiting to authentication endpoints to prevent brute-force and credential stuffing attacks
- Login: 5 requests/min, Registration: 3 requests/min, Password reset: 3 requests/min
- Uses DRF's built-in throttling with scoped `AnonRateThrottle` subclasses, no new deps introduced.

Fixes #249 

## Reproduction

Before this fix, unlimited login attempts are possible with no lockout:

```bash
for i in $(seq 1 50); do
  curl -s -o /dev/null -w "Attempt $i: HTTP %{http_code}\n" \
    http://localhost:8000/api/auth/login/ -X POST \
    -H "Content-Type: application/json" \
    -d "{\"email\":\"admin@precogly.dev\",\"password\":\"wrong$i\"}"
done
# All 50 return HTTP 400 - no lockout, no rate limit

After this fix, the 6th attempt returns HTTP 429 with a Retry-After header.

Changes

- backend/apps/core/throttles.py - three scoped throttle classes (login, registration, password_reset)
- backend/apps/core/auth_views.py - throttled subclasses of dj-rest-auth LoginView, RegisterView, PasswordResetView
- backend/config/urls.py - override auth URLs with throttled views (placed before dj-rest-auth includes)
- backend/config/settings/base.py - throttle rate configuration in REST_FRAMEWORK