### PR TITLE
fix(threats): exclude flow-scoped threats from the component library picker

### DIFF
--- a/backend/apps/threats/tests/test_threat_library_scoping.py
+++ b/backend/apps/threats/tests/test_threat_library_scoping.py
@@ -1,0 +1,94 @@
+"""What the ``component_id`` filter on ``/threat-library/`` may offer.
+
+A component library maps two different things through the same join table: the
+threats a component carries itself, and the threats its *connections* carry. An
+API gateway maps eavesdropping and replay so that flows touching it inherit
+them — those threats belong on the data flow, never on the gateway.
+
+The picker filtered by component library but not by ``applies_to``, so it
+offered flow-scoped threats when adding to a component, and users added them
+there. The AI ranker never had the bug because
+``candidate_library_threats`` filtered correctly; these tests pin the two paths
+to the same rule.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.organizations.models import Organization, OrganizationMember
+from apps.systems.models import ComponentLibrary, OrgsystemComponent
+from apps.threats.models import ComponentLibraryThreat, ThreatLibrary
+
+User = get_user_model()
+
+
+class ThreatLibraryComponentScopingTests(TestCase):
+    """The ``component_id`` filter must exclude flow-only threats."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org = Organization.objects.create(name="Scoping Org", domain="scope.test")
+        cls.user = User.objects.create_user(
+            username="scopeuser", email="scope@scope.test", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org, user=cls.user, role="security_team"
+        )
+
+        # An API gateway, mapped to one threat of each scope — the exact shape
+        # that produced the bug in the aws-mini pack.
+        gateway_library = ComponentLibrary.objects.create(
+            name="API Gateway", category=ComponentLibrary.Category.PROCESS
+        )
+        cls.component = OrgsystemComponent.objects.create(
+            component_library=gateway_library, name="Payments API Gateway"
+        )
+
+        cls.own_threat = ThreatLibrary.objects.create(name="Unauthorized API Access")
+        cls.shared_threat = ThreatLibrary.objects.create(name="API Injection")
+        cls.flow_threat = ThreatLibrary.objects.create(name="Data Eavesdropping")
+
+        for threat, applies_to in (
+            (cls.own_threat, ComponentLibraryThreat.AppliesTo.COMPONENT),
+            (cls.shared_threat, ComponentLibraryThreat.AppliesTo.BOTH),
+            (cls.flow_threat, ComponentLibraryThreat.AppliesTo.FLOW),
+        ):
+            ComponentLibraryThreat.objects.create(
+                component_library=gateway_library,
+                threat_library=threat,
+                applies_to=applies_to,
+            )
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user).access_token}"
+        )
+
+    def _names_for_component(self):
+        response = self.client.get(
+            f"/api/threat-library/?component_id={self.component.pk}"
+        )
+        self.assertEqual(response.status_code, 200)
+        return {item["name"] for item in response.data}
+
+    def test_flow_only_threats_are_not_offered_for_a_component(self):
+        self.assertNotIn("Data Eavesdropping", self._names_for_component())
+
+    def test_component_and_both_scoped_threats_are_offered(self):
+        names = self._names_for_component()
+        self.assertIn("Unauthorized API Access", names)
+        self.assertIn("API Injection", names)
+
+    def test_unfiltered_listing_still_returns_flow_threats(self):
+        """The scope rule belongs to the component filter, not the catalogue.
+
+        Without ``component_id`` this endpoint is the whole library — a flow
+        threat is a real entry and must still be listed, or browsing the
+        catalogue would silently hide part of a pack.
+        """
+        response = self.client.get("/api/threat-library/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Data Eavesdropping", {item["name"] for item in response.data})

--- a/backend/apps/threats/views.py
+++ b/backend/apps/threats/views.py
@@ -121,8 +121,19 @@ class ThreatLibraryViewSet(viewsets.ModelViewSet):
                 return queryset
 
             if component.component_library_id:
+                # A component library maps both the threats a component carries
+                # itself and the ones its connections carry (an API gateway maps
+                # eavesdropping and replay so its *flows* inherit them). Only the
+                # component-scoped ones belong on the component, so this mirrors
+                # the filter in `apps.threats.ai.suggest.candidate_library_threats`
+                # — without it the picker offers flow threats on a component and
+                # they get added there.
                 threat_ids = ComponentLibraryThreat.objects.filter(
                     component_library_id=component.component_library_id,
+                    applies_to__in=[
+                        ComponentLibraryThreat.AppliesTo.COMPONENT,
+                        ComponentLibraryThreat.AppliesTo.BOTH,
+                    ],
                 ).values_list("threat_library_id", flat=True)
                 queryset = queryset.filter(id__in=threat_ids)
 


### PR DESCRIPTION
## The problem

A component library maps two different things through the same join table: the threats a component carries itself, and the threats its *connections* carry. An API gateway maps eavesdropping and replay so that flows touching it inherit them — those threats belong on the data flow, never on the gateway.

The `component_id` filter on `/threat-library/` narrowed to the component's library but ignored `applies_to`, so the Add Threat picker offered flow-scoped threats when adding to a component. Users added them there, producing component threats that the pack never intended to exist.

## The change

Adds the `applies_to in (COMPONENT, BOTH)` filter to that queryset, mirroring `apps.threats.ai.suggest.candidate_library_threats`, which has always filtered correctly. The AI ranker therefore never had this bug — the two paths express the same conceptual scope and now apply the same rule.

The filter is deliberately scoped to the `component_id` branch only. Without `component_id` the endpoint is the whole catalogue, where a flow threat is a real entry that must still be listed, or browsing a pack would silently hide part of it. The third test pins that.

## Verification

```
$ docker compose exec backend python -m pytest apps/threats/tests/test_threat_library_scoping.py -q
3 passed in 5.19s
```

The fixture is the exact shape that produced the bug in the `aws-mini` pack: one API Gateway library mapping one threat of each scope.

## Not in this PR

The Add Threat dialog rework (#219) touches the same picker from the frontend side and ships separately. This fix stands on its own and does not depend on it.