### PR TITLE
README: point the Discord links at a non-expiring invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Release](https://img.shields.io/github/v/release/precogly/precogly)](https://github.com/precogly/precogly/releases/latest)
 [![License](https://img.shields.io/github/license/precogly/precogly)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/precogly/precogly)](https://github.com/precogly/precogly/stargazers)
-[![Discord](https://img.shields.io/badge/Discord-Join%20Chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/EMn653Qkq)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/uBFZGJzpYa)
 ![OWASP Project](https://img.shields.io/badge/OWASP-Project-blue?logo=owasp)
 
 > [!IMPORTANT]
@@ -84,7 +84,7 @@ If you find Precogly useful, give the project a star!
 
 ### Community
 
-Join the conversation on [Discord](https://discord.gg/EMn653Qkq).
+Join the conversation on [Discord](https://discord.gg/uBFZGJzpYa).
 
 ### Need Help? Contact the Developer
 


### PR DESCRIPTION
## Problem

Both Discord links in the README point at invite `EMn653Qkq`, which has expired:

```
$ curl -s https://discord.com/api/v10/invites/EMn653Qkq
{"message": "Invite is expired.", "code": 10006}
```

So the badge at the top and the "Join the conversation on Discord" line under
**Community** both land a reader on Discord's expired-invite page. This is what
prompted the request for the link on #209 ("can anyone share the discord link
please").

## Change

Both occurrences now use `uBFZGJzpYa`. Nothing else in the README moves.

## Verification

The replacement resolves, opens on `#general`, and carries no expiry — where the
old invite lapsed, this one reports `expires_at: null`:

```
$ curl -s 'https://discord.com/api/v10/invites/uBFZGJzpYa?with_expiration=true'
"guild":   {"name": "Precogly", ...}
"channel": {"name": "general", "type": 0}
"expires_at": null
```

The expiry check is the point of the verification rather than a formality: an
invite that lapses reproduces exactly the bug being fixed here, silently, some
months from now.

## Not addressed

`docs/changelog.md` references the original link's PR (#85) as a historical
record, and is left alone.