### PR TITLE
docs: add SECURITY.md vulnerability disclosure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Precogly is designed for enterprise workflows, but smaller organizations can als
 
 See the [v0.3.0 milestone](https://github.com/precogly/precogly/milestone/1) for what's coming next.
 
+### Security
+
+To report a vulnerability, please see our [Security Policy](SECURITY.md).
+
 ### Contributing
 
 - [Open an issue](https://github.com/precogly/precogly/issues)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.3.x   | Yes                |
+| 0.2.x   | Security fixes only|
+| 0.1.x   | No                 |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Precogly, please report it responsibly.
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+1. Email **vikramsnarayan@gmail.com** with a description of the vulnerability.
+2. Include steps to reproduce the issue, affected version(s), and potential impact.
+3. If possible, provide a proof of concept or relevant logs (redact sensitive data).
+4. You will receive an acknowledgment within **48 hours**.
+
+### Response Timeline
+
+- **Acknowledgment:** Within 48 hours of report submission.
+- **Initial assessment:** Within 5 business days.
+- **Fix or mitigation:** Target resolution within 30 days for confirmed vulnerabilities, depending on severity and complexity.
+- **Disclosure:** Coordinated with the reporter once a fix is available.
+
+## Scope
+
+### In Scope
+
+- The Precogly web application and its API endpoints
+- Authentication and authorization flows
+- Data handling and storage within the platform
+
+### Out of Scope
+
+- Third-party dependencies (report these to the upstream project)
+- Social engineering attacks against contributors or users
+- Denial of service attacks
+- Issues in environments running unsupported versions
+
+## Safe Harbor
+
+Precogly supports safe harbor for security researchers who:
+
+- Act in good faith to avoid privacy violations, data destruction, and service disruption.
+- Only interact with accounts you own or with explicit permission of the account holder.
+- Report vulnerabilities through the process described above.
+- Allow reasonable time for the issue to be resolved before any public disclosure.
+
+We will not pursue legal action against researchers who follow this policy.
+
+## Recognition
+
+We appreciate the efforts of security researchers who help keep Precogly secure.
+With your permission, we will acknowledge your contribution in release notes
+associated with the fix. We do not currently offer a paid bug bounty program.
+
+## Questions
+
+For general security questions (not vulnerability reports), open a
+[GitHub Discussion](https://github.com/precogly/precogly/discussions) or
+reach out at vikramsnarayan@gmail.com.


### PR DESCRIPTION
 - Adds SECURITY.md with responsible disclosure process, supported versions table, scope, safe harbor, and recognition policy
- Contact: as given in #18 with 48h acknowledgment SLA
- Standard format expected by GitHub's security advisory tooling

This fixes #18 more or less

