### PR TITLE
feat: AI-powered DFD generation from architecture diagrams 

### DIFF
--- a/backend/apps/ai/providers/base.py
+++ b/backend/apps/ai/providers/base.py
@@ -17,6 +17,7 @@ key is plaintext and the only job left is to make the call.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import Any
 
 
 class AIProviderError(Exception):
@@ -115,14 +116,16 @@ class ChatProvider(ABC):
     @abstractmethod
     def complete(
         self,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         *,
         temperature: float = 0.2,
         force_json: bool = True,
     ) -> "Completion":
         """Run one chat completion and return its content plus token usage.
 
-        ``messages`` follows the OpenAI role/content shape. Raises
+        ``messages`` follows the OpenAI role/content shape and may include
+        multimodal content parts (text, image_url) for vision-capable models.
+        Raises
         :class:`AIProviderError` if the endpoint is unreachable, times out, or
         returns a response the adapter cannot parse. The returned
         :class:`Completion` carries ``usage=None`` when the provider did not

--- a/backend/apps/ai/providers/base.py
+++ b/backend/apps/ai/providers/base.py
@@ -120,11 +120,19 @@ class ChatProvider(ABC):
         *,
         temperature: float = 0.2,
         force_json: bool = True,
+        max_tokens: int = 4096,
     ) -> "Completion":
         """Run one chat completion and return its content plus token usage.
 
         ``messages`` follows the OpenAI role/content shape and may include
         multimodal content parts (text, image_url) for vision-capable models.
+
+        ``max_tokens`` caps the response length. The default (4096) suits most
+        structured-JSON tasks. Callers that need larger output (e.g. full DFD
+        canvas data) should pass a higher value. Setting a limit avoids
+        providers like OpenRouter pre-authorizing the model's full context
+        window against the user's credit balance.
+
         Raises
         :class:`AIProviderError` if the endpoint is unreachable, times out, or
         returns a response the adapter cannot parse. The returned

--- a/backend/apps/ai/providers/openai_compat.py
+++ b/backend/apps/ai/providers/openai_compat.py
@@ -11,6 +11,7 @@ operator who hasn't started their local model should see "model unreachable at
 <url>", not a generic 500.
 """
 
+import logging
 from typing import Any
 
 import requests
@@ -24,6 +25,9 @@ from .base import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
 class OpenAICompatProvider(ChatProvider):
     """Talk to an OpenAI-compatible server described by ``self.config``."""
 
@@ -33,6 +37,7 @@ class OpenAICompatProvider(ChatProvider):
         *,
         temperature: float = 0.2,
         force_json: bool = True,
+        max_tokens: int = 4096,
     ) -> Completion:
         # Default to a low temperature because this is a selection-and-explanation
         # task, not creative writing — we want stable, repeatable output. When
@@ -43,6 +48,7 @@ class OpenAICompatProvider(ChatProvider):
             "model": self.config.model,
             "messages": messages,
             "temperature": temperature,
+            "max_tokens": max_tokens,
         }
         if force_json:
             payload["response_format"] = {"type": "json_object"}
@@ -61,6 +67,14 @@ class OpenAICompatProvider(ChatProvider):
             and _is_response_format_error(response)
         ):
             payload.pop("response_format", None)
+            response = self._post("/chat/completions", payload)
+
+        # Newer OpenAI models (e.g. gpt-4o, gpt-5.4-nano) reject ``max_tokens``
+        # and require ``max_completion_tokens`` instead. When a server complains
+        # about max_tokens, swap the parameter name and retry once.
+        if response.status_code == 400 and _is_max_tokens_error(response):
+            payload.pop("max_tokens", None)
+            payload["max_completion_tokens"] = max_tokens
             response = self._post("/chat/completions", payload)
 
         if response.status_code != 200:
@@ -201,6 +215,17 @@ def _is_response_format_error(response: requests.Response) -> bool:
     silently retried.
     """
     return "response_format" in _safe_error_detail(response).lower()
+
+
+def _is_max_tokens_error(response: requests.Response) -> bool:
+    """Whether a 400 is the server objecting to ``max_tokens``.
+
+    Newer OpenAI models require ``max_completion_tokens`` instead. We detect the
+    complaint and swap the parameter name on retry — same pattern as the
+    ``response_format`` fallback above.
+    """
+    detail = _safe_error_detail(response).lower()
+    return "max_tokens" in detail
 
 
 def _model_count(response: requests.Response) -> int | None:

--- a/backend/apps/ai/providers/openai_compat.py
+++ b/backend/apps/ai/providers/openai_compat.py
@@ -11,6 +11,8 @@ operator who hasn't started their local model should see "model unreachable at
 <url>", not a generic 500.
 """
 
+from typing import Any
+
 import requests
 
 from .base import (
@@ -27,7 +29,7 @@ class OpenAICompatProvider(ChatProvider):
 
     def complete(
         self,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         *,
         temperature: float = 0.2,
         force_json: bool = True,

--- a/backend/apps/ai/providers/openai_compat.py
+++ b/backend/apps/ai/providers/openai_compat.py
@@ -81,6 +81,13 @@ class OpenAICompatProvider(ChatProvider):
             # Surface the provider's own error body when present — for a hosted
             # provider this is usually the most useful thing (bad key, no quota).
             detail = _safe_error_detail(response)
+            logger.warning(
+                "AI provider %s (%s) returned HTTP %s: %s",
+                self.config.base_url,
+                self.config.model,
+                response.status_code,
+                detail[:500],
+            )
             raise AIProviderError(
                 f"The AI model returned HTTP {response.status_code}: {detail}"
             )

--- a/backend/apps/ai/resolver.py
+++ b/backend/apps/ai/resolver.py
@@ -86,9 +86,9 @@ class MeteringProvider(ChatProvider):
         self._feature = feature
         self._user = user
 
-    def complete(self, messages, *, temperature=0.2, force_json=True) -> Completion:
+    def complete(self, messages, *, temperature=0.2, force_json=True, max_tokens=4096) -> Completion:
         completion = self._inner.complete(
-            messages, temperature=temperature, force_json=force_json
+            messages, temperature=temperature, force_json=force_json, max_tokens=max_tokens
         )
         self._record(completion)
         return completion

--- a/backend/apps/ai/tests/test_infra.py
+++ b/backend/apps/ai/tests/test_infra.py
@@ -191,6 +191,46 @@ class OpenAICompatCompleteTests(SimpleTestCase):
             self.provider.complete([{"role": "user", "content": "hi"}], force_json=True)
         self.assertEqual(post.call_count, 1)
 
+    @mock.patch.object(openai_compat.requests, "post")
+    def test_max_tokens_is_sent_in_payload(self, post):
+        post.return_value = _response(json_body=self._ok_body())
+        self.provider.complete([{"role": "user", "content": "hi"}])
+        self.assertEqual(post.call_args.kwargs["json"]["max_tokens"], 4096)
+
+    @mock.patch.object(openai_compat.requests, "post")
+    def test_custom_max_tokens_is_sent(self, post):
+        post.return_value = _response(json_body=self._ok_body())
+        self.provider.complete([{"role": "user", "content": "hi"}], max_tokens=16384)
+        self.assertEqual(post.call_args.kwargs["json"]["max_tokens"], 16384)
+
+    @mock.patch.object(openai_compat.requests, "post")
+    def test_retries_with_max_completion_tokens_when_max_tokens_rejected(self, post):
+        rejected = _response(
+            status_code=400,
+            json_body={
+                "error": {
+                    "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."
+                }
+            },
+        )
+        ok = _response(json_body=self._ok_body("recovered"))
+        responses = [rejected, ok]
+        sent_payloads = []
+
+        def record_and_respond(*args, **kwargs):
+            sent_payloads.append(deepcopy(kwargs["json"]))
+            return responses.pop(0)
+
+        post.side_effect = record_and_respond
+        result = self.provider.complete([{"role": "user", "content": "hi"}])
+        self.assertEqual(result.content, "recovered")
+        self.assertEqual(post.call_count, 2)
+        # First attempt uses max_tokens; the retry swaps to max_completion_tokens.
+        self.assertIn("max_tokens", sent_payloads[0])
+        self.assertNotIn("max_completion_tokens", sent_payloads[0])
+        self.assertNotIn("max_tokens", sent_payloads[1])
+        self.assertEqual(sent_payloads[1]["max_completion_tokens"], 4096)
+
 
 class OpenAICompatTestConnectionTests(SimpleTestCase):
     def setUp(self):

--- a/backend/apps/ai/tests/test_usage.py
+++ b/backend/apps/ai/tests/test_usage.py
@@ -40,7 +40,7 @@ class _FakeProvider(ChatProvider):
         self._completion = completion
         self._price = price
 
-    def complete(self, messages, *, temperature=0.2, force_json=True):
+    def complete(self, messages, *, temperature=0.2, force_json=True, max_tokens=4096):
         return self._completion
 
     def test_connection(self):

--- a/backend/apps/ai/utils.py
+++ b/backend/apps/ai/utils.py
@@ -1,0 +1,32 @@
+"""Shared helpers for AI feature modules."""
+
+from __future__ import annotations
+
+import json
+
+
+def extract_json_object(raw: str) -> dict | None:
+    """Parse a JSON object from a possibly-noisy model response.
+
+    Tolerates markdown fences (``````json … ``````), prose around the JSON, and
+    other common noise patterns.  Returns ``None`` when nothing parseable is
+    found — callers decide how to handle that (empty result, error, etc.).
+    """
+    if not raw:
+        return None
+    text = raw.strip()
+    try:
+        result = json.loads(text)
+        return result if isinstance(result, dict) else None
+    except ValueError:
+        pass
+    # Fall back to the substring between the first '{' and last '}'.
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        result = json.loads(text[start : end + 1])
+        return result if isinstance(result, dict) else None
+    except ValueError:
+        return None

--- a/backend/apps/diagrams/ai/__init__.py
+++ b/backend/apps/diagrams/ai/__init__.py
@@ -1,0 +1,6 @@
+"""AI-powered DFD generation from architecture diagrams."""
+
+from .analyze import analyze_architecture_image
+from .generate import generate_dfd_from_analysis
+
+__all__ = ["analyze_architecture_image", "generate_dfd_from_analysis"]

--- a/backend/apps/diagrams/ai/analyze.py
+++ b/backend/apps/diagrams/ai/analyze.py
@@ -1,0 +1,90 @@
+"""Step 1: Analyze an architecture image with a vision-capable model."""
+
+from __future__ import annotations
+
+import base64
+
+from apps.ai.providers.base import AIProviderError
+from apps.ai.resolver import resolve_provider
+from apps.ai.utils import extract_json_object
+
+from .prompts import ANALYZE_SYSTEM_PROMPT
+
+# Keys we require in the analysis response.
+_REQUIRED_KEYS = {"components", "dataFlows", "trustZones", "systemScope", "questions"}
+
+
+def analyze_architecture_image(
+    *,
+    image_bytes: bytes,
+    image_content_type: str,
+    app_name: str,
+    app_description: str,
+    organization,
+    user=None,
+) -> dict:
+    """Send an architecture image to a vision model and return structured analysis.
+
+    Returns a dict with keys: components, dataFlows, trustZones, systemScope,
+    questions.  Raises ``AIProviderError`` if the model cannot be reached or
+    returns unparseable output (e.g. the model does not support vision).
+    """
+    provider = resolve_provider(
+        organization, feature="generate_dfd", user=user
+    )
+
+    image_b64 = base64.b64encode(image_bytes).decode("ascii")
+    data_uri = f"data:{image_content_type};base64,{image_b64}"
+
+    user_text = f"Application: {app_name}"
+    if app_description:
+        user_text += f"\nDescription: {app_description}"
+    user_text += "\n\nAnalyze the architecture diagram above and extract all components, data flows, trust zones, and clarifying questions."
+
+    messages = [
+        {"role": "system", "content": ANALYZE_SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": data_uri, "detail": "high"},
+                },
+                {"type": "text", "text": user_text},
+            ],
+        },
+    ]
+
+    completion = provider.complete(messages, temperature=0.3)
+    result = extract_json_object(completion.content)
+
+    if result is None:
+        raise AIProviderError(
+            "The AI model returned a response that could not be parsed as JSON. "
+            "The model may not support vision/image inputs. Try a vision-capable "
+            "model such as GPT-4o."
+        )
+
+    # Validate required keys, filling in defaults for missing ones so
+    # downstream code always sees a consistent shape.
+    for key in _REQUIRED_KEYS:
+        if key not in result:
+            result[key] = [] if key != "systemScope" else {"name": app_name, "description": app_description}
+
+    # Ensure components is a list of dicts.
+    if not isinstance(result["components"], list):
+        result["components"] = []
+    # Ensure dataFlows is a list.
+    if not isinstance(result["dataFlows"], list):
+        result["dataFlows"] = []
+    # Ensure trustZones is a list.
+    if not isinstance(result["trustZones"], list):
+        result["trustZones"] = []
+    # Ensure questions is a list.
+    if not isinstance(result["questions"], list):
+        result["questions"] = []
+    # Ensure systemScope is a dict.
+    if not isinstance(result["systemScope"], dict):
+        result["systemScope"] = {"name": app_name, "description": app_description}
+
+    return result

--- a/backend/apps/diagrams/ai/analyze.py
+++ b/backend/apps/diagrams/ai/analyze.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import base64
+import logging
 
 from apps.ai.providers.base import AIProviderError
 from apps.ai.resolver import resolve_provider
 from apps.ai.utils import extract_json_object
 
 from .prompts import ANALYZE_SYSTEM_PROMPT
+
+logger = logging.getLogger(__name__)
 
 # Keys we require in the analysis response.
 _REQUIRED_KEYS = {"components", "dataFlows", "trustZones", "systemScope", "questions"}
@@ -59,6 +62,12 @@ def analyze_architecture_image(
     result = extract_json_object(completion.content)
 
     if result is None:
+        logger.error(
+            "[analyze_image] Model response could not be parsed as JSON. "
+            "Raw content (%d chars):\n%s",
+            len(completion.content),
+            completion.content[:2000],
+        )
         raise AIProviderError(
             "The AI model returned a response that could not be parsed as JSON. "
             "The model may not support vision/image inputs. Try a vision-capable "

--- a/backend/apps/diagrams/ai/generate.py
+++ b/backend/apps/diagrams/ai/generate.py
@@ -1,0 +1,536 @@
+"""Step 2: Generate DFD canvas_data from a structured analysis."""
+
+from __future__ import annotations
+
+import json
+import math
+
+from apps.ai.providers.base import AIProviderError
+from apps.ai.resolver import resolve_provider
+from apps.ai.utils import extract_json_object
+
+from .prompts import (
+    DEFAULT_NODE_SIZES,
+    GENERATE_SYSTEM_PROMPT,
+    MAX_COMPONENT_LIBRARY_ENTRIES,
+    NODE_TYPE_TO_CATEGORY,
+    VALID_NODE_TYPES,
+)
+
+# Node types that act as containers (can have children).
+_CONTAINER_TYPES = frozenset({"trustZone", "systemScope"})
+
+# Node types that are external actors and belong outside the system scope.
+_ACTOR_TYPES = frozenset({"humanActor", "systemActor"})
+
+# Padding inside containers around the bounding box of their children.
+_CONTAINER_PADDING = 40
+
+# Gap between children when re-laid out inside a container.
+_CHILD_GAP = 30
+
+# Gap between actors placed outside the system scope.
+_ACTOR_GAP = 30
+
+
+def generate_dfd_from_analysis(
+    *,
+    analysis: dict,
+    answers: list[dict],
+    threat_model,
+    organization,
+    user=None,
+) -> dict:
+    """Generate ``canvas_data`` (nodes + edges) from an architecture analysis.
+
+    Fetches the component library scoped to the threat model's connected packs,
+    asks the model to produce positioned canvas data, then validates and
+    resolves component references.
+
+    Returns ``{"nodes": [...], "edges": [...]}``.
+    """
+    provider = resolve_provider(
+        organization, feature="generate_dfd", user=user
+    )
+
+    library_lines = _build_component_library_prompt(threat_model)
+
+    user_content = f"Architecture analysis:\n{json.dumps(analysis, indent=2)}\n\n"
+
+    if answers:
+        user_content += "User's answers to clarifying questions:\n"
+        for qa in answers:
+            question = qa.get("question", "")
+            answer = qa.get("answer", "")
+            if answer:
+                user_content += f"Q: {question}\nA: {answer}\n\n"
+
+    if library_lines:
+        user_content += f"Available component library entries (use component_ref when matching):\n{library_lines}\n\n"
+
+    user_content += "Generate the DFD canvas data JSON now."
+
+    messages = [
+        {"role": "system", "content": GENERATE_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+    completion = provider.complete(messages, temperature=0.2)
+    result = extract_json_object(completion.content)
+
+    if result is None:
+        raise AIProviderError(
+            "The AI model returned a response that could not be parsed as JSON. "
+            "Try again or use a different model."
+        )
+
+    nodes = result.get("nodes", [])
+    edges = result.get("edges", [])
+
+    if not isinstance(nodes, list):
+        nodes = []
+    if not isinstance(edges, list):
+        edges = []
+
+    nodes, edges = _validate_and_resolve(nodes, edges, threat_model)
+    nodes, edges = _fix_layout(nodes, edges, analysis)
+
+    return {"nodes": nodes, "edges": edges}
+
+
+def _build_component_library_prompt(threat_model) -> str:
+    """Build a compact listing of available component library entries."""
+    from apps.systems.models import ComponentLibrary
+    from apps.threat_models.models import ThreatModelLibraryPack
+
+    connected_pack_ids = ThreatModelLibraryPack.objects.filter(
+        threat_model=threat_model
+    ).values_list("library_pack_id", flat=True)
+
+    entries = ComponentLibrary.objects.filter(
+        source_pack_id__in=connected_pack_ids
+    ).select_related("source_pack").order_by("name")[:MAX_COMPONENT_LIBRARY_ENTRIES]
+
+    lines = []
+    for entry in entries:
+        slug = entry.qualified_slug or entry.slug
+        line = f"slug={slug} | {entry.name} ({entry.category}, {entry.component_type}, {entry.provider})"
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def _validate_and_resolve(
+    nodes: list[dict], edges: list[dict], threat_model
+) -> tuple[list[dict], list[dict]]:
+    """Post-process model output: validate types, resolve refs, drop invalid items."""
+    from apps.systems.models import ComponentLibrary
+    from apps.threat_models.models import ThreatModelLibraryPack
+
+    # Build a lookup of available component library entries.
+    connected_pack_ids = list(
+        ThreatModelLibraryPack.objects.filter(
+            threat_model=threat_model
+        ).values_list("library_pack_id", flat=True)
+    )
+
+    library_by_qualified_slug: dict[str, ComponentLibrary] = {}
+    library_by_slug: dict[str, ComponentLibrary] = {}
+
+    if connected_pack_ids:
+        for entry in ComponentLibrary.objects.filter(
+            source_pack_id__in=connected_pack_ids
+        ):
+            if entry.qualified_slug:
+                library_by_qualified_slug[entry.qualified_slug] = entry
+            if entry.slug:
+                library_by_slug[entry.slug] = entry
+
+    valid_nodes = []
+    valid_node_ids: set[str] = set()
+
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+
+        node_type = node.get("type")
+        node_id = node.get("id")
+
+        if not node_id or not isinstance(node_id, str):
+            continue
+
+        # Drop nodes with invalid types.
+        if node_type not in VALID_NODE_TYPES:
+            continue
+
+        # Ensure position exists.
+        if "position" not in node or not isinstance(node.get("position"), dict):
+            node["position"] = {"x": 0, "y": 0}
+
+        # Ensure style with dimensions exists.
+        if "style" not in node or not isinstance(node.get("style"), dict):
+            defaults = DEFAULT_NODE_SIZES.get(node_type, {"width": 150, "height": 70})
+            node["style"] = {**defaults}
+
+        # Ensure data dict with label.
+        if "data" not in node or not isinstance(node.get("data"), dict):
+            node["data"] = {"label": node_id}
+        elif not node["data"].get("label"):
+            node["data"]["label"] = node_id
+
+        # Resolve component_ref against the component library.
+        data = node["data"]
+        component_ref = data.get("component_ref")
+        if component_ref and node_type in NODE_TYPE_TO_CATEGORY:
+            resolved = (
+                library_by_qualified_slug.get(component_ref)
+                or library_by_slug.get(component_ref)
+            )
+            if resolved:
+                data["component_library_id"] = resolved.id
+                data["component_library_name"] = resolved.name
+            # Strip component_ref regardless — it served its purpose.
+            data.pop("component_ref", None)
+
+        valid_nodes.append(node)
+        valid_node_ids.add(node_id)
+
+    # Second pass: validate parentId references.
+    for node in valid_nodes:
+        parent_id = node.get("parentId")
+        if parent_id and parent_id not in valid_node_ids:
+            node.pop("parentId", None)
+
+    # Validate edges: both source and target must reference valid nodes.
+    valid_edges = []
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+
+        edge_id = edge.get("id")
+        source = edge.get("source")
+        target = edge.get("target")
+
+        if not edge_id or not source or not target:
+            continue
+
+        if source not in valid_node_ids or target not in valid_node_ids:
+            continue
+
+        # Ensure edge has type.
+        if "type" not in edge:
+            edge["type"] = "dataFlow"
+
+        # Ensure edge has data dict.
+        if "data" not in edge or not isinstance(edge.get("data"), dict):
+            edge["data"] = {}
+
+        valid_edges.append(edge)
+
+    return valid_nodes, valid_edges
+
+
+# ---------------------------------------------------------------------------
+# Layout correction
+# ---------------------------------------------------------------------------
+
+
+def _fix_layout(
+    nodes: list[dict], edges: list[dict], analysis: dict
+) -> tuple[list[dict], list[dict]]:
+    """Deterministic layout correction for LLM-generated canvas data.
+
+    The model gets the *semantics* right (what belongs where) but struggles
+    with precise coordinates. This function:
+
+    1. Recovers orphaned nodes by matching them to trust zones via the
+       analysis's component→trustZone mapping.
+    2. Re-lays out children inside each container in a compact grid.
+    3. Auto-sizes containers (bottom-up) to fit their children with padding.
+    4. Places external actors outside the system scope.
+    5. Recomputes edge handles from actual node positions.
+    """
+    by_id: dict[str, dict] = {n["id"]: n for n in nodes}
+
+    # Find the system scope and trust zone nodes.
+    system_scope_id = _find_system_scope(nodes)
+    trust_zone_ids = {n["id"] for n in nodes if n["type"] == "trustZone"}
+
+    # Step 1: Orphan recovery — assign parentId to nodes that should be inside
+    # a container but aren't.
+    _recover_orphans(nodes, by_id, analysis, system_scope_id, trust_zone_ids)
+
+    # Step 2: Re-layout children inside each container (bottom-up: trust zones
+    # first, then system scope).
+    for zone_id in trust_zone_ids:
+        _layout_children(nodes, by_id, zone_id)
+
+    if system_scope_id:
+        # Layout trust zones inside the system scope.
+        _layout_children(nodes, by_id, system_scope_id)
+
+    # Step 3: Place actors outside the system scope (to the left).
+    _place_actors_outside(nodes, by_id, system_scope_id)
+
+    # Step 4: Recompute edge handles from actual absolute positions.
+    _recompute_handles(edges, nodes, by_id)
+
+    return nodes, edges
+
+
+def _find_system_scope(nodes: list[dict]) -> str | None:
+    """Return the id of the first systemScope node, or None."""
+    for node in nodes:
+        if node["type"] == "systemScope":
+            return node["id"]
+    return None
+
+
+def _recover_orphans(
+    nodes: list[dict],
+    by_id: dict[str, dict],
+    analysis: dict,
+    system_scope_id: str | None,
+    trust_zone_ids: set[str],
+) -> None:
+    """Assign parentId to leaf nodes that lost their container reference.
+
+    Uses the analysis's component→trustZone name mapping to match nodes to
+    the trust zone node whose label best matches.
+    """
+    # Build component name → trustZone name from the analysis.
+    component_zone_map: dict[str, str] = {}
+    for comp in analysis.get("components", []):
+        name = comp.get("name", "")
+        zone = comp.get("trustZone", "")
+        if name and zone:
+            component_zone_map[name.lower()] = zone.lower()
+
+    # Build zone label → zone id lookup.
+    zone_label_to_id: dict[str, str] = {}
+    for zone_id in trust_zone_ids:
+        zone_node = by_id.get(zone_id)
+        if zone_node:
+            label = zone_node.get("data", {}).get("label", "").lower()
+            if label:
+                zone_label_to_id[label] = zone_id
+
+    for node in nodes:
+        node_type = node["type"]
+
+        # Skip containers and nodes that already have a valid parent.
+        if node_type in _CONTAINER_TYPES:
+            continue
+        if node_type in _ACTOR_TYPES:
+            # Actors should be outside — clear any parentId.
+            node.pop("parentId", None)
+            continue
+
+        parent_id = node.get("parentId")
+        if parent_id and parent_id in by_id:
+            continue  # Already parented correctly.
+
+        # Try to match via analysis trustZone.
+        node_label = node.get("data", {}).get("label", "").lower()
+        target_zone_name = component_zone_map.get(node_label, "")
+
+        matched_zone_id = None
+        if target_zone_name:
+            # Exact match first, then substring.
+            matched_zone_id = zone_label_to_id.get(target_zone_name)
+            if not matched_zone_id:
+                for zone_label, zone_id in zone_label_to_id.items():
+                    if target_zone_name in zone_label or zone_label in target_zone_name:
+                        matched_zone_id = zone_id
+                        break
+
+        if matched_zone_id:
+            node["parentId"] = matched_zone_id
+        elif trust_zone_ids:
+            # Fall back to the first trust zone.
+            node["parentId"] = next(iter(trust_zone_ids))
+        elif system_scope_id:
+            node["parentId"] = system_scope_id
+
+    # Ensure trust zones are parented to the system scope.
+    if system_scope_id:
+        for zone_id in trust_zone_ids:
+            zone_node = by_id.get(zone_id)
+            if zone_node:
+                zone_node["parentId"] = system_scope_id
+
+
+def _layout_children(
+    nodes: list[dict], by_id: dict[str, dict], container_id: str
+) -> None:
+    """Re-lay out children of ``container_id`` in a compact grid and resize
+    the container to fit."""
+    children = [n for n in nodes if n.get("parentId") == container_id]
+    if not children:
+        # No children — use default size.
+        container = by_id.get(container_id)
+        if container:
+            defaults = DEFAULT_NODE_SIZES.get(
+                container["type"], {"width": 500, "height": 350}
+            )
+            container["style"] = {**defaults}
+        return
+
+    # Sort children: containers first (so trust zones are placed before leaf
+    # nodes when inside a system scope), then by original position.
+    children.sort(
+        key=lambda n: (
+            0 if n["type"] in _CONTAINER_TYPES else 1,
+            n.get("position", {}).get("y", 0),
+            n.get("position", {}).get("x", 0),
+        )
+    )
+
+    # Compute child sizes.
+    child_sizes = []
+    for child in children:
+        style = child.get("style", {})
+        child_sizes.append({
+            "w": style.get("width", DEFAULT_NODE_SIZES.get(child["type"], {}).get("width", 150)),
+            "h": style.get("height", DEFAULT_NODE_SIZES.get(child["type"], {}).get("height", 70)),
+        })
+
+    # Determine grid columns based on number of children.
+    num_children = len(children)
+    if num_children <= 3:
+        cols = num_children
+    elif num_children <= 8:
+        cols = 3
+    else:
+        cols = int(math.ceil(math.sqrt(num_children)))
+
+    # Place children in grid rows, each row packed by actual child widths.
+    cursor_x = _CONTAINER_PADDING
+    cursor_y = _CONTAINER_PADDING + 30  # Extra 30px for the container label.
+    row_max_height = 0
+    max_row_right = 0
+
+    for i, (child, size) in enumerate(zip(children, child_sizes)):
+        col_index = i % cols
+        if col_index == 0 and i > 0:
+            # New row.
+            cursor_x = _CONTAINER_PADDING
+            cursor_y += row_max_height + _CHILD_GAP
+            row_max_height = 0
+
+        child["position"] = {"x": cursor_x, "y": cursor_y}
+        right_edge = cursor_x + size["w"]
+        if right_edge > max_row_right:
+            max_row_right = right_edge
+
+        cursor_x += size["w"] + _CHILD_GAP
+        if size["h"] > row_max_height:
+            row_max_height = size["h"]
+
+    # Size the container to enclose all children.
+    total_width = max_row_right + _CONTAINER_PADDING
+    total_height = cursor_y + row_max_height + _CONTAINER_PADDING
+
+    # Enforce minimums.
+    container = by_id.get(container_id)
+    if container:
+        min_sizes = DEFAULT_NODE_SIZES.get(
+            container["type"], {"width": 400, "height": 300}
+        )
+        container["style"] = {
+            "width": max(total_width, min_sizes["width"]),
+            "height": max(total_height, min_sizes["height"]),
+        }
+
+
+def _place_actors_outside(
+    nodes: list[dict], by_id: dict[str, dict], system_scope_id: str | None
+) -> None:
+    """Position external actors to the left of the system scope."""
+    actors = [n for n in nodes if n["type"] in _ACTOR_TYPES]
+    if not actors:
+        return
+
+    # Determine the left edge of the system scope for reference.
+    scope_x = 0
+    if system_scope_id:
+        scope_node = by_id.get(system_scope_id)
+        if scope_node:
+            scope_x = scope_node.get("position", {}).get("x", 0)
+
+    # Stack actors vertically to the left of the system scope.
+    actor_x = scope_x - 180
+    actor_y = 20
+
+    for actor in actors:
+        actor.pop("parentId", None)
+        size = DEFAULT_NODE_SIZES.get(actor["type"], {"width": 100, "height": 100})
+        actor["position"] = {"x": actor_x, "y": actor_y}
+        actor["style"] = {**size}
+        actor_y += size["height"] + _ACTOR_GAP
+
+
+def _get_absolute_position(
+    node: dict, by_id: dict[str, dict]
+) -> tuple[float, float]:
+    """Compute a node's absolute position by walking the parent chain."""
+    abs_x = node.get("position", {}).get("x", 0)
+    abs_y = node.get("position", {}).get("y", 0)
+
+    parent_id = node.get("parentId")
+    visited: set[str] = set()
+    while parent_id and parent_id not in visited:
+        visited.add(parent_id)
+        parent = by_id.get(parent_id)
+        if not parent:
+            break
+        abs_x += parent.get("position", {}).get("x", 0)
+        abs_y += parent.get("position", {}).get("y", 0)
+        parent_id = parent.get("parentId")
+
+    return abs_x, abs_y
+
+
+def _get_node_center(
+    node: dict, by_id: dict[str, dict]
+) -> tuple[float, float]:
+    """Compute the absolute center point of a node."""
+    abs_x, abs_y = _get_absolute_position(node, by_id)
+    style = node.get("style", {})
+    default_size = DEFAULT_NODE_SIZES.get(node["type"], {"width": 150, "height": 70})
+    w = style.get("width", default_size["width"])
+    h = style.get("height", default_size["height"])
+    return abs_x + w / 2, abs_y + h / 2
+
+
+def _recompute_handles(
+    edges: list[dict], nodes: list[dict], by_id: dict[str, dict]
+) -> None:
+    """Set sourceHandle/targetHandle based on actual relative positions."""
+    for edge in edges:
+        source_node = by_id.get(edge.get("source", ""))
+        target_node = by_id.get(edge.get("target", ""))
+        if not source_node or not target_node:
+            continue
+
+        src_cx, src_cy = _get_node_center(source_node, by_id)
+        tgt_cx, tgt_cy = _get_node_center(target_node, by_id)
+
+        dx = tgt_cx - src_cx
+        dy = tgt_cy - src_cy
+
+        # Choose primary axis based on which delta is larger.
+        if abs(dx) >= abs(dy):
+            if dx >= 0:
+                edge["sourceHandle"] = "right-source"
+                edge["targetHandle"] = "left-target"
+            else:
+                edge["sourceHandle"] = "left-source"
+                edge["targetHandle"] = "right-target"
+        else:
+            if dy >= 0:
+                edge["sourceHandle"] = "bottom-source"
+                edge["targetHandle"] = "top-target"
+            else:
+                edge["sourceHandle"] = "top-source"
+                edge["targetHandle"] = "bottom-target"

--- a/backend/apps/diagrams/ai/generate.py
+++ b/backend/apps/diagrams/ai/generate.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 
 from apps.ai.providers.base import AIProviderError
 from apps.ai.resolver import resolve_provider
 from apps.ai.utils import extract_json_object
+
+logger = logging.getLogger(__name__)
 
 from .prompts import (
     DEFAULT_NODE_SIZES,
@@ -75,10 +78,16 @@ def generate_dfd_from_analysis(
         {"role": "user", "content": user_content},
     ]
 
-    completion = provider.complete(messages, temperature=0.2)
+    completion = provider.complete(messages, temperature=0.2, max_tokens=16384)
     result = extract_json_object(completion.content)
 
     if result is None:
+        logger.error(
+            "[generate_dfd] Model response could not be parsed as JSON. "
+            "Raw content (%d chars):\n%s",
+            len(completion.content),
+            completion.content[:2000],
+        )
         raise AIProviderError(
             "The AI model returned a response that could not be parsed as JSON. "
             "Try again or use a different model."

--- a/backend/apps/diagrams/ai/prompts.py
+++ b/backend/apps/diagrams/ai/prompts.py
@@ -1,0 +1,158 @@
+"""Prompt templates, output schemas, and constants for DFD generation."""
+
+# Valid DFD node types the model may emit.
+VALID_NODE_TYPES = frozenset({
+    "process",
+    "datastore",
+    "humanActor",
+    "systemActor",
+    "trustZone",
+    "systemScope",
+})
+
+# Maps DFD node types to ComponentLibrary category values.
+NODE_TYPE_TO_CATEGORY = {
+    "process": "process",
+    "datastore": "datastore",
+    "humanActor": "external_human_actor",
+    "systemActor": "external_system_actor",
+}
+
+# Default pixel dimensions for each node type on the canvas.
+DEFAULT_NODE_SIZES = {
+    "process": {"width": 150, "height": 70},
+    "datastore": {"width": 170, "height": 70},
+    "humanActor": {"width": 100, "height": 100},
+    "systemActor": {"width": 100, "height": 90},
+    "trustZone": {"width": 500, "height": 350},
+    "systemScope": {"width": 700, "height": 500},
+}
+
+ANALYZE_SYSTEM_PROMPT = """\
+You are a threat-modeling assistant for Precogly. You analyze architecture \
+diagrams (architecture diagrams, sequence diagrams, C4 diagrams, deployment \
+diagrams, etc.) and extract the components, data flows, and trust boundaries \
+needed to build a Data Flow Diagram (DFD).
+
+Analyze the provided image and return a JSON object with exactly this shape:
+
+{
+  "components": [
+    {
+      "name": "<component name>",
+      "type": "process | datastore | humanActor | systemActor",
+      "description": "<brief description of what this component does>",
+      "technology": "<specific technology if identifiable, e.g. PostgreSQL, S3, Nginx>",
+      "trustZone": "<which trust zone this component belongs in, e.g. 'Internal Network', 'DMZ', 'External'>",
+      "dataSensitivity": "<low | medium | high | critical>"
+    }
+  ],
+  "dataFlows": [
+    {
+      "from": "<source component name>",
+      "to": "<target component name>",
+      "description": "<what data flows between them>",
+      "protocol": "<protocol if identifiable, e.g. HTTPS, gRPC, SQL>",
+      "encrypted": true | false,
+      "authenticated": true | false
+    }
+  ],
+  "trustZones": [
+    {
+      "name": "<zone name>",
+      "trustLevel": <0-100 integer, higher = more trusted>
+    }
+  ],
+  "systemScope": {
+    "name": "<overall system or application name>",
+    "description": "<brief description of the system>"
+  },
+  "questions": [
+    "<clarifying question about the architecture>"
+  ]
+}
+
+Rules:
+- Extract ALL components visible in the diagram.
+- Classify each component as process, datastore, humanActor, or systemActor.
+- Identify data flows between components. Use the exact component names from your components list.
+- Group components into trust zones based on network boundaries, cloud regions, or security domains.
+- Ask 2-5 clarifying questions about aspects you cannot determine from the diagram alone \
+(e.g. authentication methods, encryption, data sensitivity, missing components).
+- If technology is not identifiable, use an empty string.
+- Be thorough but accurate. Only include what you can reasonably infer.
+"""
+
+GENERATE_SYSTEM_PROMPT = """\
+You are a threat-modeling assistant for Precogly. You generate Data Flow \
+Diagram (DFD) canvas data from a structured analysis of an architecture.
+
+You will receive:
+1. An analysis containing components, data flows, trust zones, and system scope.
+2. The user's answers to clarifying questions (may be empty if skipped).
+3. A component library with available component templates to reference.
+
+Return a JSON object with exactly this shape:
+
+{
+  "nodes": [
+    {
+      "id": "<unique string id, e.g. 'process-1', 'datastore-2'>",
+      "type": "process | datastore | humanActor | systemActor | trustZone | systemScope",
+      "position": {"x": <number>, "y": <number>},
+      "style": {"width": <number>, "height": <number>},
+      "data": {
+        "label": "<display name>",
+        "description": "<brief description>",
+        "technology": "<technology if known>"
+      },
+      "parentId": "<id of parent trustZone or systemScope, if nested>"
+    }
+  ],
+  "edges": [
+    {
+      "id": "<unique string id, e.g. 'edge-1'>",
+      "type": "dataFlow",
+      "source": "<source node id>",
+      "target": "<target node id>",
+      "sourceHandle": "right-source",
+      "targetHandle": "left-target",
+      "data": {
+        "label": "<flow description>",
+        "protocol": "<protocol>",
+        "encrypted": true | false,
+        "authenticated": true | false
+      }
+    }
+  ]
+}
+
+Layout rules:
+- Create ONE systemScope node at position (0, 0) containing all trust zones.
+- Create trustZone nodes INSIDE the systemScope (parentId = systemScope id).
+- Place process, datastore nodes INSIDE their trust zones (parentId = trustZone id).
+- Place humanActor and systemActor nodes OUTSIDE the systemScope (no parentId) \
+to the left or top of the diagram.
+- Trust zones should be large enough to contain their children (width >= 400, height >= 300).
+- The systemScope should be large enough to contain all trust zones (width >= 700, height >= 500).
+- Space nodes within a zone with at least 50px gaps.
+- Positions for children are RELATIVE to their parent's position.
+- Use these handle pairs for edges based on relative positions:
+  - Left to right flow: sourceHandle="right-source", targetHandle="left-target"
+  - Right to left flow: sourceHandle="left-source", targetHandle="right-target"
+  - Top to bottom flow: sourceHandle="bottom-source", targetHandle="top-target"
+  - Bottom to top flow: sourceHandle="top-source", targetHandle="bottom-target"
+
+Component library matching:
+- When a component_library entry matches a node's technology, add \
+"component_ref": "<qualified_slug>" to the node's data.
+- Match by technology name (e.g. if technology is "PostgreSQL" and library has \
+slug "postgresql", use it).
+- Only add component_ref when confident in the match. Skip if uncertain.
+
+Incorporate the user's answers to refine the diagram. If they indicated \
+additional components, data flows, or trust boundaries, include them.
+"""
+
+# Maximum number of component library entries to include in the prompt.
+MAX_COMPONENT_LIBRARY_ENTRIES = 200

--- a/backend/apps/diagrams/ai/prompts.py
+++ b/backend/apps/diagrams/ai/prompts.py
@@ -73,14 +73,26 @@ Analyze the provided image and return a JSON object with exactly this shape:
 }
 
 Rules:
-- Extract ALL components visible in the diagram.
+- Model at the SERVICE level, not the feature or content-type level. Each process \
+node should represent a deployable service or application (e.g. "Web Application", \
+"API Gateway"), not an internal module, UI variant, or content format.
+- Merge implementation variants into single logical nodes. For example, free-tier \
+and paid-tier frontends that share the same codebase are ONE "Web Application" \
+process; multiple content types stored in the same system are ONE datastore.
+- Aim for 6-12 components total. A DFD is a security-focused abstraction, not a \
+full architecture replica. Fewer nodes with clear trust boundaries are more useful \
+than an exhaustive inventory.
 - Classify each component as process, datastore, humanActor, or systemActor.
-- Identify data flows between components. Use the exact component names from your components list.
-- Group components into trust zones based on network boundaries, cloud regions, or security domains.
-- Ask 2-5 clarifying questions about aspects you cannot determine from the diagram alone \
-(e.g. authentication methods, encryption, data sensitivity, missing components).
+- Create ONE data flow per logical communication channel between two components. \
+Summarize multiple operations into a single flow description \
+(e.g. "HTTPS: authentication, course browsing, subscription management").
+- Group components into trust zones based on network boundaries, cloud regions, \
+or security domains.
+- Ask 1-3 clarifying questions about aspects you cannot determine from the diagram \
+alone (e.g. authentication methods, encryption, data sensitivity, missing components).
 - If technology is not identifiable, use an empty string.
-- Be thorough but accurate. Only include what you can reasonably infer.
+- Prioritize clarity over completeness. Only include components that represent \
+distinct trust or threat boundaries.
 """
 
 GENERATE_SYSTEM_PROMPT = """\
@@ -142,6 +154,12 @@ to the left or top of the diagram.
   - Right to left flow: sourceHandle="left-source", targetHandle="right-target"
   - Top to bottom flow: sourceHandle="bottom-source", targetHandle="top-target"
   - Bottom to top flow: sourceHandle="top-source", targetHandle="bottom-target"
+
+Simplification:
+- Create exactly ONE edge between any two nodes, even if the analysis lists \
+multiple data flows between them. Combine their descriptions into a single label \
+(e.g. "HTTPS: auth, course data, subscriptions").
+- Do not split a single analysis component into multiple nodes. One component = one node.
 
 Component library matching:
 - When a component_library entry matches a node's technology, add \

--- a/backend/apps/diagrams/views.py
+++ b/backend/apps/diagrams/views.py
@@ -10,9 +10,12 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 
+from apps.ai.providers.base import AIDisabledError, AIProviderError
+from apps.ai.resolver import resolve_config
 from apps.core.permissions import CanWrite
 from apps.threat_models.models import ThreatModel
 
+from .ai import analyze_architecture_image, generate_dfd_from_analysis
 from .models import DFD, DFDTemplatesLibrary
 from .serializers import (
     DFDListSerializer,
@@ -20,6 +23,10 @@ from .serializers import (
     DFDTemplatesLibrarySerializer,
 )
 from .services import sync_dfd_nodes_to_components
+
+# Image types accepted for architecture diagram analysis.
+_ACCEPTED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp"}
+_MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
 class DFDViewSet(viewsets.ModelViewSet):
@@ -170,6 +177,144 @@ class DFDViewSet(viewsets.ModelViewSet):
             "orphaned_components": orphaned_components,
             "orphaned_component_count": len(orphaned_components),
         })
+
+    @action(detail=False, methods=["get"], url_path="ai-availability")
+    def ai_availability(self, request):
+        """Report whether AI-powered DFD generation is available for an org."""
+        threat_model_id = request.query_params.get("threat_model_id")
+        if not threat_model_id:
+            return Response(
+                {"error": "threat_model_id query parameter is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        org_ids = request.user.organization_memberships.values_list(
+            "organization_id", flat=True
+        )
+        threat_model = ThreatModel.objects.filter(
+            id=threat_model_id, organization_id__in=org_ids
+        ).first()
+        if threat_model is None:
+            return Response(
+                {"error": "Threat model not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            resolve_config(threat_model.organization)
+        except AIDisabledError as err:
+            return Response({"available": False, "reason": str(err)})
+        return Response({"available": True, "reason": None})
+
+    @action(detail=False, methods=["post"], url_path="analyze-image")
+    def analyze_image(self, request):
+        """Analyze an architecture diagram image and extract components."""
+        image = request.FILES.get("image")
+        app_name = request.data.get("app_name", "").strip()
+        app_description = request.data.get("app_description", "").strip()
+        threat_model_id = request.data.get("threat_model_id")
+
+        if not image:
+            return Response(
+                {"error": "An image file is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not app_name:
+            return Response(
+                {"error": "app_name is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not threat_model_id:
+            return Response(
+                {"error": "threat_model_id is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Validate image type and size.
+        if image.content_type not in _ACCEPTED_IMAGE_TYPES:
+            return Response(
+                {"error": f"Unsupported image type: {image.content_type}. Accepted: JPEG, PNG, WebP."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if image.size > _MAX_IMAGE_SIZE:
+            return Response(
+                {"error": "Image must be 10 MB or smaller."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Scope threat model to user's orgs.
+        org_ids = request.user.organization_memberships.values_list(
+            "organization_id", flat=True
+        )
+        threat_model = ThreatModel.objects.filter(
+            id=threat_model_id, organization_id__in=org_ids
+        ).select_related("organization").first()
+        if threat_model is None:
+            return Response(
+                {"error": "Threat model not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            result = analyze_architecture_image(
+                image_bytes=image.read(),
+                image_content_type=image.content_type,
+                app_name=app_name,
+                app_description=app_description,
+                organization=threat_model.organization,
+                user=request.user,
+            )
+        except AIDisabledError as err:
+            return Response({"error": str(err)}, status=status.HTTP_400_BAD_REQUEST)
+        except AIProviderError as err:
+            return Response({"error": str(err)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+        return Response(result)
+
+    @action(detail=False, methods=["post"], url_path="generate-dfd")
+    def generate_dfd(self, request):
+        """Generate DFD canvas data from an analysis and user answers."""
+        threat_model_id = request.data.get("threat_model_id")
+        analysis = request.data.get("analysis")
+        answers = request.data.get("answers", [])
+
+        if not threat_model_id:
+            return Response(
+                {"error": "threat_model_id is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not analysis or not isinstance(analysis, dict):
+            return Response(
+                {"error": "analysis object is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        org_ids = request.user.organization_memberships.values_list(
+            "organization_id", flat=True
+        )
+        threat_model = ThreatModel.objects.filter(
+            id=threat_model_id, organization_id__in=org_ids
+        ).select_related("organization").first()
+        if threat_model is None:
+            return Response(
+                {"error": "Threat model not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            canvas_data = generate_dfd_from_analysis(
+                analysis=analysis,
+                answers=answers if isinstance(answers, list) else [],
+                threat_model=threat_model,
+                organization=threat_model.organization,
+                user=request.user,
+            )
+        except AIDisabledError as err:
+            return Response({"error": str(err)}, status=status.HTTP_400_BAD_REQUEST)
+        except AIProviderError as err:
+            return Response({"error": str(err)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+        return Response(canvas_data)
 
     def destroy(self, request, *args, **kwargs):
         """

--- a/backend/apps/threats/ai/suggest.py
+++ b/backend/apps/threats/ai/suggest.py
@@ -24,6 +24,7 @@ import json
 from django.db.models import Q
 
 from apps.ai import resolve_provider_for_component
+from apps.ai.utils import extract_json_object
 from apps.threats.models import ComponentInstanceThreat, ComponentLibraryThreat
 from apps.threat_models.models import ThreatModelLibraryPack
 
@@ -221,35 +222,13 @@ def _parse_selections(raw: str) -> list[dict]:
     can't parse — a malformed reply should yield no suggestions, never an error
     that blocks the user.
     """
-    payload = _extract_json_object(raw)
+    payload = extract_json_object(raw)
     if payload is None:
         return []
     suggestions = payload.get("suggestions")
     if not isinstance(suggestions, list):
         return []
     return [item for item in suggestions if isinstance(item, dict)]
-
-
-def _extract_json_object(raw: str) -> dict | None:
-    """Parse a JSON object from a possibly-noisy model response."""
-    if not raw:
-        return None
-    text = raw.strip()
-    try:
-        result = json.loads(text)
-        return result if isinstance(result, dict) else None
-    except ValueError:
-        pass
-    # Fall back to the substring between the first '{' and last '}'.
-    start = text.find("{")
-    end = text.rfind("}")
-    if start == -1 or end == -1 or end <= start:
-        return None
-    try:
-        result = json.loads(text[start : end + 1])
-        return result if isinstance(result, dict) else None
-    except ValueError:
-        return None
 
 
 def _coerce_severity(value, fallback: str) -> str:

--- a/frontend/src/features/ai/components/AiErrorState.tsx
+++ b/frontend/src/features/ai/components/AiErrorState.tsx
@@ -7,8 +7,9 @@
  * ```text
  *   400   configured -> unconfigured between the availability check and the
  *         request. Nothing to retry; the user needs to set up a provider.
- *   503   configured but unreachable. Retrying is exactly right once they have
- *         started the model or fixed the URL.
+ *   503   provider error — the backend reached the provider but got back an
+ *         error (billing, auth, model not found, unreachable, …). The real
+ *         error message is surfaced from the response body when available.
  *   else  unknown. Offer the retry and say plainly what was being attempted.
  *   ```
  *
@@ -32,6 +33,14 @@ interface AiErrorStateProps {
   onRetry: () => void
 }
 
+/** Extract the provider error message from a 503 response body, if available. */
+function extractProviderMessage(error: unknown): string | undefined {
+  if (!(error instanceof ApiError) || !error.data) return undefined
+  const data = error.data as Record<string, unknown>
+  if (typeof data.error === 'string') return data.error
+  return undefined
+}
+
 export function AiErrorState({ error, fallbackMessage, onRetry }: AiErrorStateProps) {
   const navigate = useNavigate()
   const status = error instanceof ApiError ? error.status : undefined
@@ -39,7 +48,7 @@ export function AiErrorState({ error, fallbackMessage, onRetry }: AiErrorStatePr
   if (status === 400) {
     return (
       <div className="space-y-2 p-4 py-10 text-center text-sm">
-        <p className="text-muted-foreground">AI isn’t configured for this organization.</p>
+        <p className="text-muted-foreground">AI isn't configured for this organization.</p>
         <Button size="sm" variant="outline" onClick={() => navigate(AI_PROVIDER_SETTINGS_PATH)}>
           Set up a provider
         </Button>
@@ -47,13 +56,13 @@ export function AiErrorState({ error, fallbackMessage, onRetry }: AiErrorStatePr
     )
   }
 
+  const providerMessage = status === 503 ? extractProviderMessage(error) : undefined
+
   return (
     <div className="space-y-2 p-4 py-10 text-center text-sm">
       <div className="flex items-center justify-center gap-1.5 text-muted-foreground">
         <AlertTriangle className="h-4 w-4" />
-        {status === 503
-          ? 'The AI model is unreachable. Start it, or check the provider URL.'
-          : fallbackMessage}
+        {providerMessage ?? fallbackMessage}
       </div>
       <Button size="sm" variant="outline" className="gap-1.5" onClick={onRetry}>
         <RefreshCw className="h-3.5 w-3.5" />

--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -13,7 +13,7 @@ import {
   addEdge,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { ArrowLeft, Save, Clock, Loader2, Pencil, Trash2, ShieldAlert } from 'lucide-react'
+import { ArrowLeft, Save, Clock, Loader2, Pencil, Trash2, ShieldAlert, LayoutTemplate } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { DeleteDFDDialog } from '@/features/threat-models/components'
 import {
@@ -32,6 +32,8 @@ import { CanvasThreatSection } from './components/panels/CanvasThreatSection'
 import { useThreatModelThreats } from '@/features/threat-models/api/threats'
 import { TrustBoundaryEdgeEditPanel } from './components/panels/TrustBoundaryEdgeEditPanel'
 import { TemplateBrowser } from './components/TemplateBrowser'
+import { GenerateDFDDialog } from './components/GenerateDFDDialog'
+import { OwlMark } from '@/features/ai/components/OwlMark'
 import { CanvasOverlays } from './components/CanvasOverlays'
 import { DFDNotationProvider } from './context/DFDNotationContext'
 import { useDiagramState } from './hooks/useDiagramState'
@@ -53,6 +55,7 @@ function DFDEditorContent() {
   const [selectedNode, setSelectedNode] = useState<DiagramNode | null>(null)
   const [selectedEdge, setSelectedEdge] = useState<DiagramEdge | null>(null)
   const [showTemplates, setShowTemplates] = useState(false)
+  const [showGenerateDFD, setShowGenerateDFD] = useState(false)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
 
   // ReactFlow instance for coordinate conversion and edge queries
@@ -581,6 +584,7 @@ function DFDEditorContent() {
         onBoundaryModeChange={handleBoundaryModeChange}
         getCanvasCenterPosition={getCanvasCenterPosition}
         onOpenTemplates={() => setShowTemplates(true)}
+        onOpenGenerateDFD={() => setShowGenerateDFD(true)}
         onOpenThreatAnalysis={() => {}}
         hideAnalyzeThreats
         notationStyle={notationStyle}
@@ -635,6 +639,33 @@ function DFDEditorContent() {
               />
               <Background gap={15} size={1} />
               <Controls />
+
+              {/* Empty canvas CTA */}
+              {nodes.length === 0 && (
+                <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
+                  <div className="pointer-events-auto bg-background/95 border rounded-xl shadow-lg p-8 text-center max-w-sm">
+                    <h3 className="text-lg font-semibold mb-2">
+                      Start building your DFD
+                    </h3>
+                    <p className="text-sm text-muted-foreground mb-6">
+                      Drag nodes from the toolbar, use a template, or let AI generate a diagram from your architecture.
+                    </p>
+                    <div className="flex gap-3 justify-center">
+                      <Button
+                        variant="outline"
+                        onClick={() => setShowTemplates(true)}
+                      >
+                        <LayoutTemplate className="h-4 w-4 mr-2" />
+                        Use Template
+                      </Button>
+                      <Button onClick={() => setShowGenerateDFD(true)}>
+                        <OwlMark className="h-4 w-4 mr-2" />
+                        Generate with AI
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              )}
             </ReactFlow>
           </DFDNotationProvider>
         </div>
@@ -697,6 +728,14 @@ function DFDEditorContent() {
           threatModelId={threatModelId}
         />
       )}
+
+      {/* Generate DFD Dialog */}
+      <GenerateDFDDialog
+        open={showGenerateDFD}
+        onOpenChange={setShowGenerateDFD}
+        threatModelId={threatModelId}
+        onInsert={handleInsertTemplate}
+      />
 
       {/* Delete DFD Dialog */}
       <DeleteDFDDialog

--- a/frontend/src/features/dfd-editor/api/generate-dfd.ts
+++ b/frontend/src/features/dfd-editor/api/generate-dfd.ts
@@ -1,0 +1,138 @@
+/**
+ * React Query hooks for AI-powered DFD generation from architecture diagrams.
+ *
+ * Two-step flow:
+ *  1. `analyze-image` (POST, multipart): send architecture diagram image + context,
+ *     receive extracted components, data flows, trust zones, and clarifying questions.
+ *  2. `generate-dfd` (POST, JSON): send analysis + user answers, receive canvas_data
+ *     (nodes + edges) ready for insertion via handleInsertTemplate.
+ *
+ * Plus an availability check that mirrors the suggest-threats pattern.
+ *
+ * Query params stay snake_case (not converted by djangorestframework-camel-case).
+ * Body fields are camelCase (converted automatically).
+ */
+
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+
+// ---------- Types ----------
+
+export interface AnalysisComponent {
+  name: string
+  type: 'process' | 'datastore' | 'humanActor' | 'systemActor'
+  description: string
+  technology: string
+  trustZone: string
+  dataSensitivity: string
+}
+
+export interface AnalysisDataFlow {
+  from: string
+  to: string
+  description: string
+  protocol: string
+  encrypted: boolean
+  authenticated: boolean
+}
+
+export interface AnalysisTrustZone {
+  name: string
+  trustLevel: number
+}
+
+export interface AnalysisResult {
+  components: AnalysisComponent[]
+  dataFlows: AnalysisDataFlow[]
+  trustZones: AnalysisTrustZone[]
+  systemScope: { name: string; description: string }
+  questions: string[]
+}
+
+export interface QuestionAnswer {
+  question: string
+  answer: string
+}
+
+export interface GenerateDFDResponse {
+  nodes: Record<string, unknown>[]
+  edges: Record<string, unknown>[]
+}
+
+export interface DfdAiAvailability {
+  available: boolean
+  reason: string | null
+}
+
+// ---------- Query keys ----------
+
+export const dfdGenerateKeys = {
+  availability: (threatModelId: string) =>
+    ['dfd-ai-availability', threatModelId] as const,
+}
+
+// ---------- Hooks ----------
+
+/**
+ * Whether AI-powered DFD generation is available for this threat model's org.
+ * Cached 60s; availability changes rarely.
+ */
+export function useDfdAiAvailability(threatModelId: string | undefined) {
+  return useQuery({
+    queryKey: dfdGenerateKeys.availability(threatModelId ?? ''),
+    queryFn: () =>
+      api.get<DfdAiAvailability>(
+        `/diagrams/ai-availability/?threat_model_id=${threatModelId}`
+      ),
+    enabled: !!threatModelId,
+    staleTime: 60_000,
+  })
+}
+
+/**
+ * Analyze an architecture diagram image. Returns extracted components,
+ * data flows, trust zones, and clarifying questions.
+ */
+export function useAnalyzeImage() {
+  return useMutation({
+    mutationFn: ({
+      image,
+      appName,
+      appDescription,
+      threatModelId,
+    }: {
+      image: File
+      appName: string
+      appDescription: string
+      threatModelId: string
+    }) =>
+      api.uploadFile<AnalysisResult>('/diagrams/analyze-image/', image, {
+        app_name: appName,
+        app_description: appDescription,
+        threat_model_id: threatModelId,
+      }),
+  })
+}
+
+/**
+ * Generate DFD canvas data from a prior analysis and the user's answers to
+ * clarifying questions.
+ */
+export function useGenerateDfd() {
+  return useMutation({
+    mutationFn: ({
+      threatModelId,
+      analysis,
+      answers,
+    }: {
+      threatModelId: string
+      analysis: AnalysisResult
+      answers: QuestionAnswer[]
+    }) =>
+      api.post<GenerateDFDResponse>('/diagrams/generate-dfd/', {
+        threatModelId,
+        analysis,
+        answers,
+      }),
+  })
+}

--- a/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
+++ b/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
@@ -23,6 +23,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { OwlMark } from '@/features/ai/components/OwlMark'
 import type { DiagramNodeType } from '../types'
 import type { DFDNotationStyle } from '../types/notation'
 import { useCreateNode } from '../hooks/useCreateNode'
@@ -35,8 +36,10 @@ interface DiagramToolbarProps {
   getCanvasCenterPosition: () => XYPosition
   onOpenTemplates: () => void
   onOpenThreatAnalysis: () => void
+  onOpenGenerateDFD?: () => void
   hideTemplates?: boolean
   hideAnalyzeThreats?: boolean
+  hideGenerateDFD?: boolean
   notationStyle?: DFDNotationStyle
   onNotationChange?: (notation: DFDNotationStyle) => void
   onExportImage?: (format: 'png' | 'svg') => void
@@ -103,8 +106,10 @@ export const DiagramToolbar = memo(function DiagramToolbar({
   getCanvasCenterPosition,
   onOpenTemplates,
   onOpenThreatAnalysis,
+  onOpenGenerateDFD,
   hideTemplates,
   hideAnalyzeThreats,
+  hideGenerateDFD,
   notationStyle = 'dfd3',
   onNotationChange,
   onExportImage,
@@ -240,6 +245,33 @@ export const DiagramToolbar = memo(function DiagramToolbar({
                 <p className="font-medium">DFD Templates</p>
                 <p className="text-xs text-muted-foreground">
                   Browse and insert pre-built diagram templates
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </>
+        )}
+
+        {!hideGenerateDFD && onOpenGenerateDFD && (
+          <>
+            <Separator orientation="vertical" className="h-8 mx-2" />
+
+            {/* AI Generate DFD button */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  onClick={onOpenGenerateDFD}
+                >
+                  <OwlMark className="h-4 w-4" />
+                  <span className="hidden sm:inline">Generate</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p className="font-medium">Generate DFD with AI</p>
+                <p className="text-xs text-muted-foreground">
+                  Upload an architecture diagram and let AI build a DFD
                 </p>
               </TooltipContent>
             </Tooltip>

--- a/frontend/src/features/dfd-editor/components/GenerateDFDDialog.tsx
+++ b/frontend/src/features/dfd-editor/components/GenerateDFDDialog.tsx
@@ -1,0 +1,525 @@
+/**
+ * Three-step dialog for AI-powered DFD generation from architecture diagrams.
+ *
+ * Step 1 (form):       Upload image + app name + description → analyze
+ * Step 2 (chat):       Review extracted components + answer clarifying Qs → generate
+ * Step 3 (generating): Spinner while the model produces canvas_data → insert
+ *
+ * Uses the same insertion path as template insertion (handleInsertTemplate) so
+ * ID remapping, position offsetting, and parent relationships are handled by
+ * the caller.
+ */
+
+import { useState, useCallback, useRef } from 'react'
+import { Upload, X, ArrowLeft, Loader2, Sparkles } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { OwlMark } from '@/features/ai/components/OwlMark'
+import { AiErrorState } from '@/features/ai/components/AiErrorState'
+import {
+  useAnalyzeImage,
+  useGenerateDfd,
+  type AnalysisResult,
+  type QuestionAnswer,
+} from '../api/generate-dfd'
+import type { DiagramNode, DiagramEdge } from '../types'
+
+type Step = 'form' | 'chat' | 'generating'
+
+interface GenerateDFDDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  threatModelId: string | undefined
+  onInsert: (nodes: DiagramNode[], edges: DiagramEdge[]) => void
+}
+
+const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+const MAX_SIZE_MB = 10
+
+export function GenerateDFDDialog({
+  open,
+  onOpenChange,
+  threatModelId,
+  onInsert,
+}: GenerateDFDDialogProps) {
+  // Step state machine
+  const [step, setStep] = useState<Step>('form')
+
+  // Form state (step 1)
+  const [appName, setAppName] = useState('')
+  const [appDescription, setAppDescription] = useState('')
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [preview, setPreview] = useState<string | null>(null)
+  const [fileError, setFileError] = useState<string | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Analysis state (step 2)
+  const [analysis, setAnalysis] = useState<AnalysisResult | null>(null)
+  const [answers, setAnswers] = useState<QuestionAnswer[]>([])
+
+  // Mutations
+  const analyzeMutation = useAnalyzeImage()
+  const generateMutation = useGenerateDfd()
+
+  // --- File handling ---
+
+  const validateFile = useCallback((file: File): string | null => {
+    if (!ACCEPTED_TYPES.includes(file.type)) {
+      return 'Only JPEG, PNG, and WebP images are accepted'
+    }
+    if (file.size > MAX_SIZE_MB * 1024 * 1024) {
+      return `Image must be smaller than ${MAX_SIZE_MB} MB`
+    }
+    return null
+  }, [])
+
+  const handleFileSelect = useCallback(
+    (file: File) => {
+      const error = validateFile(file)
+      if (error) {
+        setFileError(error)
+        return
+      }
+      setFileError(null)
+      setSelectedFile(file)
+      const reader = new FileReader()
+      reader.onloadend = () => setPreview(reader.result as string)
+      reader.readAsDataURL(file)
+    },
+    [validateFile]
+  )
+
+  const handleFileInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      if (file) handleFileSelect(file)
+    },
+    [handleFileSelect]
+  )
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragging(true)
+  }, [])
+
+  const handleDragLeave = useCallback(() => {
+    setIsDragging(false)
+  }, [])
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      setIsDragging(false)
+      const file = e.dataTransfer.files[0]
+      if (file) handleFileSelect(file)
+    },
+    [handleFileSelect]
+  )
+
+  const handleClearFile = useCallback(() => {
+    setSelectedFile(null)
+    setPreview(null)
+    setFileError(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }, [])
+
+  // --- Step transitions ---
+
+  const handleAnalyze = useCallback(() => {
+    if (!selectedFile || !appName.trim() || !threatModelId) return
+
+    analyzeMutation.mutate(
+      {
+        image: selectedFile,
+        appName: appName.trim(),
+        appDescription: appDescription.trim(),
+        threatModelId,
+      },
+      {
+        onSuccess: (result) => {
+          setAnalysis(result)
+          // Pre-fill answer slots for each question.
+          setAnswers(
+            (result.questions || []).map((q) => ({ question: q, answer: '' }))
+          )
+          setStep('chat')
+        },
+      }
+    )
+  }, [selectedFile, appName, appDescription, threatModelId, analyzeMutation])
+
+  // --- Reset ---
+
+  const resetState = useCallback(() => {
+    setStep('form')
+    setAppName('')
+    setAppDescription('')
+    setSelectedFile(null)
+    setPreview(null)
+    setFileError(null)
+    setIsDragging(false)
+    setAnalysis(null)
+    setAnswers([])
+    analyzeMutation.reset()
+    generateMutation.reset()
+  }, [analyzeMutation, generateMutation])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) resetState()
+      onOpenChange(nextOpen)
+    },
+    [onOpenChange, resetState]
+  )
+
+  const handleGenerate = useCallback(() => {
+    if (!analysis || !threatModelId) return
+
+    setStep('generating')
+    generateMutation.mutate(
+      {
+        threatModelId,
+        analysis,
+        answers: answers.filter((a) => a.answer.trim()),
+      },
+      {
+        onSuccess: (result) => {
+          onInsert(
+            result.nodes as unknown as DiagramNode[],
+            result.edges as unknown as DiagramEdge[]
+          )
+          resetState()
+          onOpenChange(false)
+        },
+        onError: () => {
+          // Stay on generating step so AiErrorState can show with retry.
+          setStep('generating')
+        },
+      }
+    )
+  }, [analysis, answers, threatModelId, generateMutation, onInsert, onOpenChange, resetState])
+
+  const handleRetryGenerate = useCallback(() => {
+    handleGenerate()
+  }, [handleGenerate])
+
+  // --- Answer updates ---
+
+  const updateAnswer = useCallback((index: number, value: string) => {
+    setAnswers((prev) =>
+      prev.map((a, i) => (i === index ? { ...a, answer: value } : a))
+    )
+  }, [])
+
+  // --- Node type badge color ---
+
+  const typeBadgeVariant = (
+    type: string
+  ): 'default' | 'secondary' | 'outline' | 'destructive' => {
+    switch (type) {
+      case 'process':
+        return 'default'
+      case 'datastore':
+        return 'secondary'
+      default:
+        return 'outline'
+    }
+  }
+
+  // --- Render ---
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <OwlMark className="h-5 w-5" />
+            Generate DFD with AI
+          </DialogTitle>
+          <DialogDescription>
+            Upload an architecture diagram and let AI create a Data Flow Diagram for you.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Step indicators */}
+        <div className="flex items-center gap-2 mb-4">
+          <Badge variant={step === 'form' ? 'default' : 'secondary'}>
+            1. Upload
+          </Badge>
+          <Badge
+            variant={
+              step === 'chat'
+                ? 'default'
+                : step === 'generating'
+                ? 'secondary'
+                : 'outline'
+            }
+          >
+            2. Review
+          </Badge>
+          <Badge variant={step === 'generating' ? 'default' : 'outline'}>
+            3. Generate
+          </Badge>
+        </div>
+
+        {/* Step 1: Form */}
+        {step === 'form' && (
+          <div className="space-y-4">
+            {/* App name */}
+            <div className="space-y-2">
+              <Label htmlFor="app-name">Application Name *</Label>
+              <Input
+                id="app-name"
+                value={appName}
+                onChange={(e) => setAppName(e.target.value)}
+                placeholder="e.g. Customer Portal"
+              />
+            </div>
+
+            {/* Description */}
+            <div className="space-y-2">
+              <Label htmlFor="app-desc">Description (optional)</Label>
+              <Textarea
+                id="app-desc"
+                value={appDescription}
+                onChange={(e) => setAppDescription(e.target.value)}
+                placeholder="Brief context about the application, its purpose, and key integrations..."
+                rows={3}
+              />
+            </div>
+
+            {/* Image upload */}
+            <div className="space-y-2">
+              <Label>Architecture Diagram *</Label>
+              {!selectedFile ? (
+                <div
+                  onDragOver={handleDragOver}
+                  onDragLeave={handleDragLeave}
+                  onDrop={handleDrop}
+                  className={`border-2 border-dashed rounded-lg p-8 text-center transition-colors ${
+                    isDragging
+                      ? 'border-primary bg-primary/5'
+                      : 'border-muted-foreground/25 hover:border-muted-foreground/50'
+                  }`}
+                >
+                  <Upload className="h-10 w-10 mx-auto mb-3 text-muted-foreground" />
+                  <p className="text-sm text-muted-foreground mb-2">
+                    Drag and drop an architecture diagram, or click to select
+                  </p>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept={ACCEPTED_TYPES.join(',')}
+                    onChange={handleFileInputChange}
+                    className="hidden"
+                    id="dfd-image-upload"
+                  />
+                  <label htmlFor="dfd-image-upload">
+                    <Button variant="outline" size="sm" asChild>
+                      <span>Select Image</span>
+                    </Button>
+                  </label>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    JPEG, PNG, or WebP &middot; Max {MAX_SIZE_MB} MB
+                  </p>
+                </div>
+              ) : (
+                <div className="relative border rounded-lg overflow-hidden">
+                  {preview && (
+                    <img
+                      src={preview}
+                      alt="Architecture diagram preview"
+                      className="w-full h-48 object-contain bg-muted"
+                    />
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="absolute top-2 right-2 bg-background/80"
+                    onClick={handleClearFile}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                  <p className="text-xs text-muted-foreground p-2">
+                    {selectedFile.name}
+                  </p>
+                </div>
+              )}
+              {fileError && (
+                <p className="text-sm text-destructive">{fileError}</p>
+              )}
+            </div>
+
+            {/* Analyze error */}
+            {analyzeMutation.isError && (
+              <AiErrorState
+                error={analyzeMutation.error}
+                fallbackMessage="Something went wrong analyzing the diagram."
+                onRetry={handleAnalyze}
+              />
+            )}
+
+            {/* Actions */}
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleAnalyze}
+                disabled={
+                  !selectedFile ||
+                  !appName.trim() ||
+                  analyzeMutation.isPending
+                }
+              >
+                {analyzeMutation.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Analyzing...
+                  </>
+                ) : (
+                  <>
+                    <Sparkles className="h-4 w-4 mr-2" />
+                    Analyze Diagram
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 2: Review & Clarify */}
+        {step === 'chat' && analysis && (
+          <div className="space-y-4">
+            {/* Extracted components */}
+            <div>
+              <h3 className="text-sm font-medium mb-2">
+                Extracted Components ({analysis.components.length})
+              </h3>
+              <div className="grid grid-cols-2 gap-2 max-h-48 overflow-y-auto">
+                {analysis.components.map((comp, index) => (
+                  <div
+                    key={index}
+                    className="flex items-start gap-2 p-2 border rounded-md text-sm"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        <span className="font-medium truncate">
+                          {comp.name}
+                        </span>
+                        <Badge
+                          variant={typeBadgeVariant(comp.type)}
+                          className="text-[10px] px-1 py-0 shrink-0"
+                        >
+                          {comp.type}
+                        </Badge>
+                      </div>
+                      {comp.technology && (
+                        <p className="text-xs text-muted-foreground truncate">
+                          {comp.technology}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Summary stats */}
+            <div className="flex gap-4 text-sm text-muted-foreground">
+              <span>{analysis.dataFlows.length} data flows</span>
+              <span>{analysis.trustZones.length} trust zones</span>
+              {analysis.systemScope?.name && (
+                <span>Scope: {analysis.systemScope.name}</span>
+              )}
+            </div>
+
+            {/* Clarifying questions */}
+            {answers.length > 0 && (
+              <div className="space-y-3">
+                <h3 className="text-sm font-medium">
+                  Clarifying Questions (optional)
+                </h3>
+                {answers.map((qa, index) => (
+                  <div key={index} className="space-y-1">
+                    <Label className="text-sm text-muted-foreground">
+                      {qa.question}
+                    </Label>
+                    <Textarea
+                      value={qa.answer}
+                      onChange={(e) => updateAnswer(index, e.target.value)}
+                      placeholder="Skip or provide details..."
+                      rows={2}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex justify-between pt-2">
+              <Button
+                variant="ghost"
+                onClick={() => setStep('form')}
+              >
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Back
+              </Button>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <Button onClick={handleGenerate}>
+                  <Sparkles className="h-4 w-4 mr-2" />
+                  Generate DFD
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Step 3: Generating */}
+        {step === 'generating' && (
+          <div className="py-8">
+            {generateMutation.isError ? (
+              <AiErrorState
+                error={generateMutation.error}
+                fallbackMessage="Something went wrong generating the DFD."
+                onRetry={handleRetryGenerate}
+              />
+            ) : (
+              <div className="flex flex-col items-center gap-4 text-center">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                <div>
+                  <p className="font-medium">
+                    Generating your Data Flow Diagram...
+                  </p>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    This may take a moment while the AI builds the layout.
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary                                                                                                                        
                                                                                                                                    
  Upload an architecture diagram image and let AI generate a first-cut DFD on the canvas. Two-step flow:
                                                                                                                                    
  - **Step 1 (Vision):** Extracts components, data flows, trust zones, and asks clarifying questions                                
  - **Step 2 (Generation):** Produces canvas data with component library matching and algorithmic layout correction                 
                                                                                                                                    
Follows the same provider-resolution, metering, and trust-boundary patterns as `suggest_threats`. Nothing is persisted until the user accepts the generated diagram.                                                                                               
                                                                                                                                    
