### PR TITLE
fix: image export cropping and add an export options dialog

### DIFF
--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -44,7 +44,7 @@ import { useBoundaryMode } from './hooks/useBoundaryMode'
 import type { DiagramNode, DiagramEdge, DataFlowEdge, TrustBoundaryEdge } from './types'
 import { useCreateNode, useHandleDrop } from './hooks/useCreateNode'
 import { type DFDNotationStyle, NOTATION_NODE_SIZES } from './types/notation'
-import { exportDiagramImage } from './lib/export-diagram-image'
+import { exportDiagramImage, type ExportImageOptions } from './lib/export-diagram-image'
 
 function DFDEditorContent() {
   const { diagramId, id: threatModelId } = useParams<{ id: string; diagramId: string }>()
@@ -430,13 +430,13 @@ function DFDEditorContent() {
 
   // Export diagram as image
   const handleExportImage = useCallback(
-    (format: 'png' | 'svg') => {
+    (format: 'png' | 'svg', options?: ExportImageOptions) => {
       if (!reactFlowWrapper.current) return
       const filename = (diagramTitle || 'diagram')
         .replace(/[^a-zA-Z0-9-_ ]/g, '')
         .replace(/\s+/g, '-')
         .toLowerCase()
-      exportDiagramImage(format, filename, reactFlowWrapper.current, nodes, getViewport, setViewport, getNodesBounds)
+      return exportDiagramImage(format, filename, reactFlowWrapper.current, nodes, getViewport, setViewport, getNodesBounds, options)
     },
     [diagramTitle, nodes, getViewport, setViewport]
   )

--- a/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
+++ b/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
@@ -1,14 +1,8 @@
-import { memo, useCallback } from 'react'
+import { memo, useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { XYPosition } from '@xyflow/react'
 import { User, Server, Cog, Database, Shield, Box, ArrowUp, LayoutTemplate, ShieldAlert, ShieldCheck, ImageDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import { Separator } from '@/components/ui/separator'
 import {
   Select,
@@ -29,6 +23,8 @@ import { AI_PROVIDER_SETTINGS_PATH } from '@/features/ai/constants'
 import type { DiagramNodeType } from '../types'
 import type { DFDNotationStyle } from '../types/notation'
 import { useCreateNode } from '../hooks/useCreateNode'
+import { ExportImageDialog } from './ExportImageDialog'
+import type { ExportImageOptions } from '../lib/export-diagram-image'
 
 interface DiagramToolbarProps {
   connectionMode: boolean
@@ -44,7 +40,7 @@ interface DiagramToolbarProps {
   hideGenerateDFD?: boolean
   notationStyle?: DFDNotationStyle
   onNotationChange?: (notation: DFDNotationStyle) => void
-  onExportImage?: (format: 'png' | 'svg') => void
+  onExportImage?: (format: 'png' | 'svg', options?: ExportImageOptions) => void | Promise<void>
   aiAvailable?: boolean
 }
 
@@ -120,6 +116,7 @@ export const DiagramToolbar = memo(function DiagramToolbar({
 }: DiagramToolbarProps) {
   const navigate = useNavigate()
   const { createNode } = useCreateNode(notationStyle)
+  const [exportDialogOpen, setExportDialogOpen] = useState(false)
 
   const handleAddNode = useCallback(
     (type: DiagramNodeType) => {
@@ -318,27 +315,25 @@ export const DiagramToolbar = memo(function DiagramToolbar({
 
         {onExportImage && (
           <div className="ml-auto">
-            <DropdownMenu>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="sm" className="gap-2">
-                      <ImageDown className="h-4 w-4" />
-                      <span className="hidden sm:inline">Export Image</span>
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Download diagram as PNG or SVG</TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => onExportImage('png')}>
-                  Download as PNG
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onExportImage('svg')}>
-                  Download as SVG
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="gap-2"
+                  onClick={() => setExportDialogOpen(true)}
+                >
+                  <ImageDown className="h-4 w-4" />
+                  <span className="hidden sm:inline">Export Image</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Download diagram as PNG or SVG</TooltipContent>
+            </Tooltip>
+            <ExportImageDialog
+              open={exportDialogOpen}
+              onOpenChange={setExportDialogOpen}
+              onExport={onExportImage}
+            />
           </div>
         )}
       </div>

--- a/frontend/src/features/dfd-editor/components/ExportImageDialog.tsx
+++ b/frontend/src/features/dfd-editor/components/ExportImageDialog.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react'
+import { useReactFlow, useStoreApi } from '@xyflow/react'
+import { toast } from 'sonner'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import type { ExportImageOptions } from '../lib/export-diagram-image'
+
+interface ExportImageDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onExport: (format: 'png' | 'svg', options: ExportImageOptions) => void | Promise<void>
+}
+
+export function ExportImageDialog({ open, onOpenChange, onExport }: ExportImageDialogProps) {
+  const [format, setFormat] = useState<'png' | 'svg'>('png')
+  const [transparent, setTransparent] = useState(false)
+  const [selectedOnly, setSelectedOnly] = useState(false)
+  const [exporting, setExporting] = useState(false)
+  const { getNodes, getEdges } = useReactFlow()
+  const store = useStoreApi()
+
+  // Snapshot on open: getNodes()/getEdges() are non-reactive, and the export
+  // itself deselects everything mid-flight — reading on every render would
+  // flicker the checkbox while exporting
+  const [snapshot, setSnapshot] = useState({ hasNodes: false, hasSelection: false })
+  const [wasOpen, setWasOpen] = useState(false)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) {
+      setSnapshot({
+        hasNodes: getNodes().length > 0,
+        hasSelection:
+          getNodes().some((node) => node.selected) || getEdges().some((edge) => edge.selected),
+      })
+    }
+  }
+  const { hasNodes, hasSelection } = snapshot
+
+  const handleExport = async () => {
+    const nodes = getNodes()
+    const edges = getEdges()
+    const selectedNodeIds = new Set(nodes.filter((n) => n.selected).map((n) => n.id))
+    const selectedEdges = edges.filter((e) => e.selected)
+
+    let excludeIds: Set<string> | undefined
+    // Trust the fresh reads, not the open-time snapshot: if the selection is
+    // somehow gone, fall back to a full export instead of excluding everything
+    const keptNodeIds = new Set(selectedNodeIds)
+    for (const edge of selectedEdges) {
+      keptNodeIds.add(edge.source)
+      keptNodeIds.add(edge.target)
+    }
+    if (selectedOnly && keptNodeIds.size > 0) {
+      // Selected nodes plus the endpoints of explicitly selected edges,
+      // so a selected edge is never exported dangling
+      excludeIds = new Set([
+        ...nodes.filter((n) => !keptNodeIds.has(n.id)).map((n) => n.id),
+        // An edge stays when selected itself or when both endpoints are exported
+        ...edges
+          .filter((e) => !e.selected && !(keptNodeIds.has(e.source) && keptNodeIds.has(e.target)))
+          .map((e) => e.id),
+      ])
+    }
+
+    // Deselect everything so selection borders, delete buttons, and node
+    // toolbars don't bake into the capture; 'select' changes bypass undo
+    // history and unsaved-changes tracking in both editors' state hooks.
+    store.getState().unselectNodesAndEdges()
+    setExporting(true)
+    try {
+      await onExport(format, {
+        backgroundColor: transparent ? undefined : '#ffffff',
+        excludeIds,
+      })
+      onOpenChange(false)
+    } catch (error) {
+      console.error('Image export failed:', error)
+      toast.error('Image export failed')
+    } finally {
+      const { triggerNodeChanges, triggerEdgeChanges } = store.getState()
+      if (selectedNodeIds.size > 0) {
+        triggerNodeChanges([...selectedNodeIds].map((id) => ({ id, type: 'select' as const, selected: true })))
+      }
+      if (selectedEdges.length > 0) {
+        triggerEdgeChanges(selectedEdges.map((e) => ({ id: e.id, type: 'select' as const, selected: true })))
+      }
+      setExporting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Export Image</DialogTitle>
+          <DialogDescription>Download the diagram cropped to its content.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <RadioGroup
+            value={format}
+            onValueChange={(value) => setFormat(value as 'png' | 'svg')}
+            className="flex gap-6"
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="png" id="export-format-png" />
+              <Label htmlFor="export-format-png">PNG</Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="svg" id="export-format-svg" />
+              <Label htmlFor="export-format-svg">SVG</Label>
+            </div>
+          </RadioGroup>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="export-transparent"
+              checked={transparent}
+              onCheckedChange={(checked) => setTransparent(checked === true)}
+            />
+            <Label htmlFor="export-transparent">Transparent background</Label>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="export-selected-only"
+              checked={selectedOnly && hasSelection}
+              disabled={!hasSelection}
+              onCheckedChange={(checked) => setSelectedOnly(checked === true)}
+            />
+            <Label
+              htmlFor="export-selected-only"
+              className={hasSelection ? undefined : 'text-muted-foreground'}
+            >
+              Export only selected elements
+            </Label>
+          </div>
+          {!hasSelection && (
+            <p className="text-xs text-muted-foreground">
+              Select elements on the canvas first to export a subset.
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={exporting}>
+            Cancel
+          </Button>
+          <Button onClick={handleExport} disabled={exporting || !hasNodes}>
+            {exporting ? 'Exporting…' : 'Export'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/dfd-editor/components/edges/DataFlowEdge.tsx
+++ b/frontend/src/features/dfd-editor/components/edges/DataFlowEdge.tsx
@@ -59,6 +59,7 @@ export const DataFlowEdge = memo(function DataFlowEdge({
       {/* Edge labels - only show when selected or has important data */}
       <EdgeLabelRenderer>
         <div
+          data-id={id}
           className={cn(
             'absolute pointer-events-auto nodrag nopan flex flex-col items-center gap-1',
             'transform -translate-x-1/2 -translate-y-1/2 transition-opacity',

--- a/frontend/src/features/dfd-editor/components/edges/TrustBoundaryEdge.tsx
+++ b/frontend/src/features/dfd-editor/components/edges/TrustBoundaryEdge.tsx
@@ -104,6 +104,7 @@ export const TrustBoundaryEdge = memo(function TrustBoundaryEdge({
 
       <EdgeLabelRenderer>
         <div
+          data-id={id}
           className={cn(
             'absolute pointer-events-auto nodrag nopan flex items-center gap-1.5',
             'transform -translate-x-1/2 transition-opacity',

--- a/frontend/src/features/dfd-editor/components/nodes/CanvasNodeWrapper.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/CanvasNodeWrapper.tsx
@@ -72,6 +72,7 @@ function withEdgeThreatBadge<P extends EdgeProps>(EdgeComponent: ComponentType<P
         {count > 0 && (
           <EdgeLabelRenderer>
             <div
+              data-id={props.id}
               className="absolute pointer-events-none nodrag nopan"
               style={{
                 left: (props.sourceX + props.targetX) / 2,

--- a/frontend/src/features/dfd-editor/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/features/dfd-editor/hooks/useKeyboardShortcuts.ts
@@ -174,12 +174,14 @@ export function useKeyboardShortcuts({
     if (!enabled) return
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      // Don't handle shortcuts when typing in inputs
+      // Don't handle shortcuts when typing in inputs or while focus is
+      // inside a modal — canvas edits behind an open dialog are invisible
       const target = event.target as HTMLElement
       if (
         target.tagName === 'INPUT' ||
         target.tagName === 'TEXTAREA' ||
-        target.isContentEditable
+        target.isContentEditable ||
+        target.closest?.('[role="dialog"], [role="alertdialog"]')
       ) {
         return
       }

--- a/frontend/src/features/dfd-editor/lib/export-diagram-image.ts
+++ b/frontend/src/features/dfd-editor/lib/export-diagram-image.ts
@@ -5,6 +5,13 @@ import type { Node, Rect, Viewport } from '@xyflow/react'
 const PADDING = 50
 const IMAGE_SCALE = 2 // 2x resolution for crisp output
 
+export interface ExportImageOptions {
+  /** Solid background color; omitted = transparent background. */
+  backgroundColor?: string
+  /** Node/edge ids to leave out of the capture (bounds and DOM). */
+  excludeIds?: Set<string>
+}
+
 /** Filter that excludes React Flow UI overlays from image capture. */
 function overlayFilter(node: HTMLElement): boolean {
   if (!node.classList) return true
@@ -80,20 +87,26 @@ export async function exportDiagramImage(
   getViewport: () => Viewport,
   setViewport: (viewport: Viewport, options?: { duration?: number }) => void,
   getNodesBounds: (nodes: Node[]) => Rect,
+  options?: ExportImageOptions,
 ): Promise<void> {
-  await withExportViewport(wrapperElement, nodes, getViewport, setViewport, getNodesBounds, async (reactFlowElement, paddedBounds) => {
-    const imageWidth = paddedBounds.width * IMAGE_SCALE
-    const imageHeight = paddedBounds.height * IMAGE_SCALE
+  const excludeIds = options?.excludeIds
+  const exportNodes = excludeIds ? nodes.filter((node) => !excludeIds.has(node.id)) : nodes
+  const filter = excludeIds
+    ? (node: HTMLElement) => overlayFilter(node) && !excludeIds.has(node.getAttribute?.('data-id') ?? '')
+    : overlayFilter
 
+  await withExportViewport(wrapperElement, exportNodes, getViewport, setViewport, getNodesBounds, async (reactFlowElement, paddedBounds) => {
     const convertFn = format === 'png' ? toPng : toSvg
     const dataUrl = await convertFn(reactFlowElement, {
-      width: imageWidth,
-      height: imageHeight,
+      width: paddedBounds.width,
+      height: paddedBounds.height,
+      pixelRatio: IMAGE_SCALE, // ignored by toSvg
+      backgroundColor: options?.backgroundColor,
       style: {
         width: `${paddedBounds.width}px`,
         height: `${paddedBounds.height}px`,
       },
-      filter: overlayFilter,
+      filter,
     })
 
     const extension = format === 'png' ? 'png' : 'svg'
@@ -118,12 +131,10 @@ export async function captureDiagramImage(
   getNodesBounds: (nodes: Node[]) => Rect,
 ): Promise<Uint8Array> {
   return withExportViewport(wrapperElement, nodes, getViewport, setViewport, getNodesBounds, async (reactFlowElement, paddedBounds) => {
-    const imageWidth = paddedBounds.width * IMAGE_SCALE
-    const imageHeight = paddedBounds.height * IMAGE_SCALE
-
     const dataUrl = await toPng(reactFlowElement, {
-      width: imageWidth,
-      height: imageHeight,
+      width: paddedBounds.width,
+      height: paddedBounds.height,
+      pixelRatio: IMAGE_SCALE,
       style: {
         width: `${paddedBounds.width}px`,
         height: `${paddedBounds.height}px`,

--- a/frontend/src/features/guest-editor/GuestDFDEditor.tsx
+++ b/frontend/src/features/guest-editor/GuestDFDEditor.tsx
@@ -23,7 +23,7 @@ import { useParentRelationships } from '@/features/dfd-editor/hooks/useParentRel
 import { useKeyboardShortcuts } from '@/features/dfd-editor/hooks/useKeyboardShortcuts'
 import { useConnectionMode } from '@/features/dfd-editor/hooks/useConnectionMode'
 import { useBoundaryMode } from '@/features/dfd-editor/hooks/useBoundaryMode'
-import { exportDiagramImage, captureDiagramImage } from '@/features/dfd-editor/lib/export-diagram-image'
+import { exportDiagramImage, captureDiagramImage, type ExportImageOptions } from '@/features/dfd-editor/lib/export-diagram-image'
 import type {
   DiagramNode,
   DiagramEdge,
@@ -163,13 +163,13 @@ function GuestDFDEditorContent() {
 
   // Register export image handler so the header can call it
   useEffect(() => {
-    exportImageRef.current = (format: 'png' | 'svg') => {
+    exportImageRef.current = (format: 'png' | 'svg', options?: ExportImageOptions) => {
       if (!reactFlowWrapper.current) return
       const filename = (title || 'diagram')
         .replace(/[^a-zA-Z0-9-_ ]/g, '')
         .replace(/\s+/g, '-')
         .toLowerCase()
-      exportDiagramImage(format, filename, reactFlowWrapper.current, nodes, getViewport, setViewport, getNodesBounds)
+      return exportDiagramImage(format, filename, reactFlowWrapper.current, nodes, getViewport, setViewport, getNodesBounds, options)
     }
     return () => { exportImageRef.current = null }
   }, [exportImageRef, title, nodes, getViewport, setViewport])
@@ -317,7 +317,7 @@ function GuestDFDEditorContent() {
         hideAnalyzeThreats
         notationStyle={notationStyle}
         onNotationChange={handleNotationChange}
-        onExportImage={(format) => exportImageRef.current?.(format)}
+        onExportImage={(format, options) => exportImageRef.current?.(format, options)}
       />
 
       <div className="flex flex-1 overflow-hidden">

--- a/frontend/src/features/guest-editor/GuestLayout.tsx
+++ b/frontend/src/features/guest-editor/GuestLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useNavigate } from 'react-router-dom'
 import type { NodeChange, EdgeChange } from '@xyflow/react'
 import type { DiagramNode, DiagramEdge } from '@/features/dfd-editor/types'
 import type { DFDNotationStyle } from '@/features/dfd-editor/types/notation'
+import type { ExportImageOptions } from '@/features/dfd-editor/lib/export-diagram-image'
 import { useGuestDiagramState } from './hooks/useGuestDiagramState'
 import { useGuestThreats } from './hooks/useGuestThreats'
 import { useGuestCountermeasures } from './hooks/useGuestCountermeasures'
@@ -24,7 +25,7 @@ export interface GuestDiagramOutletContext {
   canUndo: boolean
   notationStyle: DFDNotationStyle
   setNotationStyle: (notation: DFDNotationStyle) => void
-  exportImageRef: React.MutableRefObject<((format: 'png' | 'svg') => void) | null>
+  exportImageRef: React.MutableRefObject<((format: 'png' | 'svg', options?: ExportImageOptions) => void | Promise<void>) | null>
   captureImageRef: React.MutableRefObject<(() => Promise<Uint8Array | null>) | null>
   onCacheImage: (image: Uint8Array | null) => void
 }
@@ -37,7 +38,7 @@ export function GuestLayout() {
   const systemContextOps = useGuestSystemContext()
   const [notationStyle, setNotationStyle] = useState<DFDNotationStyle>('yourdon')
   const fileHandleState = useFileHandle()
-  const exportImageRef = useRef<((format: 'png' | 'svg') => void) | null>(null)
+  const exportImageRef = useRef<((format: 'png' | 'svg', options?: ExportImageOptions) => void | Promise<void>) | null>(null)
   const captureImageRef = useRef<(() => Promise<Uint8Array | null>) | null>(null)
   const [cachedDiagramImage, setCachedDiagramImage] = useState<Uint8Array | null>(null)
 

--- a/frontend/src/features/guest-editor/components/GuestNodeWrapper.tsx
+++ b/frontend/src/features/guest-editor/components/GuestNodeWrapper.tsx
@@ -61,6 +61,7 @@ function withEdgeThreatBadge<P extends EdgeProps>(EdgeComponent: ComponentType<P
         {count > 0 && (
           <EdgeLabelRenderer>
             <div
+              data-id={props.id}
               className="absolute pointer-events-none nodrag nopan"
               style={{
                 left: (props.sourceX + props.targetX) / 2,


### PR DESCRIPTION
Closes #280

The exported diagram images had a ton of blank space around the actual diagram — turns out we were passing html-to-image a canvas twice the size of the content while styling the element at 1x, so the diagram only filled the top-left quarter. The same broken image ended up in the Word report since both go through the same helper, so fixing the capture fixed both.

While at it, I replaced the PNG/SVG dropdown with a small export dialog (similar to draw.io's):

- pick PNG or SVG
- transparent background — default is now solid white; the old exports were accidentally transparent, which is part of why they looked so empty in viewers
- export only selected elements — useful when a diagram has parts you don't want in a report. Selected edges bring their endpoint nodes along so nothing dangles, and edges between exported nodes are included automatically. Disabled with a hint when nothing is selected.

A few smaller things that came out of this:

- the export now deselects everything before capturing, so selection borders and delete buttons no longer show up in the image (they did before), then reselects afterwards. This goes through React Flow's `select` changes so it doesn't pollute undo history or trigger autosave.
- exporting an empty canvas is blocked, and a failed export shows a toast instead of silently closing the dialog like it worked
- added `data-id` to the edge label / threat badge portals so excluded edges don't leave floating labels behind in selected-only exports

Both the normal editor and the guest editor share the same dialog. The export functions kept their signatures (just one optional options param added), and the Word report flow only picks up the crop fix — nothing else in reports was touched.

Tested: build + lint clean, plus manually checked cropping, transparency, selected-only export, selection restore, undo/dirty state, and the guest Word report embed.
