### PR TITLE
fix: dataflow labels washed out over system context boundaries

### DIFF
--- a/frontend/src/features/dfd-editor/components/nodes/SystemScopeNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/SystemScopeNode.tsx
@@ -92,7 +92,7 @@ export const SystemScopeNode = memo(function SystemScopeNode({
 
       <div
         className={cn(
-          'w-full h-full rounded-lg border-2 border-solid bg-slate-50/50 transition-all',
+          'w-full h-full rounded-lg border-2 border-solid bg-slate-500/10 transition-all',
           selected ? 'border-slate-500' : 'border-slate-300',
           isNewlyInserted && 'ring-2 ring-green-400 ring-offset-2',
           showLockAnimation && 'animate-lock-pulse ring-2 ring-orange-400 ring-offset-2'


### PR DESCRIPTION
Closes #307

Turns out this wasn't a label styling problem at all (that part was already fixed in #247). React Flow draws edge labels *underneath* nodes, so the system context boundary's background was literally painting over the labels. The boundary used `bg-slate-50/50` — basically a 50% white veil — hence the washed out text. Trust boundaries never had this issue because their backgrounds are only 10% alpha, which also explains why #246's fix looked fine inside them but not here.

So the fix is one line: swap `bg-slate-50/50` for `bg-slate-500/10` on the boundary. Same slate tint, but at the same 10% alpha the trust zones use. And since the component is shared, the guest editor, read-only viewers and image exports all get it for free.

Tested locally in both editors — labels inside a boundary and crossing its edge now read the same as on open canvas. Build passes.