### PR TITLE
fix: wrap long component labels on process and data store nodes

### DIFF
--- a/frontend/src/features/dfd-editor/components/nodes/DataStoreNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/DataStoreNode.tsx
@@ -67,7 +67,7 @@ export const DataStoreNode = memo(function DataStoreNode({
           /* Yourdon/DeMarco: two parallel horizontal lines */
           <div
             className={cn(
-              'w-full h-full relative bg-purple-50 flex items-center border-t-2 border-b-2',
+              'w-full min-h-full relative bg-purple-50 flex items-center border-t-2 border-b-2',
               selected ? 'border-purple-500 shadow-md' : 'border-purple-200',
               isNewlyInserted && 'shadow-[0_-2px_0_0_#4ade80,0_2px_0_0_#4ade80]',
               showLockAnimation && 'animate-lock-pulse shadow-[0_-2px_0_0_#fb923c,0_2px_0_0_#fb923c]'
@@ -80,7 +80,7 @@ export const DataStoreNode = memo(function DataStoreNode({
                   nodeId={id}
                   label={data.label}
                   isEditing={data.isInlineEditing}
-                  className="font-medium text-xs text-purple-900 truncate"
+                  className="font-medium text-xs text-purple-900 line-clamp-6 break-words"
                   inputClassName="text-xs text-purple-900 w-full"
                 />
                 {data.technology && (
@@ -95,7 +95,7 @@ export const DataStoreNode = memo(function DataStoreNode({
           /* DFD3: Cylinder shape using CSS */
           <div
             className={cn(
-              'w-full h-full relative bg-purple-50 border-2 rounded-lg overflow-hidden flex flex-col min-w-[120px]',
+              'w-full min-h-full relative bg-purple-50 border-2 rounded-lg overflow-hidden flex flex-col min-w-[120px]',
               selected ? 'border-purple-500 shadow-md' : 'border-purple-200'
             )}
           >
@@ -111,7 +111,7 @@ export const DataStoreNode = memo(function DataStoreNode({
                     nodeId={id}
                     label={data.label}
                     isEditing={data.isInlineEditing}
-                    className="font-medium text-sm text-purple-900 truncate"
+                    className="font-medium text-sm text-purple-900 line-clamp-6 break-words"
                     inputClassName="text-sm text-purple-900 w-full"
                   />
                   {data.technology && (

--- a/frontend/src/features/dfd-editor/components/nodes/InlineEditableLabel.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/InlineEditableLabel.tsx
@@ -98,7 +98,7 @@ export const InlineEditableLabel = memo(function InlineEditableLabel({
   }, [])
 
   if (!isEditing) {
-    return <span className={className}>{label}</span>
+    return <span title={label} className={className}>{label}</span>
   }
 
   return (

--- a/frontend/src/features/dfd-editor/components/nodes/ProcessNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/ProcessNode.tsx
@@ -93,7 +93,9 @@ export const ProcessNode = memo(function ProcessNode({
       <ProcessHandles />
       <div
         className={cn(
-          'w-full h-full border-2 transition-all',
+          'w-full border-2 transition-all',
+          // Containers stay fixed to the node bounds; leaves grow with wrapped labels like actor nodes
+          isContainer ? 'h-full' : 'min-h-full',
           isContainer
             ? cn(
                 'rounded-lg border-solid',
@@ -153,7 +155,7 @@ export const ProcessNode = memo(function ProcessNode({
               nodeId={id}
               label={data.label}
               isEditing={data.isInlineEditing}
-              className="font-medium text-xs text-blue-900 truncate max-w-[90%] text-center px-1"
+              className="font-medium text-xs text-blue-900 line-clamp-6 break-words max-w-[90%] text-center px-1"
               inputClassName="max-w-[90%] text-xs text-blue-900 text-center"
             />
             {data.technology && (
@@ -182,7 +184,7 @@ export const ProcessNode = memo(function ProcessNode({
                   nodeId={id}
                   label={data.label}
                   isEditing={data.isInlineEditing}
-                  className="font-medium text-sm text-blue-900 truncate"
+                  className="font-medium text-sm text-blue-900 line-clamp-6 break-words"
                   inputClassName="text-sm text-blue-900 w-full"
                 />
                 {data.technology && (


### PR DESCRIPTION
Fixes #297

Long labels on Process and Data store nodes were cut off with an ellipsis, and even resizing the node didn't reveal the text. These turned out to be the only two node types whose label span had Tailwind's `truncate` class (`white-space: nowrap` + ellipsis) — which is also why Human and System actors wrapped fine all along.

**What I changed:**

- Replaced `truncate` with `line-clamp-6 break-words` on the four label spots (both node types, both notations). Labels now wrap up to 6 lines before an ellipsis kicks in, and a long unbroken string breaks across lines instead of overflowing the shape.
- Switched the leaf shapes from `h-full` to `min-h-full` so the node visual grows with the wrapped text, the same way actor nodes already behave. Process containers keep `h-full` since their children are positioned inside fixed bounds, and the Yourdon circle keeps its geometry.
- Added a `title` attribute on the shared label span in `InlineEditableLabel`, so hovering any node shows the full name — handy for the rare label that still gets elided past 6 lines.

The signed-in editor, the guest editor, the read-only viewer and image export all render these same node components, so the fix covers every surface without touching anything else. I deliberately left the default node sizes and the backend AI layout constants alone so existing diagrams keep their dimensions and notation switching behaves as before.

Tested manually in both editors: both notations, node resizing, inline edit (Enter and Escape), a label with one long unbroken word, and PNG export — the wrapping survives html-to-image. `npx tsc --noEmit` is clean.

**Screenshots:**

before: 
<img width="1490" height="480" alt="image" src="https://github.com/user-attachments/assets/65de652f-aea7-4803-b708-b8229c461345" />

after:
<img width="1208" height="604" alt="image" src="https://github.com/user-attachments/assets/8bd14d18-1dbe-4206-bed1-de4373975654" />
