### PR TITLE
fix: include description in countermeasure library list serializer

### DIFF
--- a/backend/apps/threats/serializers.py
+++ b/backend/apps/threats/serializers.py
@@ -142,7 +142,17 @@ class CountermeasureLibraryListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CountermeasureLibrary
-        fields = ["id", "name", "control_type", "cost", "default_status", "source_pack", "source_pack_name", "source_pack_slug"]
+        fields = [
+            "id",
+            "name",
+            "description",
+            "control_type",
+            "cost",
+            "default_status",
+            "source_pack",
+            "source_pack_name",
+            "source_pack_slug",
+        ]
 
 
 class ComponentLibraryThreatSerializer(serializers.ModelSerializer):

--- a/backend/apps/threats/tests/test_countermeasure_library_listing.py
+++ b/backend/apps/threats/tests/test_countermeasure_library_listing.py
@@ -1,0 +1,63 @@
+"""The countermeasure library list endpoint must return ``description``.
+
+The list view searches against ``name`` and ``description``, but the list
+serializer dropped ``description`` from its fields. A search match could
+therefore never be seen in the results, and the listing was inconsistent
+with its sibling ``ThreatLibraryListSerializer``.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.organizations.models import Organization, OrganizationMember
+from apps.threats.models import CountermeasureLibrary
+
+User = get_user_model()
+
+
+class CountermeasureLibraryListTests(TestCase):
+    """The ``/api/countermeasure-library/`` listing includes descriptions."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org = Organization.objects.create(name="Counter Org", domain="counter.test")
+        cls.user = User.objects.create_user(
+            username="counteruser", email="counter@counter.test", password="testpass123"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org, user=cls.user, role="security_team"
+        )
+        cls.countermeasure = CountermeasureLibrary.objects.create(
+            name="Encrypt Data at Rest",
+            description="Apply encryption to data stored on disk.",
+            control_type="preventive",
+        )
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user).access_token}"
+        )
+
+    def test_list_returns_description(self):
+        """The list route must include each item's description."""
+        response = self.client.get("/api/countermeasure-library/")
+        self.assertEqual(response.status_code, 200)
+        item = next(
+            (c for c in response.data if c["name"] == "Encrypt Data at Rest"),
+            None,
+        )
+        self.assertIsNotNone(item)
+        self.assertEqual(
+            item["description"], "Apply encryption to data stored on disk."
+        )
+
+    def test_search_matches_description_and_returns_it(self):
+        """A search on description must surface the match with its text."""
+        response = self.client.get("/api/countermeasure-library/?search=encryption")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], "Encrypt Data at Rest")
+        self.assertIn("description", response.data[0])


### PR DESCRIPTION
## Summary

The `/api/countermeasure-library/` list route searches against `name` and `description` (views.py:168), but `CountermeasureLibraryListSerializer.Meta.fields` did not include `description` — so a search match on description could never be seen in the results.

The detail serializer (`CountermeasureLibrarySerializer`) carries it, and the sibling `ThreatLibraryListSerializer` includes it too. This makes the countermeasure listing consistent with both.

## Changes

- Added `description` to `CountermeasureLibraryListSerializer.Meta.fields` (serializers.py:145)
- Added `test_countermeasure_library_listing.py` covering:
  - the list route returns each countermeasure's `description`
  - a search on a description term returns the match with its text

## Testing

```
pytest apps/threats/tests/test_countermeasure_library_listing.py   # 2 passed
pytest apps/threats                                              # 18 passed
flake8 apps/threats/serializers.py                                # no new errors
```

## Type

`fix:` — resolves a bug where the search field was never returned by the list serializer.

Closes #316