### PR TITLE
chore(backend): lint and format with ruff, enforced in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,24 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # --from-ref resolves against the base branch, which a shallow clone
+          # does not fetch.
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pre-commit
+      - run: |
+          pre-commit run \
+            --from-ref origin/${{ github.base_ref }} \
+            --to-ref HEAD \
+            --show-diff-on-failure
+
   backend:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ site/
 # Local working files (session notes, scratch artifacts)
 SESSION.md
 tmp/
+docs/design/
 
 # Proposed icon (pending approval)
 frontend/src/features/ai/components/OwlMark_proposed.tsx

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Hooks run from the repository root, so every path here is repo-root-relative
+# even though the only Python lives under `backend/`. Ruff's own settings are in
+# `backend/ruff.toml`, which it finds by walking up from each file.
+#
+# Keep `rev` in step with the ruff pin in `backend/requirements/development.txt`.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.3
+    hooks:
+      # Lint first so the formatter's output is what actually lands in the commit.
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+
+# Django regenerates migrations in its own style, so formatting them would
+# rewrite every new one on the commit that creates it. `backend/ruff.toml`
+# excludes them too, but that only takes effect for runs whose working
+# directory is `backend/` — see the note beside `force-exclude` there.
+exclude: |
+  (?x)^(
+    backend/.*/migrations/.*
+  )$

--- a/backend/.flake8
+++ b/backend/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 120
-exclude = */migrations/*,venv/*

--- a/backend/apps/core/management/commands/seed.py
+++ b/backend/apps/core/management/commands/seed.py
@@ -13,20 +13,27 @@ Usage:
     python manage.py seed --force  (re-import packs even if they exist)
 """
 
-from django.core.management.base import BaseCommand
 from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
 
-from apps.organizations.models import Organization, OrganizationMember, Team, TeamMembership
-from apps.packs.models import LibraryPack
-from apps.threat_models.models import ThreatModel, ThreatModelLibraryPack
 from apps.diagrams.models import DFD, DFDTemplatesLibrary
 from apps.diagrams.services import sync_dfd_nodes_to_components
+from apps.organizations.models import (
+    Organization,
+    OrganizationMember,
+    Team,
+    TeamMembership,
+)
+from apps.packs.models import LibraryPack
 from apps.packs.services import get_libraries_path, import_pack_from_path, validate_pack
+from apps.threat_models.models import ThreatModel, ThreatModelLibraryPack
 
 User = get_user_model()
 
 DEMO_EMAIL = "admin@precogly.dev"
-DEMO_PASSWORD = "admin123"
+# Published in the setup docs on purpose, so a new contributor can sign in to a
+# freshly seeded database. It grants nothing beyond a local demo organization.
+DEMO_PASSWORD = "admin123"  # noqa: S105
 DEMO_ORG_NAME = "Demo Organization"
 DEMO_TEAM_NAME = "My Team"
 
@@ -127,7 +134,9 @@ class Command(BaseCommand):
                 plan=Organization.Plan.FREE,
                 is_primary=True,
             )
-            self.stdout.write(self.style.SUCCESS(f"Created organization: {DEMO_ORG_NAME}"))
+            self.stdout.write(
+                self.style.SUCCESS(f"Created organization: {DEMO_ORG_NAME}")
+            )
 
         self._ensure_default_team(org, DEMO_TEAM_NAME)
         return org
@@ -151,7 +160,9 @@ class Command(BaseCommand):
             self.stdout.write(f"{label} already exists: {email}")
             return existing
 
-        create = User.objects.create_superuser if superuser else User.objects.create_user
+        create = (
+            User.objects.create_superuser if superuser else User.objects.create_user
+        )
         user = create(username=email, email=email, password=DEMO_PASSWORD)
         self.stdout.write(self.style.SUCCESS(f"Created {label.lower()}: {email}"))
         return user
@@ -249,9 +260,9 @@ class Command(BaseCommand):
     def _import_packs(self, force):
         libraries_path = get_libraries_path()
         if not libraries_path.exists():
-            self.stdout.write(self.style.ERROR(
-                f"Libraries path not found: {libraries_path}"
-            ))
+            self.stdout.write(
+                self.style.ERROR(f"Libraries path not found: {libraries_path}")
+            )
             return
 
         all_packs = TAXONOMY_PACKS + STANDARD_PACKS + FULL_PACKS
@@ -267,8 +278,12 @@ class Command(BaseCommand):
                 for error in validation_result.errors:
                     self.stdout.write(self.style.ERROR(f"  Error: {error.message}"))
                 for warning in validation_result.warnings:
-                    self.stdout.write(self.style.WARNING(f"  Warning: {warning.message}"))
-                self.stdout.write(self.style.WARNING(f"Skipped: {pack_slug} — validation failed"))
+                    self.stdout.write(
+                        self.style.WARNING(f"  Warning: {warning.message}")
+                    )
+                self.stdout.write(
+                    self.style.WARNING(f"Skipped: {pack_slug} — validation failed")
+                )
                 continue
 
             result = import_pack_from_path(
@@ -280,7 +295,9 @@ class Command(BaseCommand):
             if result.success:
                 self.stdout.write(self.style.SUCCESS(f"Imported: {pack_slug}"))
             else:
-                self.stdout.write(self.style.WARNING(f"Skipped: {pack_slug} — {result.message}"))
+                self.stdout.write(
+                    self.style.WARNING(f"Skipped: {pack_slug} — {result.message}")
+                )
 
     def _create_sample_threat_models(self, org, team, user, samples):
         for sample in samples:
@@ -298,10 +315,12 @@ class Command(BaseCommand):
                     qualified_slug=template_slug
                 ).first()
                 if not template:
-                    self.stdout.write(self.style.WARNING(
-                        f"DFD template not found: {template_slug}. "
-                        "Threat model created without diagram."
-                    ))
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"DFD template not found: {template_slug}. "
+                            "Threat model created without diagram."
+                        )
+                    )
 
             criticality = getattr(ThreatModel.Criticality, sample["criticality"])
 
@@ -329,8 +348,10 @@ class Command(BaseCommand):
             # Connect all imported packs before generating threats
             imported_packs = LibraryPack.objects.all()
             ThreatModelLibraryPack.objects.bulk_create(
-                [ThreatModelLibraryPack(threat_model=threat_model, library_pack=pack)
-                 for pack in imported_packs],
+                [
+                    ThreatModelLibraryPack(threat_model=threat_model, library_pack=pack)
+                    for pack in imported_packs
+                ],
                 ignore_conflicts=True,
             )
 
@@ -348,10 +369,12 @@ class Command(BaseCommand):
             components_count = sync_result.get("created_count", 0)
             threats_count = sync_result.get("threats_generated", 0)
 
-            self.stdout.write(self.style.SUCCESS(
-                f"Created: {name} "
-                f"({components_count} components, {threats_count} threats)"
-            ))
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Created: {name} "
+                    f"({components_count} components, {threats_count} threats)"
+                )
+            )
 
     def _connect_packs_to_threat_models(self):
         """Ensure all imported packs are connected to all threat models."""
@@ -370,9 +393,11 @@ class Command(BaseCommand):
         )
         count = len(created)
         if count:
-            self.stdout.write(self.style.SUCCESS(
-                f"Connected {all_packs.count()} packs to {all_threat_models.count()} threat models"
-            ))
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Connected {all_packs.count()} packs to {all_threat_models.count()} threat models"
+                )
+            )
 
     def _report_accounts(self):
         """Print the seeded logins as a table.
@@ -391,13 +416,14 @@ class Command(BaseCommand):
         self.stdout.write("  URL:      http://localhost:5173")
         self.stdout.write(f"  Password: {DEMO_PASSWORD}   (every account below)")
         self.stdout.write("")
-        self.stdout.write(self.style.MIGRATE_HEADING(
-            f"  {'EMAIL':<22} {'ORGANIZATION':<20} ROLE"
-        ))
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(f"  {'EMAIL':<22} {'ORGANIZATION':<20} ROLE")
+        )
 
         memberships = (
-            OrganizationMember.objects
-            .filter(user__username__in=[DEMO_EMAIL, ANALYST_EMAIL, SECOND_ORG_EMAIL])
+            OrganizationMember.objects.filter(
+                user__username__in=[DEMO_EMAIL, ANALYST_EMAIL, SECOND_ORG_EMAIL]
+            )
             .select_related("organization", "user")
             .order_by("user__username")
         )

--- a/backend/config/settings/development.py
+++ b/backend/config/settings/development.py
@@ -2,11 +2,13 @@
 Development settings for Precogly backend.
 """
 
-from .base import *  # noqa: F401, F403
+from .base import *  # noqa: F403
 
 DEBUG = True
 
-ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0", "backend"]
+# "0.0.0.0" is here so the container's runserver is reachable from the host;
+# this settings module is never loaded in production, which uses production.py.
+ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0", "backend"]  # noqa: S104
 
 # Development-only apps
 INSTALLED_APPS += [  # noqa: F405

--- a/backend/requirements/development.txt
+++ b/backend/requirements/development.txt
@@ -11,9 +11,8 @@ pytest-cov>=5.0,<6.0
 factory-boy>=3.3,<4.0
 
 # Code quality
-black>=24.0,<25.0
-isort>=5.13,<6.0
-flake8>=7.0,<8.0
+ruff>=0.16.3,<0.17
+pre-commit>=4.0,<5.0
 
 # Type checking
 mypy>=1.11,<2.0

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -1,0 +1,71 @@
+# Ruff replaces black (formatting), isort (import ordering), and flake8
+# (linting) with one binary, and adds the flake8-bandit rules
+target-version = "py312"
+
+# The formatter wraps at 88. The linter tolerates more — see [lint.pycodestyle].
+line-length = 88
+
+# Django generates migrations in its own style and rewrites them on every
+# `makemigrations`, so formatting them means reformatting each new one on the
+# commit that creates it. The `.flake8` this replaces excluded them too.
+# The `**` matters: a single `*` does not cross a path separator, so
+# `*/migrations/*` matches nothing under `apps/<app>/migrations/`.
+extend-exclude = ["**/migrations/**"]
+
+# Needed for exclusions to apply to paths named explicitly on the command line
+# rather than discovered by walking a directory.
+#
+# This only covers runs whose working directory is `backend/`. Ruff resolves
+# exclude patterns against the project root, and when it is invoked from the
+# repository root with a path like `backend/apps/ai/migrations/0001_initial.py`
+# no pattern matches — verified on 2026-08-17 against `migrations`,
+# `**/migrations`, `*/migrations/**`, and `**/migrations/**/*`, all of which
+# still linted the file. pre-commit invokes hooks from the repository root, so
+# it carries the same exclusion as a regex in `../.pre-commit-config.yaml`.
+# Both are load-bearing; neither covers the other's case.
+force-exclude = true
+
+[lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes — undefined names, unused imports
+    "I",   # isort — import ordering
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear — patterns that are usually bugs
+    "S",   # flake8-bandit — the security pass
+    "C4",  # flake8-comprehensions
+    "DJ",  # flake8-django
+    "SIM", # flake8-simplify
+    "RUF", # ruff's own rules
+]
+
+ignore = [
+    # RUF012 asks for `ClassVar` on every mutable class attribute. In DRF those
+    # attributes are the framework's declarative surface — `permission_classes`,
+    # `queryset`, `serializer_class`, `filterset_fields` — and it fires 513
+    # times across 48 viewsets, every one of them the documented idiom.
+    "RUF012",
+]
+
+[lint.pycodestyle]
+# The formatter cannot split a long string, URL, or comment, so setting the
+# E501 limit equal to `line-length` reports lines that nothing can fix.
+# Residual E501 count after `ruff format` at 88:
+#
+#     limit 88 -> 187     limit 100 -> 65     limit 120 -> 16
+#
+# 120 is also what the `.flake8` this replaces used. The formatter still
+# produces 88-column code wherever it can; E501 now only catches the lines it
+# had to leave alone.
+max-line-length = 120
+
+[lint.isort]
+# Imports are rooted at `backend/`, but pre-commit runs hooks from the
+# repository root, so ruff cannot infer this from the working directory.
+# Without it `from apps.core...` sorts in among the third-party imports.
+known-first-party = ["apps", "config"]
+
+[lint.per-file-ignores]
+"**/tests/**" = ["S105", "S106"]
+"**/tests.py" = ["S105", "S106"]


### PR DESCRIPTION
## Problem

Nothing enforced code style. `ci.yml` ran `pytest` and `tsc --noEmit`; that was the whole quality gate.

`black`, `isort`, and `flake8` were installed in `backend/requirements/development.txt` and configured in `backend/.flake8`, but nothing ran them — not CI, not an editor config.

## What this does

Replaces all three with `ruff`, which also brings the `flake8-bandit` (`S`) rules the AppSec work depends on.

- `backend/ruff.toml` — rule selection, with the reasoning at each setting.
- `.pre-commit-config.yaml` — `ruff-check --fix` then `ruff-format`, on staged files.
- A `lint` job in `ci.yml` running the same hooks via `pre-commit run --from-ref`, so the rule set lives in one file instead of being restated in the workflow.
- `backend/.flake8` deleted; `development.txt` swapped to `ruff>=0.16.3,<0.17`.

This does not reformat the tree. Both the hook and CI are scoped to the files a commit or PR touches. 68 of 135 files still want formatting and 218 lint findings remain, 93 of them autofixable; commits clean their own files as they go.

## Decisions

- **Formatter at 88, `E501` at 120.** The formatter cannot split a long string, URL, or comment, so an equal limit reports lines nothing can fix. Residual `E501` after formatting at 88: 187 at limit 88, 65 at 100, 16 at 120. 120 is also what the deleted `.flake8` used.
- **`RUF012` off.** It asks for `ClassVar` on every mutable class attribute, which in DRF means `permission_classes`, `queryset`, `serializer_class`, `filterset_fields` — 513 hits across 48 viewsets, all of them the documented idiom.
- **Migrations excluded twice.** Ruff's `extend-exclude` only takes effect when the working directory is `backend/`. Invoked from the repository root the way pre-commit invokes it, no glob matches: `migrations`, `**/migrations`, `*/migrations/**`, and `**/migrations/**/*` all still linted the file. So `.pre-commit-config.yaml` carries the same exclusion as a regex. Neither covers the other's case, and it is written down at both sites.
- **Bandit findings outside tests get an inline `noqa` with a reason**, not a blanket ignore, so a real hardcoded credential still has to be argued for at the site. There are two: `DEMO_PASSWORD` in `seed.py` and `0.0.0.0` in development settings.

## Verification

- `pre-commit run --from-ref upstream/main --to-ref HEAD`, which is what the CI job runs: `ruff check` and `ruff format` pass.
- CI mode against a deliberately bad file committed with `--no-verify`: fails, catching `F841` and reformatting. `pre-commit run --from-ref` passes silently when it selects no files, so a green job on its own would not have shown the gate works. Probe reverted.
- A migration passed explicitly to pre-commit is left untouched.
- `seed.py` conflicted on the rebase, since #327 restructured it. Resolved to upstream's version throughout, then re-run through ruff. Diffed against a ruff-normalised copy of `upstream/main`'s file: the only remaining difference is the added `noqa` and its comment.

## Left out

- **The repo-wide reformat.** 68 files, so it conflicts with anything in flight, and `feat/oauth-authorization-server` is 6 commits deep — it should land after that merges. The cost until then: a PR touching a file that already carried findings fails the `lint` job on findings it did not introduce.
- **`mypy`.** Installed in `development.txt`, configured nowhere, reporting 414 errors in 24 files. Ruff lints; it does not type-check, so this needs its own PR.
- **Frontend lint.** `eslint.config.js` and `npm run lint` exist and are still run by nothing.
- **Dependency and container scanning, secrets detection, action SHA pinning.** Separate PRs, as is the move to `uv` — every dependency is currently an unpinned range with no lockfile.
