### PR TITLE
fix(ai): bound where a model endpoint may point

### DIFF
--- a/backend/apps/ai/providers/openai_compat.py
+++ b/backend/apps/ai/providers/openai_compat.py
@@ -13,6 +13,7 @@ operator who hasn't started their local model should see "model unreachable at
 
 import requests
 
+from ..url_policy import URLPolicyError, check_url
 from .base import (
     AIProviderError,
     ChatProvider,
@@ -90,10 +91,21 @@ class OpenAICompatProvider(ChatProvider):
         completion. Connectivity problems are reported, not raised, so a UI can
         render the reason next to a "Test connection" button.
         """
+        try:
+            self._enforce_url_policy()
+        except URLPolicyError as err:
+            # Reported, not raised, so the operator can know
+            # what to change when looking at the output of the
+            # "Test Connection" button.
+            return ProviderHealth(ok=False, detail=str(err))
+
         url = self._url("/models")
         try:
             response = requests.get(
-                url, headers=self._headers(), timeout=self.config.request_timeout
+                url,
+                headers=self._headers(),
+                timeout=self.config.request_timeout,
+                allow_redirects=False,
             )
         except requests.exceptions.ConnectionError:
             return ProviderHealth(
@@ -126,11 +138,17 @@ class OpenAICompatProvider(ChatProvider):
     def _post(self, path: str, payload: dict) -> requests.Response:
         """POST JSON to ``path``, mapping transport failures to typed errors."""
         try:
+            self._enforce_url_policy()
+        except URLPolicyError as err:
+            raise AIProviderError(str(err)) from err
+
+        try:
             return requests.post(
                 self._url(path),
                 json=payload,
                 headers=self._headers(),
                 timeout=self.config.request_timeout,
+                allow_redirects=False,
             )
         except requests.exceptions.ConnectionError as err:
             raise AIProviderError(
@@ -143,6 +161,20 @@ class OpenAICompatProvider(ChatProvider):
                 f"{self.config.request_timeout}s. Try a smaller/faster model or "
                 "raise the request timeout."
             ) from err
+
+    def _enforce_url_policy(self) -> None:
+        """Refuse an endpoint the deployment's policy does not permit.
+
+        Checked immediately before each request rather than only when a config
+        was saved: a hostname that resolved publicly at save time can resolve
+        into the private range later, and a saved config may predate the policy
+        being tightened. The serializer runs the same check on write, but that
+        is for the error message — this is the control.
+
+        Applies to the operator-wide fallback too, not only to an organization's
+        saved config; :mod:`apps.ai.url_policy` says why one rule covers both.
+        """
+        check_url(self.config.base_url)
 
     def _url(self, path: str) -> str:
         return f"{self.config.base_url.rstrip('/')}{path}"

--- a/backend/apps/ai/serializers.py
+++ b/backend/apps/ai/serializers.py
@@ -16,6 +16,7 @@ contract the settings UI consumes.
 from rest_framework import serializers
 
 from .models import AIProviderConfig
+from .url_policy import URLPolicyError, check_url
 
 
 class AIProviderConfigSerializer(serializers.ModelSerializer):
@@ -55,3 +56,18 @@ class AIProviderConfigSerializer(serializers.ModelSerializer):
 
     def get_has_api_key(self, obj: AIProviderConfig) -> bool:
         return bool(obj.api_key_encrypted)
+
+    def validate_base_url(self, value: str) -> str:
+        """Reject an endpoint this deployment will refuse to fetch anyway.
+
+        This is the error message, not the control. A name resolves again at
+        request time and can answer differently by then, so the provider
+        re-checks before every call; what this adds is a 400 against the field
+        while the operator is still looking at the form, instead of a config
+        that saves cleanly and fails later.
+        """
+        try:
+            check_url(value)
+        except URLPolicyError as err:
+            raise serializers.ValidationError(str(err)) from err
+        return value

--- a/backend/apps/ai/tests/test_url_policy.py
+++ b/backend/apps/ai/tests/test_url_policy.py
@@ -1,0 +1,315 @@
+"""Tests for the outbound-URL policy on tenant-supplied model endpoints.
+
+Two layers, because the policy has two jobs. The first set drives
+:func:`apps.ai.url_policy.check_url` directly and is about *which* addresses are
+refused — the cases that matter are the ones a naive string check would miss:
+a hostname that resolves into a private range, a hostname with one public and
+one private answer, and the cloud metadata address, which has to stay refused
+even on the permissive setting.
+
+The second set is about *where* the check runs. It belongs immediately before
+each request rather than only at save time, and it must not fire on the
+operator-wide fallback, which is the deployment's own setting and ships pointing
+at loopback.
+
+DNS is mocked throughout. A test that resolved real names would be measuring the
+network.
+"""
+
+import socket
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.ai import url_policy
+from apps.ai.models import AIProviderConfig
+from apps.ai.providers import openai_compat
+from apps.ai.providers.base import AIProviderError, ResolvedConfig
+from apps.ai.providers.openai_compat import OpenAICompatProvider
+from apps.ai.url_policy import ALLOW_LOOPBACK, DENY_PRIVATE, URLPolicyError, check_url
+from apps.organizations.models import Organization, OrganizationMember
+
+User = get_user_model()
+
+# 169.254.169.254 is the link-local address that AWS, GCP, and Azure all serve
+# instance credentials from. It is the reason this module exists, so it gets a
+# name rather than appearing as a bare literal in one assertion.
+CLOUD_METADATA = "169.254.169.254"
+
+
+def _addrinfo(*ips):
+    """A ``getaddrinfo`` return value carrying ``ips``.
+
+    Only element 4, the sockaddr, is read by the code under test; the rest is
+    filled in so the shape matches what the real call returns.
+    """
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 443)) for ip in ips]
+
+
+class AddressDecisionTests(SimpleTestCase):
+    """Which addresses each policy admits, checked on literals — no DNS."""
+
+    def test_public_address_allowed_under_both_policies(self):
+        for policy in (DENY_PRIVATE, ALLOW_LOOPBACK):
+            with self.subTest(policy=policy):
+                check_url("https://93.184.216.34/v1", policy=policy)
+
+    def test_loopback_refused_under_deny_private(self):
+        with self.assertRaises(URLPolicyError) as caught:
+            check_url("http://127.0.0.1:1234/v1", policy=DENY_PRIVATE)
+        # The message has to name the escape hatch, or a self-hoster whose local
+        # model stopped working has no way to find out why.
+        self.assertIn(ALLOW_LOOPBACK, str(caught.exception))
+
+    def test_loopback_allowed_under_allow_loopback(self):
+        check_url("http://127.0.0.1:1234/v1", policy=ALLOW_LOOPBACK)
+
+    def test_metadata_address_refused_under_every_policy(self):
+        # allow-loopback exists so a self-hoster can reach a model on the same
+        # box. That is 127.0.0.0/8. It must not become a way to reach the
+        # instance's credentials.
+        for policy in (DENY_PRIVATE, ALLOW_LOOPBACK):
+            with self.subTest(policy=policy), self.assertRaises(URLPolicyError):
+                check_url(f"http://{CLOUD_METADATA}/latest/meta-data/", policy=policy)
+
+    def test_private_range_refused_under_allow_loopback(self):
+        with self.assertRaises(URLPolicyError):
+            check_url("http://10.0.0.5:8000/v1", policy=ALLOW_LOOPBACK)
+
+    def test_ipv4_mapped_loopback_is_treated_as_loopback(self):
+        # ::ffff:127.0.0.1 is loopback in an IPv6 shape. Judged as plain IPv6 it
+        # is neither loopback nor global, so it would be refused even under
+        # allow-loopback — right answer, wrong reason, and the message would
+        # tell the operator to set a policy that is already set.
+        check_url("http://[::ffff:127.0.0.1]:1234/v1", policy=ALLOW_LOOPBACK)
+        with self.assertRaises(URLPolicyError):
+            check_url("http://[::ffff:127.0.0.1]:1234/v1", policy=DENY_PRIVATE)
+
+    def test_non_http_scheme_refused(self):
+        for url in (
+            "file:///etc/passwd",
+            "gopher://example.com/",
+            "ftp://example.com/",
+        ):
+            with self.subTest(url=url), self.assertRaises(URLPolicyError):
+                check_url(url, policy=DENY_PRIVATE)
+
+    def test_url_without_host_refused(self):
+        with self.assertRaises(URLPolicyError):
+            check_url("http:///v1", policy=DENY_PRIVATE)
+
+
+class ResolutionTests(SimpleTestCase):
+    """What the policy does with names, which is where a string check fails."""
+
+    @mock.patch.object(url_policy.socket, "getaddrinfo")
+    def test_hostname_resolving_into_private_range_is_refused(self, getaddrinfo):
+        getaddrinfo.return_value = _addrinfo("10.0.0.5")
+        with self.assertRaises(URLPolicyError) as caught:
+            check_url("http://internal.example.com/v1", policy=DENY_PRIVATE)
+        # Both halves belong in the message: the name the operator typed, and
+        # the address that actually caused the refusal.
+        self.assertIn("internal.example.com", str(caught.exception))
+        self.assertIn("10.0.0.5", str(caught.exception))
+
+    @mock.patch.object(url_policy.socket, "getaddrinfo")
+    def test_every_resolved_address_must_pass(self, getaddrinfo):
+        # A name answering with one public and one private address is a bypass
+        # if only the first answer is checked, and which one `requests` picks
+        # when it connects is not ours to choose.
+        getaddrinfo.return_value = _addrinfo("93.184.216.34", CLOUD_METADATA)
+        with self.assertRaises(URLPolicyError):
+            check_url("http://split-horizon.example.com/v1", policy=DENY_PRIVATE)
+
+    @mock.patch.object(url_policy.socket, "getaddrinfo")
+    def test_public_hostname_allowed(self, getaddrinfo):
+        getaddrinfo.return_value = _addrinfo("93.184.216.34")
+        check_url("https://api.example.com/v1", policy=DENY_PRIVATE)
+
+    @mock.patch.object(url_policy.socket, "getaddrinfo")
+    def test_unresolvable_host_is_refused_with_an_actionable_message(self, getaddrinfo):
+        getaddrinfo.side_effect = socket.gaierror("nope")
+        with self.assertRaises(URLPolicyError) as caught:
+            check_url("http://nx.example.invalid/v1", policy=DENY_PRIVATE)
+        self.assertIn("resolve", str(caught.exception).lower())
+
+    @mock.patch.object(url_policy.socket, "getaddrinfo")
+    def test_literal_address_skips_the_lookup(self, getaddrinfo):
+        check_url("https://93.184.216.34/v1", policy=DENY_PRIVATE)
+        getaddrinfo.assert_not_called()
+
+
+class PolicySelectionTests(SimpleTestCase):
+    """How the configured value is read, including when it is wrong."""
+
+    @override_settings(AI_PROVIDER_URL_POLICY=ALLOW_LOOPBACK)
+    def test_configured_policy_is_used(self):
+        self.assertEqual(url_policy.current_policy(), ALLOW_LOOPBACK)
+        check_url("http://127.0.0.1:1234/v1")
+
+    @override_settings(AI_PROVIDER_URL_POLICY="allow-everything")
+    def test_unrecognised_policy_fails_closed(self):
+        # A typo in a deployment's environment should cost that deployment its
+        # loopback provider, not silently turn the check off.
+        self.assertEqual(url_policy.current_policy(), DENY_PRIVATE)
+        with self.assertRaises(URLPolicyError):
+            check_url("http://127.0.0.1:1234/v1")
+
+
+def _response(status_code=200, json_body=None):
+    resp = mock.Mock(spec=["status_code", "json", "text"])
+    resp.status_code = status_code
+    resp.text = ""
+    if json_body is None:
+        resp.json.side_effect = ValueError("no json")
+    else:
+        resp.json.return_value = json_body
+    return resp
+
+
+def _tenant_config(base_url):
+    """A config as it arrives from an org's saved row: it carries a config_id."""
+    return ResolvedConfig(
+        provider_type="openai_compat",
+        base_url=base_url,
+        model="local-model",
+        request_timeout=5,
+        config_id=42,
+    )
+
+
+def _operator_config(base_url):
+    """The settings fallback: no config_id, so the policy does not apply."""
+    return ResolvedConfig(
+        provider_type="openai_compat",
+        base_url=base_url,
+        model="local-model",
+        request_timeout=5,
+    )
+
+
+@override_settings(AI_PROVIDER_URL_POLICY=DENY_PRIVATE)
+class ProviderEnforcementTests(SimpleTestCase):
+    """That the check runs before the request, and on the right configs."""
+
+    @mock.patch.object(openai_compat.requests, "get")
+    def test_probe_of_blocked_tenant_url_makes_no_request(self, get):
+        health = OpenAICompatProvider(
+            _tenant_config("http://127.0.0.1:1234/v1")
+        ).test_connection()
+
+        self.assertFalse(health.ok)
+        # The point of the whole change: not merely that the caller is told no,
+        # but that nothing left the process.
+        get.assert_not_called()
+
+    @mock.patch.object(openai_compat.requests, "post")
+    def test_completion_against_blocked_tenant_url_makes_no_request(self, post):
+        provider = OpenAICompatProvider(_tenant_config(f"http://{CLOUD_METADATA}/v1"))
+        with self.assertRaises(AIProviderError):
+            provider.complete([{"role": "user", "content": "hi"}])
+        post.assert_not_called()
+
+    @mock.patch.object(openai_compat.requests, "get")
+    def test_operator_fallback_is_checked_too(self, get):
+        # One rule, both sources. The fallback comes from the same environment
+        # as the policy, so exempting it would have been defensible — but it
+        # does nothing until AI_SUGGESTIONS_ENABLED is on, so there is no
+        # shipped default that a uniform rule breaks.
+        health = OpenAICompatProvider(
+            _operator_config("http://127.0.0.1:1234/v1")
+        ).test_connection()
+
+        self.assertFalse(health.ok)
+        get.assert_not_called()
+
+    @mock.patch.object(openai_compat.requests, "get")
+    def test_probe_does_not_follow_redirects(self, get):
+        # A permitted host answering 302 Location: http://169.254.169.254/ would
+        # defeat a check made on the original URL, so the redirect must not be
+        # followed. This is the other half of the fix; neither half covers the
+        # other's case.
+        get.return_value = _response(json_body={"data": []})
+        OpenAICompatProvider(
+            _tenant_config("https://93.184.216.34/v1")
+        ).test_connection()
+        self.assertIs(get.call_args.kwargs["allow_redirects"], False)
+
+    @mock.patch.object(openai_compat.requests, "post")
+    def test_completion_does_not_follow_redirects(self, post):
+        post.return_value = _response(
+            json_body={"choices": [{"message": {"content": "hi"}}]}
+        )
+        OpenAICompatProvider(_tenant_config("https://93.184.216.34/v1")).complete(
+            [{"role": "user", "content": "hi"}]
+        )
+        self.assertIs(post.call_args.kwargs["allow_redirects"], False)
+
+
+@override_settings(
+    AI_SECRET_KEY="policy-test-secret", AI_PROVIDER_URL_POLICY=DENY_PRIVATE
+)
+class ProviderConfigAPIPolicyTests(APITestCase):
+    """The refusal as a client sees it, through auth, serializer, and viewset.
+
+    The unit tests above prove the policy decides correctly and that the adapter
+    consults it. This proves the two are actually wired to each other on the path
+    a request takes, which is the only claim that matters to someone reproducing
+    the original finding.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org = Organization.objects.create(name="Acme")
+        cls.member = User.objects.create_user(
+            username="member", email="member@acme.test", password="pw"
+        )
+        OrganizationMember.objects.create(organization=cls.org, user=cls.member)
+
+    def setUp(self):
+        self.client.force_authenticate(self.member)
+
+    def _payload(self, base_url):
+        return {
+            "organization": self.org.id,
+            "name": "Probe",
+            "providerType": "openai_compat",
+            "baseUrl": base_url,
+            "model": "local-model",
+        }
+
+    def test_metadata_endpoint_is_rejected_on_create(self):
+        response = self.client.post(
+            "/api/ai-providers/",
+            self._payload(f"http://{CLOUD_METADATA}/latest/meta-data/"),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # `response.data` is pre-render, so the key is still snake_case here;
+        # djangorestframework-camel-case rewrites it on the way out.
+        self.assertIn("base_url", response.data)
+        self.assertEqual(AIProviderConfig.objects.count(), 0)
+
+    def test_probe_of_a_config_that_predates_the_policy_is_refused(self):
+        # The serializer cannot be the only check: this row was written before
+        # the policy existed, or by a name that resolved publicly at the time.
+        # Saving is bypassed here deliberately to reproduce that state.
+        config = AIProviderConfig.objects.create(
+            organization=self.org,
+            name="Legacy",
+            base_url=f"http://{CLOUD_METADATA}/latest/meta-data/",
+            model="local-model",
+        )
+
+        with mock.patch.object(openai_compat.requests, "get") as get:
+            response = self.client.post(
+                f"/api/ai-providers/{config.id}/test-connection/", format="json"
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["ok"])
+        get.assert_not_called()

--- a/backend/apps/ai/url_policy.py
+++ b/backend/apps/ai/url_policy.py
@@ -1,0 +1,138 @@
+"""Policy for which addresses a model endpoint may resolve to.
+
+An organization sets :attr:`AIProviderConfig.base_url` through the settings UI and
+Precogly fetches it server-side. Unchecked, that makes the form a way to send a
+request from inside the deployment's network — including to the host Precogly
+runs on, which no firewall or egress rule can prevent.
+
+Users with freshly minted accounts can exploit this in a production environment:
+signup is routed unconditionally (``config/urls.py``), ``ACCOUNT_EMAIL_VERIFICATION``
+is ``"optional"``, and ``apps.organizations.signals`` auto-joins uninvited new
+users to the primary organization (intended; see ``docs/concepts/org-hierarchy.md``).
+Saving a config needs membership and no particular role. So anyone who can
+register can reach this.
+
+``AI_PROVIDER_URL_POLICY`` selects which addresses pass, defaulted per settings
+module; see ``config/settings/production.py``.
+
+# Trade-offs
+
+The hostname is resolved here and again by ``requests`` when it connects, so a
+name that answers differently across those two moments — DNS rebinding — defeats
+this. Closing it means pinning the checked address for the connection: a custom
+``requests`` transport adapter, plus SNI and certificate handling for TLS.
+
+Redirects would defeat it the same way, and are closed: callers pass
+``allow_redirects=False``.
+"""
+
+import socket
+from ipaddress import IPv6Address, ip_address
+from urllib.parse import urlsplit
+
+from django.conf import settings
+
+DENY_PRIVATE = "deny-private"
+ALLOW_LOOPBACK = "allow-loopback"
+
+POLICIES = (DENY_PRIVATE, ALLOW_LOOPBACK)
+
+
+class URLPolicyError(ValueError):
+    """A model endpoint URL is not permitted by this deployment's policy.
+
+    A ``ValueError`` so a DRF serializer's ``validate_*`` hook can let it
+    surface as a 400 against the field, while the request-time callers catch it
+    explicitly.
+    """
+
+
+def current_policy() -> str:
+    """The configured policy, falling back to the strict one.
+
+    An unrecognised value fails closed rather than raising at request time: a
+    typo in a deployment's environment should cost that deployment its loopback
+    provider, not turn the check off.
+    """
+    configured = getattr(settings, "AI_PROVIDER_URL_POLICY", DENY_PRIVATE)
+    return configured if configured in POLICIES else DENY_PRIVATE
+
+
+def check_url(raw_url: str, *, policy: str | None = None) -> None:
+    """Raise :class:`URLPolicyError` unless ``raw_url`` may be fetched.
+
+    Every address the hostname resolves to has to pass, not just the first.
+    A name with both a public and a private answer is a bypass if only one is
+    checked, and which one ``requests`` picks is not ours to decide.
+    """
+    policy = policy or current_policy()
+    parts = urlsplit(raw_url)
+
+    if parts.scheme not in ("http", "https"):
+        raise URLPolicyError(
+            f"Model endpoints must use http or https, not '{parts.scheme}'."
+        )
+
+    hostname = parts.hostname
+    if not hostname:
+        raise URLPolicyError("Model endpoint URL has no host.")
+
+    for resolved in _resolve(hostname):
+        if not _is_permitted(resolved, policy):
+            raise URLPolicyError(_rejection(hostname, resolved, policy))
+
+
+def _resolve(hostname: str) -> list:
+    """Every IP the hostname answers with, as :mod:`ipaddress` objects.
+
+    A literal address parses without a lookup — ``getaddrinfo`` would return it
+    unchanged, but only after a syscall that can block.
+    """
+    try:
+        return [ip_address(hostname)]
+    except ValueError:
+        pass
+
+    try:
+        infos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as err:
+        raise URLPolicyError(
+            f"Could not resolve '{hostname}'. Check the base URL is spelled "
+            "correctly and the host exists."
+        ) from err
+
+    return [ip_address(info[4][0]) for info in infos]
+
+
+def _is_permitted(ip, policy: str) -> bool:
+    """Whether one resolved address may be connected to under ``policy``."""
+    # ::ffff:127.0.0.1 is loopback wearing an IPv6 shape. Judging it as IPv6
+    # would call it neither loopback nor global, making it rejected under
+    # allow-loopback for the wrong reason.
+    if isinstance(ip, IPv6Address) and ip.ipv4_mapped:
+        ip = ip.ipv4_mapped
+
+    if ip.is_loopback:
+        return policy == ALLOW_LOOPBACK
+
+    # is_global is false for private, link-local, multicast, reserved,
+    # unspecified, and the shared CGNAT range — every category we would
+    # otherwise have to enumerate and keep in step with IANA.
+    return ip.is_global
+
+
+def _rejection(hostname: str, ip, policy: str) -> str:
+    """Properly explain why the hostname got rejected."""
+    where = f"'{hostname}'" if str(ip) == hostname else f"'{hostname}' ({ip})"
+
+    if ip.is_loopback:
+        return (
+            f"{where} is a loopback address, which this deployment does not "
+            f"allow for model endpoints. Set AI_PROVIDER_URL_POLICY to "
+            f"'{ALLOW_LOOPBACK}' if the model runs on the same host as Precogly."
+        )
+    return (
+        f"{where} is not a publicly routable address, so it cannot be used as a "
+        f"model endpoint. Private, link-local, and reserved ranges are refused "
+        f"under every policy setting."
+    )

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -286,6 +286,20 @@ AI_API_KEY = env("AI_API_KEY", default="")
 # actionable error rather than hanging the user's request indefinitely.
 AI_REQUEST_TIMEOUT = env.int("AI_REQUEST_TIMEOUT", default=60)
 
+# Which addresses a model endpoint may resolve to, whether it came from
+# AI_BASE_URL above or from an organization's own saved config. Organizations set
+# their own base_url through the UI and Precogly fetches it server-side, which is
+# what this guards; see apps.ai.url_policy.
+#
+#   allow-loopback   127.0.0.0/8 and ::1 as well as public addresses
+#   deny-private     public addresses only
+#
+# Permissive here because running a model beside Precogly is what a local install
+# is for — docker-compose.yml carries a socat sidecar so that http://localhost:1234
+# reaches the host. production.py tightens it, which is where the deployment has
+# already said it is exposed.
+AI_PROVIDER_URL_POLICY = env.str("AI_PROVIDER_URL_POLICY", default="allow-loopback")
+
 # The AI_* values above act as the *fallback* provider: a single operator-wide
 # config used when an organization has not saved its own AIProviderConfig. Orgs
 # that bring their own model override it per-tenant in the database.

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -20,6 +20,15 @@ X_FRAME_OPTIONS = "DENY"
 # Stricter CORS in production
 CORS_ALLOW_ALL_ORIGINS = False
 
+# No loopback model endpoints on an exposed deployment. Any org member can save
+# one, and signup adds new users to the primary organization automatically, so on
+# an install with open registration a permissive policy hands anyone who can
+# register a request originating inside the network. A deployment that really does
+# run its model on the same host sets AI_PROVIDER_URL_POLICY back to allow-loopback.
+AI_PROVIDER_URL_POLICY = env.str(  # noqa: F405
+    "AI_PROVIDER_URL_POLICY", default="deny-private"
+)
+
 # Email backend for production
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -37,6 +37,30 @@ The values below reflect what `.env.example` provides for local development.
 | `CORS_ALLOWED_ORIGINS` | `http://localhost:5173,http://localhost`          | Origins allowed for API requests |
 | `FRONTEND_URL`         | `http://localhost:5173`                          | Used for password reset links     |
 
+### AI model endpoints
+
+Organizations configure their own model endpoint in the settings UI and Precogly
+fetches that URL from the server, so `AI_PROVIDER_URL_POLICY` bounds where those
+requests can go.
+
+| Value            | Permits                                          | Default in    |
+| ---------------- | ------------------------------------------------ | ------------- |
+| `allow-loopback` | `127.0.0.0/8` and `::1`, plus public addresses    | development   |
+| `deny-private`   | Public addresses only                            | production    |
+
+You do not normally set this. A local install runs a model on the same host, so
+development settings permit loopback; production settings do not, because any
+member can save an endpoint and new signups join the primary organization
+automatically — a permissive policy there would let anyone who can register make
+the server issue requests from inside your network.
+
+Set it explicitly to override, most often `allow-loopback` in production when the
+model really does run beside Precogly.
+
+Neither value permits private or link-local ranges: `169.254.169.254` and
+`10.0.0.0/8` are refused under both. `allow-loopback` reaches a model on the same
+host; it does not reach the cloud metadata service.
+
 ## Settings Modules
 
 Precogly uses split settings for different environments:


### PR DESCRIPTION
## Problem

An organization sets its own `base_url` in the settings UI, and Precogly fetches it server-side. Nothing checks the address.

So any org member could make the server issue a request to any address reachable from inside the deployment's network, and read back the outcome. "Org member" is a wider set than it sounds:

- `config/urls.py:22` routes `POST /api/auth/registration/` unconditionally
- `settings/base.py` sets `ACCOUNT_EMAIL_VERIFICATION = "optional"`
- `apps/organizations/signals.py:52` auto-joins uninvited new users to the primary organization — intended, and documented in `docs/concepts/org-hierarchy.md`
- `apps/ai/views.py:45` gates provider configs on membership, with no role check

On an install with open registration, that chain means anyone who can sign up.

## What changes

`apps/ai/url_policy.py` resolves the hostname and checks **every** address it answers with. A name with one public and one private answer is a bypass if it checks only the first, and' requests` picks whichever one it wants.

Checked before each request rather than only on save: a name can resolve publicly today and privately tomorrow, and a saved config can predate the policy. The serializer runs the same check on write so the operator gets a 400 against the field instead of a confusing failure later.

Redirects are disabled at the same time. A permitted host answering `302 Location: http://169.254.169.254/` would otherwise defeat any check made on the original URL. Both halves are needed; neither covers the other.

## Why the application and not the network

For `10.0.0.0/8`, this is the weaker control — VPC rules and egress policy cover it better, and cover every outbound call rather than this one path.

Loopback is different. That traffic never leaves the host, so no firewall or security group can see it, and `docker-compose.yml` runs a socat sidecar inside the backend's network namespace precisely so `http://localhost:1234` reaches the host machine. There is no deployment-level control for that one.

## The default is derived, not asked for

```python
# base.py         → allow-loopback
# production.py   → deny-private
```

## Verification

`192 passed` — 22 new. Beyond the obvious cases:

- `169.254.169.254` refused under **both** policies, so `allow-loopback` never becomes a route to cloud metadata
- a hostname resolving to one public and one private address is refused
- `::ffff:127.0.0.1` classified as loopback, not rejected for the wrong reason
- an unrecognized policy value fails closed
- a literal address skips the DNS lookup entirely
- two API-level tests, one of which writes a config straight to the DB to reproduce one predating the policy — `get.assert_not_called()` is the claim there: nothing left the process

Also confirmed by loading each settings module: `production -> deny-private`, `development -> allow-loopback`.

## Not covered

**DNS rebinding.** The hostname is resolved here and again by `requests` when it connects. Closing it requires a custom transport adapter that pins the checked address, plus SNI and certificate handling for TLS. Recorded in the module's `# Trade-offs` rather than left for a reader to find.

**`_safe_error_detail` returns whole JSON bodies.** Its comment claims to avoid dumping unbounded output, but the 200-char cap only guards the non-JSON path — `return str(error or body)` doesn't. Separate bug, still live, and it still matters under `allow-loopback`. Left out because it's a different change with a UX trade-off attached: that message exists so an operator sees `incorrect API key provided` rather than `the provider returned an error`.

**Other adapters.** The check is called from `openai_compat`, the only adapter today. `providers/base.py` anticipates Bedrock, Anthropic, and Gemini adapters; when the second one exists, the call should move to `ChatProvider` or `build_provider`, so it can't be forgotten.

## Note for review

Based on `main`, so it predates the `ruff.toml` in #332 — I linted against that branch's config explicitly. Wants a rebase once #332 lands.
