### PR TITLE
chore(ci): add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+
+# Version updates only. Security updates are a repository setting and are
+# already on, so an advisory opens a PR whether or not an ecosystem is listed
+# here, and regardless of open-pull-requests-limit. This file adds currency.
+#
+# commit-message repeats per entry because dependabot.yml v2 has no top-level
+# defaults. prefix + include:scope gives "chore(deps): bump x from 1 to 2" —
+# the convention CONTRIBUTING.md sets, and it keeps release-please from
+# treating a dependency bump as a release.
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "pip"
+    directory: "/backend/requirements"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "docker"
+    directories:
+      - "/frontend"
+      - "/backend/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## What this is

Version updates for `npm`, `pip`, `docker`, `docker-compose`, `github-actions`, and `pre-commit`. Weekly, ungrouped, with a `chore(deps)` prefix so the squashed commit matches the convention release-please parses.

## What it does not do

Dependabot **security** updates are a repository setting and are already enabled — `vulnerability-alerts` and `automated-security-fixes` both report enabled. A dependency with a known advisory already opens a PR without this file. What this adds is currency, not coverage.

The value is concentrated in `github-actions`. Actions currently float on `@v4` tags, so a moved tag silently changes what runs in CI with write access to the repo. Pinning them to commit SHAs fixes that but freezes them permanently — Dependabot is what makes pinning survivable. Those two land together or neither is worth much, and the SHA pinning is a separate PR.

`docker` is the weakest entry: Dependabot updates image *tags*, and `python:3.12-slim` gets rebuilt with CVE fixes under the same tag. Trivy is what will catch base-image CVEs, not this.

## Depends on #332

The `pre-commit` entry reads `.pre-commit-config.yaml`, which arrives in that PR. If this merges first, Dependabot reports that one ecosystem as having no manifest and opens nothing for it; each `updates` entry is evaluated independently, so the other five are unaffected, and it self-heals when #332 lands.

## Verification is post-merge

Dependabot only reads config from the default branch, so nothing here is checkable on a branch and there is no PR check that validates it. After merge: **Insights → Dependency graph → Dependabot** lists all six entries with last-checked timestamps and any errors, plus a "Check for updates" button to force a run.

One entry I checked from source rather than by experiment. `pip` points at `/backend/requirements`, where the files are `base.txt`, `development.txt`, and `production.txt` — none named `requirements.txt`. Dependabot's `SharedFileFetcher#requirements_file?` accepts any `.txt` or `.in` file whose lines all parse as requirements, comments, or `-r`/`-c`/`-e`/`--` directives, not only files matching the name. All three parse, so the entry will resolve.

## Deliberately left out

- **Grouping.** Six ungrouped weekly streams is a real volume of PRs. Grouping minor and patch per ecosystem would cut that, at the cost of making a failing batch harder to bisect. Worth revisiting once there is a triage policy saying what blocks a merge and who decides.
- **Action SHA pinning**, which is the half that makes `github-actions` worth having.
- **The CI scanners** — `pip-audit`, `osv-scanner`, Trivy, Gitleaks. Those block merges, which Dependabot does not.
