### PR TITLE
docs: add 3 missing countermeasure statuses to docs

### DIFF
--- a/docs/concepts/threat-analysis.md
+++ b/docs/concepts/threat-analysis.md
@@ -10,9 +10,9 @@ Threats carry taxonomy tags from your imported [library packs](library-packs.md)
 
 ![Threats with STRIDE, CAPEC, CWE, and MITRE ATT&CK taxonomy tags](../assets/images/threat-analysis-taxonomy-links.png)
 
-Each countermeasure moves through a lifecycle: **Platform** (provided by infrastructure), **Gap** (not yet addressed), **Planned** (assigned to an owner), **Verified** (confirmed in place), or **Waived** (accepted risk).
+Each countermeasure moves through a lifecycle: **Gap** (not yet addressed), **Planned** (assigned to an owner), **In Progress** (implementation underway), **Implemented** (deployed, not yet verified), **Verified** (confirmed by security team), **Platform** (provided by infrastructure), **Waived** (accepted risk), or **Decommissioned** (no longer active).
 
-![Countermeasure status lifecycle — Platform, Gap, Planned, Verified, Waived](../assets/images/threat-analysis-countermeasures-states.png)
+![Countermeasure status lifecycle](../assets/images/threat-analysis-countermeasures-states.png)
 
 Assign a team member as owner to move a countermeasure from Gap to Planned. Set priority and track progress across your team.
 

--- a/docs/guides/creating-threat-model.md
+++ b/docs/guides/creating-threat-model.md
@@ -272,21 +272,24 @@ Click **Add Custom Countermeasure** to create one manually. You write the name a
 
 Each countermeasure has a status that drives the overall threat status:
 
-| Status   | Meaning                                     | Color  |
-| -------- | ------------------------------------------- | ------ |
-| Gap      | Not implemented                             | Red    |
-| Planned  | Implementation scheduled or in progress     | Yellow |
-| Verified | Confirmed by security team                  | Green  |
-| Platform | Handled at platform/infrastructure level    | Green  |
-| Waived   | Risk accepted with documented justification | Blue   |
+| Status         | Meaning                                     | Color  |
+| -------------- | ------------------------------------------- | ------ |
+| Gap            | Not implemented                             | Red    |
+| Planned        | Implementation scheduled                    | Yellow |
+| In Progress    | Implementation underway                     | Yellow |
+| Implemented    | Deployed, not yet verified                  | Yellow |
+| Verified       | Confirmed by security team                  | Green  |
+| Platform       | Handled at platform/infrastructure level    | Green  |
+| Waived         | Risk accepted with documented justification | Blue   |
+| Decommissioned | No longer active                            | Gray   |
 
 The threat's overall status is derived from its countermeasures:
 
-| Threat status | Condition                                            |
-| ------------- | ---------------------------------------------------- |
-| Exposed       | At least one countermeasure is a gap                 |
-| Addressable   | All countermeasures are planned, waived, or platform |
-| Mitigated     | All countermeasures are verified or platform         |
+| Threat status | Condition                                                          |
+| ------------- | ------------------------------------------------------------------ |
+| Exposed       | No countermeasures applied, or at least one countermeasure is a gap |
+| Addressable   | All countermeasures are planned, in progress, waived, or decommissioned |
+| Mitigated     | All countermeasures are implemented, verified, or platform         |
 
 !!! note
     **Platform** status can only be set by **Security Team** members. This is used for controls managed centrally (e.g., WAF, DDoS protection, SSO). See [Platform Controls](../concepts/platform-controls.md).


### PR DESCRIPTION
## Summary
- Adds In Progress, Implemented, and Decommissioned to the countermeasure status table and lifecycle description
- Fixes threat status derivation table to match backend logic (includes no-countermeasures case, in_progress/decommissioned → addressable, implemented → mitigated)
- Updates both `docs/concepts/threat-analysis.md` and `docs/guides/creating-threat-model.md`