### PR TITLE
chore(ci): scan for secrets with gitleaks

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,55 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+
+# Scanners live here rather than in ci.yml so that workflow stays the quality
+# gate — tests, types, lint. The two have different failure meanings: a CI
+# failure says the change is broken, a Security failure says the change is
+# dangerous. Keeping them apart also means a scanner needing wider permissions
+# or a longer checkout does not widen the whole quality gate.
+permissions:
+  contents: read
+
+jobs:
+  # Secrets that reach a public repository are burned the moment they are
+  # pushed, so the only useful place to catch them is before the merge.
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+        # Scan the whole repo history (all commits)
+          fetch-depth: 0
+
+      # Installed from the release archive rather than through
+      # gitleaks/gitleaks-action. The action requires a GITLEAKS_LICENSE secret
+      # for repositories owned by an organization, which precogly/precogly is.
+      # The license is free, but it puts a third-party signup and a stored
+      # secret in the path of a merge gate, and buys nothing the CLI does not
+      # already do. The CLI has no such requirement.
+      #
+      # Bump both values together — the checksum comes from the release's own
+      # gitleaks_<version>_checksums.txt.
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL -o "$archive" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+          echo "${GITLEAKS_SHA256}  ${archive}" | sha256sum --check --status
+          tar -xzf "$archive" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+
+      # --log-opts=--all walks every ref, not just the PR head.
+      #
+      # Failing here blocks the merge, which is affordable only because the
+      # history is clean as of 2026-08-22: the first failure will be a real
+      # finding, not a backlog. No suppression policy yet — there is nothing to
+      # suppress. Use `.gitleaksignore` if that changes before one exists.
+      - name: Scan history for secrets
+        run: gitleaks git . --log-opts=--all --redact --verbose --no-banner

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-        # Scan the whole repo history (all commits)
+          # Depth 0 fetches `refs/heads/*`; a shallow clone has no
+          # `origin/main` for the scan range below to resolve against.
           fetch-depth: 0
 
       # Installed from the release archive rather than through
@@ -45,11 +46,12 @@ jobs:
           tar -xzf "$archive" gitleaks
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
 
-      # --log-opts=--all walks every ref, not just the PR head.
+      # Only the PR's own commits. All 397 commits of history were scanned once,
+      # clean, on 2026-08-22; everything since passes through this gate. Not
+      # `--all` per PR: a gitleaks version bump would then fail whichever PR
+      # runs next over an old commit its author cannot act on.
       #
-      # Failing here blocks the merge, which is affordable only because the
-      # history is clean as of 2026-08-22: the first failure will be a real
-      # finding, not a backlog. No suppression policy yet — there is nothing to
-      # suppress. Use `.gitleaksignore` if that changes before one exists.
-      - name: Scan history for secrets
-        run: gitleaks git . --log-opts=--all --redact --verbose --no-banner
+      # No suppression policy yet — there is nothing to suppress. Use
+      # `.gitleaksignore` if that changes before one exists.
+      - name: Scan PR commits for secrets
+        run: gitleaks git . --log-opts=origin/main..HEAD --redact --verbose --no-banner

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,55 @@
+# Gitleaks configuration.
+#
+# The default rule set does the work; this file exists for one rule it does not
+# have. Verified against gitleaks 8.30.1 on 2026-08-22: a Django SECRET_KEY is
+# not detected by any default rule, in any form — not a real one, not the
+# placeholder this repo ships. For a Django application that is the single
+# highest-value secret in the tree, since it signs sessions and password-reset
+# tokens, so forging one is a full authentication bypass.
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "django-secret-key"
+description = "Django SECRET_KEY committed as a literal"
+
+# Two forms, because a leaked key would take the second one. `.env` is
+# gitignored at the root and in `backend/` and `frontend/`, so the way a real
+# key reaches a commit is a `git add -f`, a rename past the ignore, or a paste
+# into a settings module or a compose override. The `KEY=value` form covers the
+# first two; the quoted form covers the third.
+# The value class excludes a backslash, which is load-bearing and was not
+# obvious. Without it, this rule reported two findings on 2026-08-22, both in
+# `search/search_index.json` on the generated gh-pages branch: minified JSON
+# stores a newline as the two characters `\` and `n`, neither of which is
+# whitespace, so the match ran past the end of the documented placeholder and
+# glued it to the following line — `SECRET_KEY=your-random-secret-key-here` plus
+# `POSTGRES_PASSWORD=…` scored 5.25 as one blob. A real key never contains a
+# backslash, so stopping there costs nothing and both findings go away.
+regex = '''(?i)\b(?:django[_-])?secret[_-]?key\b\s*[:=]\s*["']?([^\s"'\\]{40,})["']?'''
+secretGroup = 1
+keywords = ["secret_key", "secretkey", "secret-key"]
+
+# Measured 2026-08-22 rather than copied from gitleaks' generic rule, which
+# uses 3.7. Shannon entropy, bits per character:
+#
+#   3.17  "your-secret-key-here"                     .env.example
+#   3.86  "django-insecure-change-me-in-production"  backend/config/settings/base.py
+#   ---- 4.5, here ----
+#   5.31  openssl rand -base64 48                    the CI throwaway in ci.yml
+#   5.35  django-admin startproject's generated key
+#   5.48  get_random_secret_key()
+#
+# The gap is wide — 0.64 above the noisiest placeholder, 0.81 below the
+# weakest real key — so the threshold is not finely balanced and should not
+# need tuning. Lower it and the two placeholders above start failing every
+# build; raise it past 5.3 and real keys start passing.
+#
+# An earlier draft allowlisted the `django-insecure-` prefix so the committed
+# placeholder would not fire. Measuring killed that: `startproject` generates
+# real keys behind the same prefix, so the allowlist would have created a
+# blind spot on the exact value most likely to be committed by accident. The
+# entropy floor separates them without one, and the placeholder is excluded
+# twice over — it is 39 characters, under the length gate as well.
+entropy = 4.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  # The hook scans staged content only; the Security workflow scans all of
-  # history. That split is deliberate — this one has to be fast enough that
+  # The hook scans staged content only; the Security workflow scans the PR's
+  # commits. That split is deliberate — this one has to be fast enough that
   # nobody disables it, and CI is where the authoritative scan belongs.
   #
   # Keep `rev` in step with GITLEAKS_VERSION in

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,18 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  # The hook scans staged content only; the Security workflow scans all of
+  # history. That split is deliberate — this one has to be fast enough that
+  # nobody disables it, and CI is where the authoritative scan belongs.
+  #
+  # Keep `rev` in step with GITLEAKS_VERSION in
+  # `.github/workflows/security.yml`, or a commit can pass locally under one
+  # rule set and fail in CI under another.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
 # Django regenerates migrations in its own style, so formatting them would
 # rewrite every new one on the commit that creates it. `backend/ruff.toml`
 # excludes them too, but that only takes effect for runs whose working


### PR DESCRIPTION
A `Security` workflow scanning the PR's own commits, plus a pre-commit hook scanning staged content.

## Why a separate workflow

Triggers are per-workflow, not per-job. A scheduled re-scan — gitleaks' rules improve, so unchanged history yields new findings — would otherwise run pytest and tsc on that schedule too. Trivy, osv-scanner and Scorecard land here as well, and they need `security-events: write`, which `ci.yml` should not grant its test jobs.

## Why not gitleaks-action

It requires a `GITLEAKS_LICENSE` secret for org-owned repos. Free, but it puts a third-party signup and a stored secret in a merge gate for nothing the CLI does not do. The CLI is pinned by version and verified by SHA-256.

## The custom rule

gitleaks 8.30.1 detects a Django `SECRET_KEY` in no form at all — verified, including the placeholder this repo ships. For a Django app that is the highest-value secret in the tree: it signs sessions and password-reset tokens.

The entropy floor is measured, not copied from gitleaks' generic rule (3.7):

| entropy | |
|---|---|
| 3.17 | `your-secret-key-here` — `.env.example` |
| 3.86 | `django-insecure-change-me-in-production` — `base.py` |
| **4.5** | **threshold** |
| 5.31 | `openssl rand -base64 48` — the throwaway in `ci.yml` |
| 5.35 | `startproject`'s generated key |

An earlier draft allowlisted the `django-insecure-` prefix. Dropped: `startproject` generates real keys behind it, so the allowlist would have blinded the rule to the value most likely to be committed by accident.

## Verification

History is clean — 397 commits, 18 MB, 3.3s, all refs.

The rule's first run produced two false positives, both in `search/search_index.json` on `gh-pages`. Minified JSON stores a newline as `\` + `n`, neither of which is whitespace, so the value class ran past the documented placeholder and glued it to the next line, scoring 5.25 as one blob. Fixed by excluding backslash from the value class.

Eight cases after that fix:

- Quiet: the `base.py` default; the `.env.example` placeholder; `env("SECRET_KEY")` with no literal; the minified-JSON regression.
- Fires: a real key as a Python literal; in `.env` form; behind the `django-insecure-` prefix; inside minified JSON.

The pre-commit hook runs and does load `.gitleaks.toml` — confirmed by staging a canary key and watching the commit fail.

`origin/main..HEAD` verified against 8.30.1: clean on the branch as-is, exit 1 with a canary `SECRET_KEY` committed in range, exit 0 with the same commit left outside it.

## Not included

- **No re-scan of existing history.** History was scanned whole once (above) and every commit since arrives through this gate. A newer gitleaks finding something in pre-2026-08-22 history would go unnoticed; a scheduled `--all` job is the fix, deferred until other scanners want the same trigger.
- **This job is not a required status check.** Required checks are `backend` and `frontend`; the `main-branch-protection` ruleset defines none. Until `secrets` is added, it runs, goes red, and does not block. That is already true of `lint` and `deploy-check`.
- No suppression policy — nothing to suppress yet. `.gitleaksignore` if that changes.
- `pip-audit` (waiting on the uv migration, #377), Trivy, osv-scanner, Scorecard, action SHA pinning.
