### PR TITLE
feat(github): add issue forms for bugs and enhancements with automatic labels (fixes #378)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+﻿name: 🐛 Bug Report
+description: File a bug report to help us identify and fix an issue
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below to help us reproduce and fix it.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: What went wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / Logs
+      description: If applicable, add screenshots or terminal/console logs to help explain your problem.
+    validations:
+      required: false
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      description: Which part of Precogly is affected?
+      options:
+        - Frontend (React / DFD Editor / UI)
+        - Backend (Django / API)
+        - MCP Server
+        - Documentation
+        - Infrastructure / Docker
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Information
+      description: Please specify OS, Browser, Python / Node version, Docker setup if relevant.
+      placeholder: |
+        - OS: [e.g. macOS, Ubuntu, Windows]
+        - Browser: [e.g. Chrome, Firefox]
+        - Setup: [e.g. Local Docker, Development server, Production]
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklists
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues to ensure this is not a duplicate.
+          required: true
+        - label: I am willing to submit a PR to help fix this issue.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+﻿blank_issues_enabled: false
+contact_links:
+  - name: Discussions & Community
+    url: https://github.com/precogly/precogly/discussions
+    about: Ask questions, discuss architecture, or chat with the Precogly community.
+  - name: Discord Community
+    url: https://discord.gg/uBFZGJzpYa
+    about: Join the real-time community chat on Discord.
+  - name: Security Vulnerability Reporting
+    url: https://github.com/precogly/precogly/security/advisories/new
+    about: Privately report a security vulnerability.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-﻿blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Discussions & Community
     url: https://github.com/precogly/precogly/discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+﻿name: 💡 Feature Request / Enhancement
+description: Propose a new feature, improvement, or idea for Precogly
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your proposed idea below.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a specific problem or pain point?
+      placeholder: A clear and concise description of the problem (e.g. I'm always frustrated when...)
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: A clear and concise description of what you want to happen.
+      placeholder: Describe your proposed solution or feature in detail.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component Area
+      description: Which part of Precogly would this enhance?
+      options:
+        - Frontend (React / DFD Editor / UI)
+        - Backend (Django / API)
+        - Threat Modeling Libraries & Rules
+        - MCP Server
+        - Integrations & Export
+        - Documentation / Tooling
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to work on this feature and submit a pull request.
+          required: false


### PR DESCRIPTION
### Summary
Closes #378

Eliminates manual issue triage overhead by introducing structured GitHub Issue Forms (.github/ISSUE_TEMPLATE) that automatically categorize and apply appropriate labels on issue creation.

---

### Key Changes
1. **ug_report.yml**:
   - Structured template with required fields: Description, Steps to Reproduce, Expected Behavior.
   - Optional fields: Screenshots/Logs, Affected Component (Dropdown), Environment Details, and Pre-flight Checklist.
   - **Auto-applies label:** ug

2. **eature_request.yml**:
   - Structured template with fields: Problem Statement, Proposed Solution, Alternatives Considered, and Component Area.
   - **Auto-applies label:** enhancement

3. **config.yml**:
   - Enables blank issues (lank_issues_enabled: true) to allow general / chore / documentation / uncategorized inquiries.
   - Directs questions to **GitHub Discussions** & **Discord**, and security vulnerability disclosures to **Private Advisories**.

---

### Verification
- [x] Validated all .yml templates for valid GitHub schema and YAML formatting.
- [x] Confirmed labels match existing repository labels (ug, enhancement).
- [x] Verified community and security contact URLs.