### PR TITLE
fix: export per-instance threat details instead of first-instance-only

### DIFF
--- a/backend/apps/threat_models/adapters/tm_library.py
+++ b/backend/apps/threat_models/adapters/tm_library.py
@@ -330,6 +330,58 @@ class TmLibraryAdapter(BaseAdapter):
 
         return warnings
 
+    @staticmethod
+    def _apply_instance_detail(threat_instance, detail, persona_map):
+        """Apply per-instance fields from an instance_details entry to a threat instance."""
+        from apps.threats.models import ThreatPersonaLink
+
+        update_fields = []
+
+        scoring_meta = detail.get("severity_scoring_metadata")
+        if scoring_meta:
+            threat_instance.severity_scoring_metadata = scoring_meta
+            update_fields.append("severity_scoring_metadata")
+
+        inherent_severity = detail.get("inherent_severity")
+        if inherent_severity:
+            threat_instance.inherent_severity = inherent_severity
+            update_fields.append("inherent_severity")
+
+        residual_severity = detail.get("residual_severity")
+        if residual_severity:
+            threat_instance.residual_severity = residual_severity
+            update_fields.append("residual_severity")
+
+        impact_description = detail.get("event")
+        if impact_description:
+            threat_instance.impact_description = impact_description
+            update_fields.append("impact_description")
+
+        if update_fields:
+            threat_instance.save(update_fields=update_fields)
+
+        # Restore per-instance persona link (replaces any top-level default)
+        persona_ref = detail.get("threat_persona")
+        if persona_ref and persona_ref in persona_map:
+            persona = persona_map[persona_ref]
+            if hasattr(threat_instance, "component_id"):
+                # Remove any existing links from top-level default
+                ThreatPersonaLink.objects.filter(
+                    component_threat=threat_instance,
+                ).exclude(persona=persona).delete()
+                ThreatPersonaLink.objects.get_or_create(
+                    persona=persona,
+                    component_threat=threat_instance,
+                )
+            elif hasattr(threat_instance, "data_flow_id"):
+                ThreatPersonaLink.objects.filter(
+                    flow_threat=threat_instance,
+                ).exclude(persona=persona).delete()
+                ThreatPersonaLink.objects.get_or_create(
+                    persona=persona,
+                    flow_threat=threat_instance,
+                )
+
     def import_data(self, json_data, organization, created_by):
         validation_warnings = self.validate(json_data) or []
 
@@ -938,17 +990,50 @@ class TmLibraryAdapter(BaseAdapter):
             # 14. Consume Precogly extensions (round-trip restore)
             extensions = json_data.get("extensions", {})
 
-            # 14a. precogly.org/threat-details → restore severity_scoring_metadata
+            # 14a. precogly.org/threat-details → restore per-instance fields
             threat_details_ext = extensions.get("precogly.org/threat-details", {})
             if threat_details_ext:
                 for threat_sym, detail_data in threat_details_ext.items():
                     instances = threat_component_map.get(threat_sym, [])
-                    scoring_meta = detail_data.get("severity_scoring_metadata")
-                    if not scoring_meta:
-                        continue
-                    for threat_type, threat_instance in instances:
-                        threat_instance.severity_scoring_metadata = scoring_meta
-                        threat_instance.save(update_fields=["severity_scoring_metadata"])
+                    instance_details = detail_data.get("instance_details")
+                    if instance_details:
+                        # Per-instance format: match by affected name
+                        for detail in instance_details:
+                            affected_name = detail.get("affected")
+                            affected_type = detail.get("affected_type")
+                            if not affected_name or not affected_type:
+                                continue
+                            # Resolve the symbolic name to a DB object
+                            if affected_type == "component":
+                                affected_obj = (
+                                    resolver.resolve("component", affected_name)
+                                    or resolver.resolve("actor", affected_name)
+                                    or resolver.resolve("data_store", affected_name)
+                                )
+                                if not affected_obj:
+                                    continue
+                                for threat_type, threat_instance in instances:
+                                    if threat_type == "component" and threat_instance.component_id == affected_obj.pk:
+                                        self._apply_instance_detail(
+                                            threat_instance, detail, persona_map
+                                        )
+                            elif affected_type == "flow":
+                                affected_obj = resolver.resolve("data_flow", affected_name)
+                                if not affected_obj:
+                                    continue
+                                for threat_type, threat_instance in instances:
+                                    if threat_type == "flow" and threat_instance.data_flow_id == affected_obj.pk:
+                                        self._apply_instance_detail(
+                                            threat_instance, detail, persona_map
+                                        )
+                    else:
+                        # Legacy flat format: apply to all instances
+                        scoring_meta = detail_data.get("severity_scoring_metadata")
+                        if not scoring_meta:
+                            continue
+                        for threat_type, threat_instance in instances:
+                            threat_instance.severity_scoring_metadata = scoring_meta
+                            threat_instance.save(update_fields=["severity_scoring_metadata"])
 
             # 14b. precogly.org/taxonomy-references → create ThreatLibraryTaxonomyEntry
             from apps.threats.models import (
@@ -1398,13 +1483,13 @@ class TmLibraryAdapter(BaseAdapter):
                 threat_entry["data_flows_affected"] = group["data_flows_affected"]
             threat_entry.update(group["tm_library_fields"])
 
-            # Export event from DB (impact_description field)
+            # Use first instance for top-level threat entry fields and taxonomy
             first_instance = group["instances"][0][1] if group["instances"] else None
             if first_instance:
                 if first_instance.impact_description:
                     threat_entry["event"] = first_instance.impact_description
 
-                # Export threat_persona from DB (ThreatPersonaLink records)
+                # Export threat_persona from first instance (top-level default)
                 first_type, first_inst = group["instances"][0]
                 if first_type == "component":
                     persona_link = ThreatPersonaLink.objects.filter(
@@ -1417,7 +1502,7 @@ class TmLibraryAdapter(BaseAdapter):
                 if persona_link:
                     threat_entry["threat_persona"] = persona_link.persona.symbolic_name
 
-                # Export severity
+                # Export severity (top-level default from first instance)
                 threat_entry["inherent_severity"] = first_instance.inherent_severity
                 if first_instance.residual_severity:
                     threat_entry["residual_severity"] = first_instance.residual_severity
@@ -1473,13 +1558,55 @@ class TmLibraryAdapter(BaseAdapter):
                             threat_tax["mitre_attack"] = attack_entries
                         ext_taxonomy[threat_sym] = threat_tax
 
-                # Extensions: severity scoring metadata
-                if first_instance.severity_scoring_metadata:
+                # Extensions: per-instance threat details
+                instance_details = []
+                for threat_type, threat_instance in group["instances"]:
+                    if threat_type == "component":
+                        affected_sym = comp_reverse.get(threat_instance.component_id)
+                        affected_name = affected_sym[1] if affected_sym else None
+                    else:
+                        affected_name = flow_reverse.get(threat_instance.data_flow_id)
+                    if not affected_name:
+                        continue
+
+                    detail_entry = {
+                        "affected": affected_name,
+                        "affected_type": threat_type,
+                    }
+
+                    # Per-instance severity
+                    detail_entry["inherent_severity"] = threat_instance.inherent_severity
+                    if threat_instance.residual_severity:
+                        detail_entry["residual_severity"] = threat_instance.residual_severity
+
+                    # Per-instance impact description
+                    if threat_instance.impact_description:
+                        detail_entry["event"] = threat_instance.impact_description
+
+                    # Per-instance severity scoring metadata
+                    if threat_instance.severity_scoring_metadata:
+                        detail_entry["severity_scoring_metadata"] = threat_instance.severity_scoring_metadata
+
+                    # Per-instance threat persona
+                    if threat_type == "component":
+                        inst_persona_link = ThreatPersonaLink.objects.filter(
+                            component_threat=threat_instance,
+                        ).select_related("persona").first()
+                    else:
+                        inst_persona_link = ThreatPersonaLink.objects.filter(
+                            flow_threat=threat_instance,
+                        ).select_related("persona").first()
+                    if inst_persona_link:
+                        detail_entry["threat_persona"] = inst_persona_link.persona.symbolic_name
+
+                    instance_details.append(detail_entry)
+
+                if instance_details:
                     ext_details = extensions.setdefault(
                         "precogly.org/threat-details", {}
                     )
                     ext_details[threat_sym] = {
-                        "severity_scoring_metadata": first_instance.severity_scoring_metadata,
+                        "instance_details": instance_details,
                     }
 
             # Export sources from DB (ThreatSourceLink records)

--- a/backend/apps/threat_models/tests/test_tm_library_adapter.py
+++ b/backend/apps/threat_models/tests/test_tm_library_adapter.py
@@ -12,6 +12,8 @@ from apps.threats.models import (
     ComponentInstanceThreat,
     Risk,
     RiskThreat,
+    ThreatPersona,
+    ThreatPersonaLink,
 )
 
 from ..adapters import TmLibraryAdapter
@@ -188,3 +190,283 @@ class TestRiskScoring(TmLibraryAdapterTestMixin, TestCase):
         # Engine: possible(3) * moderate(3) = 9 → 9/25*100 = 36 → medium
         # Export: round(36/100*25) = 9
         self.assertEqual(risk["score"], 9)
+
+
+class TestPerInstanceThreatDetails(TmLibraryAdapterTestMixin, TestCase):
+    """Test that per-instance threat details survive export/import roundtrip."""
+
+    def test_divergent_severity_metadata_survives_roundtrip(self):
+        """Two components with the same threat but different severity metadata
+        should both appear in the export and restore correctly on re-import."""
+        json_data = {
+            "scope": {"title": "Severity Test"},
+            "components": [
+                {"symbolic_name": "comp-a", "title": "Component A"},
+                {"symbolic_name": "comp-b", "title": "Component B"},
+            ],
+            "threats": [
+                {
+                    "symbolic_name": "shared-threat",
+                    "title": "Shared Threat",
+                    "components_affected": ["comp-a", "comp-b"],
+                    "inherent_severity": "medium",
+                },
+            ],
+        }
+        threat_model, _ = self.adapter.import_data(json_data, self.org, self.user)
+
+        # Set divergent severity_scoring_metadata on each instance
+        comp_a = OrgsystemComponent.objects.get(threat_model=threat_model, name="Component A")
+        comp_b = OrgsystemComponent.objects.get(threat_model=threat_model, name="Component B")
+
+        threat_a = ComponentInstanceThreat.objects.get(component=comp_a, threat_name="Shared Threat")
+        threat_a.severity_scoring_metadata = {
+            "likelihood": "certain",
+            "impact": "severe",
+            "rationale": "User-facing input",
+        }
+        threat_a.save(update_fields=["severity_scoring_metadata"])
+
+        threat_b = ComponentInstanceThreat.objects.get(component=comp_b, threat_name="Shared Threat")
+        threat_b.severity_scoring_metadata = {
+            "likelihood": "rare",
+            "impact": "negligible",
+            "rationale": "Internal service",
+        }
+        threat_b.save(update_fields=["severity_scoring_metadata"])
+
+        # Export
+        exported = self.adapter.export_data(threat_model)
+
+        # Verify both instances appear in the extension
+        threat_details = exported["extensions"]["precogly.org/threat-details"]
+        self.assertIn("shared-threat", threat_details)
+        instance_details = threat_details["shared-threat"]["instance_details"]
+        self.assertEqual(len(instance_details), 2)
+
+        details_by_affected = {d["affected"]: d for d in instance_details}
+        self.assertIn("comp-a", details_by_affected)
+        self.assertIn("comp-b", details_by_affected)
+        self.assertEqual(
+            details_by_affected["comp-a"]["severity_scoring_metadata"]["likelihood"],
+            "certain",
+        )
+        self.assertEqual(
+            details_by_affected["comp-b"]["severity_scoring_metadata"]["likelihood"],
+            "rare",
+        )
+
+        # Re-import into a fresh threat model and verify metadata is restored
+        reimported_model, _ = self.adapter.import_data(exported, self.org, self.user)
+
+        reimported_comp_a = OrgsystemComponent.objects.get(
+            threat_model=reimported_model, name="Component A"
+        )
+        reimported_comp_b = OrgsystemComponent.objects.get(
+            threat_model=reimported_model, name="Component B"
+        )
+
+        reimported_threat_a = ComponentInstanceThreat.objects.get(
+            component=reimported_comp_a, threat_name="Shared Threat"
+        )
+        reimported_threat_b = ComponentInstanceThreat.objects.get(
+            component=reimported_comp_b, threat_name="Shared Threat"
+        )
+
+        self.assertEqual(reimported_threat_a.severity_scoring_metadata["likelihood"], "certain")
+        self.assertEqual(reimported_threat_a.severity_scoring_metadata["impact"], "severe")
+        self.assertEqual(reimported_threat_b.severity_scoring_metadata["likelihood"], "rare")
+        self.assertEqual(reimported_threat_b.severity_scoring_metadata["impact"], "negligible")
+
+    def test_divergent_severity_and_impact_survives_roundtrip(self):
+        """Per-instance inherent_severity, residual_severity, and impact_description
+        should all survive export/import roundtrip."""
+        json_data = {
+            "scope": {"title": "Full Per-Instance Test"},
+            "components": [
+                {"symbolic_name": "comp-a", "title": "Component A"},
+                {"symbolic_name": "comp-b", "title": "Component B"},
+            ],
+            "threats": [
+                {
+                    "symbolic_name": "shared-threat",
+                    "title": "Shared Threat",
+                    "components_affected": ["comp-a", "comp-b"],
+                    "inherent_severity": "medium",
+                },
+            ],
+        }
+        threat_model, _ = self.adapter.import_data(json_data, self.org, self.user)
+
+        comp_a = OrgsystemComponent.objects.get(threat_model=threat_model, name="Component A")
+        comp_b = OrgsystemComponent.objects.get(threat_model=threat_model, name="Component B")
+
+        threat_a = ComponentInstanceThreat.objects.get(component=comp_a, threat_name="Shared Threat")
+        threat_a.inherent_severity = "critical"
+        threat_a.residual_severity = "high"
+        threat_a.impact_description = "Total system compromise"
+        threat_a.save(update_fields=["inherent_severity", "residual_severity", "impact_description"])
+
+        threat_b = ComponentInstanceThreat.objects.get(component=comp_b, threat_name="Shared Threat")
+        threat_b.inherent_severity = "low"
+        threat_b.residual_severity = ""
+        threat_b.impact_description = "Minor data exposure"
+        threat_b.save(update_fields=["inherent_severity", "residual_severity", "impact_description"])
+
+        # Export
+        exported = self.adapter.export_data(threat_model)
+
+        threat_details = exported["extensions"]["precogly.org/threat-details"]
+        instance_details = threat_details["shared-threat"]["instance_details"]
+        details_by_affected = {d["affected"]: d for d in instance_details}
+
+        # Verify per-instance fields in export
+        self.assertEqual(details_by_affected["comp-a"]["inherent_severity"], "critical")
+        self.assertEqual(details_by_affected["comp-a"]["residual_severity"], "high")
+        self.assertEqual(details_by_affected["comp-a"]["event"], "Total system compromise")
+        self.assertEqual(details_by_affected["comp-b"]["inherent_severity"], "low")
+        self.assertNotIn("residual_severity", details_by_affected["comp-b"])
+        self.assertEqual(details_by_affected["comp-b"]["event"], "Minor data exposure")
+
+        # Re-import and verify
+        reimported_model, _ = self.adapter.import_data(exported, self.org, self.user)
+
+        reimported_comp_a = OrgsystemComponent.objects.get(
+            threat_model=reimported_model, name="Component A"
+        )
+        reimported_comp_b = OrgsystemComponent.objects.get(
+            threat_model=reimported_model, name="Component B"
+        )
+
+        reimported_threat_a = ComponentInstanceThreat.objects.get(
+            component=reimported_comp_a, threat_name="Shared Threat"
+        )
+        reimported_threat_b = ComponentInstanceThreat.objects.get(
+            component=reimported_comp_b, threat_name="Shared Threat"
+        )
+
+        self.assertEqual(reimported_threat_a.inherent_severity, "critical")
+        self.assertEqual(reimported_threat_a.residual_severity, "high")
+        self.assertEqual(reimported_threat_a.impact_description, "Total system compromise")
+        self.assertEqual(reimported_threat_b.inherent_severity, "low")
+        self.assertEqual(reimported_threat_b.impact_description, "Minor data exposure")
+
+    def test_divergent_persona_survives_roundtrip(self):
+        """Per-instance threat_persona links should survive export/import roundtrip."""
+        json_data = {
+            "scope": {"title": "Persona Test"},
+            "components": [
+                {"symbolic_name": "comp-a", "title": "Component A"},
+                {"symbolic_name": "comp-b", "title": "Component B"},
+            ],
+            "threat_personas": [
+                {
+                    "symbolic_name": "insider",
+                    "title": "Malicious Insider",
+                    "description": "Employee with access",
+                    "is_person": True,
+                    "malicious_intent": True,
+                },
+                {
+                    "symbolic_name": "external",
+                    "title": "External Attacker",
+                    "description": "Remote attacker",
+                    "is_person": True,
+                    "malicious_intent": True,
+                },
+            ],
+            "threats": [
+                {
+                    "symbolic_name": "shared-threat",
+                    "title": "Shared Threat",
+                    "components_affected": ["comp-a", "comp-b"],
+                    "inherent_severity": "medium",
+                },
+            ],
+        }
+        threat_model, _ = self.adapter.import_data(json_data, self.org, self.user)
+
+        comp_a = OrgsystemComponent.objects.get(threat_model=threat_model, name="Component A")
+        comp_b = OrgsystemComponent.objects.get(threat_model=threat_model, name="Component B")
+        threat_a = ComponentInstanceThreat.objects.get(component=comp_a, threat_name="Shared Threat")
+        threat_b = ComponentInstanceThreat.objects.get(component=comp_b, threat_name="Shared Threat")
+
+        # Link different personas to each instance
+        insider = ThreatPersona.objects.get(threat_model=threat_model, symbolic_name="insider")
+        external = ThreatPersona.objects.get(threat_model=threat_model, symbolic_name="external")
+        ThreatPersonaLink.objects.create(persona=insider, component_threat=threat_a)
+        ThreatPersonaLink.objects.create(persona=external, component_threat=threat_b)
+
+        # Export
+        exported = self.adapter.export_data(threat_model)
+
+        threat_details = exported["extensions"]["precogly.org/threat-details"]
+        instance_details = threat_details["shared-threat"]["instance_details"]
+        details_by_affected = {d["affected"]: d for d in instance_details}
+
+        self.assertEqual(details_by_affected["comp-a"]["threat_persona"], "insider")
+        self.assertEqual(details_by_affected["comp-b"]["threat_persona"], "external")
+
+        # Re-import and verify persona links are restored
+        reimported_model, _ = self.adapter.import_data(exported, self.org, self.user)
+
+        reimported_comp_a = OrgsystemComponent.objects.get(
+            threat_model=reimported_model, name="Component A"
+        )
+        reimported_comp_b = OrgsystemComponent.objects.get(
+            threat_model=reimported_model, name="Component B"
+        )
+        reimported_threat_a = ComponentInstanceThreat.objects.get(
+            component=reimported_comp_a, threat_name="Shared Threat"
+        )
+        reimported_threat_b = ComponentInstanceThreat.objects.get(
+            component=reimported_comp_b, threat_name="Shared Threat"
+        )
+
+        persona_a = ThreatPersonaLink.objects.get(component_threat=reimported_threat_a)
+        persona_b = ThreatPersonaLink.objects.get(component_threat=reimported_threat_b)
+        self.assertEqual(persona_a.persona.symbolic_name, "insider")
+        self.assertEqual(persona_b.persona.symbolic_name, "external")
+
+    def test_legacy_flat_metadata_import(self):
+        """Old exports with flat severity_scoring_metadata (no instance_details)
+        should still apply metadata to all instances."""
+        json_data = {
+            "scope": {"title": "Legacy Test"},
+            "components": [
+                {"symbolic_name": "comp-x", "title": "Component X"},
+                {"symbolic_name": "comp-y", "title": "Component Y"},
+            ],
+            "threats": [
+                {
+                    "symbolic_name": "legacy-threat",
+                    "title": "Legacy Threat",
+                    "components_affected": ["comp-x", "comp-y"],
+                    "inherent_severity": "high",
+                },
+            ],
+            "extensions": {
+                "precogly.org/threat-details": {
+                    "legacy-threat": {
+                        "severity_scoring_metadata": {
+                            "likelihood": "likely",
+                            "impact": "major",
+                            "rationale": "Legacy format",
+                        }
+                    }
+                }
+            },
+        }
+        threat_model, _ = self.adapter.import_data(json_data, self.org, self.user)
+
+        comp_x = OrgsystemComponent.objects.get(threat_model=threat_model, name="Component X")
+        comp_y = OrgsystemComponent.objects.get(threat_model=threat_model, name="Component Y")
+
+        threat_x = ComponentInstanceThreat.objects.get(component=comp_x, threat_name="Legacy Threat")
+        threat_y = ComponentInstanceThreat.objects.get(component=comp_y, threat_name="Legacy Threat")
+
+        # Both should have the same metadata (legacy flat format applies to all)
+        self.assertEqual(threat_x.severity_scoring_metadata["likelihood"], "likely")
+        self.assertEqual(threat_y.severity_scoring_metadata["likelihood"], "likely")
+        self.assertEqual(threat_x.severity_scoring_metadata["rationale"], "Legacy format")
+        self.assertEqual(threat_y.severity_scoring_metadata["rationale"], "Legacy format")


### PR DESCRIPTION
Closes #329 

  The TM-Library export grouped threats by symbolic_name but only exported
  severity_scoring_metadata, inherent_severity, residual_severity,
  impact_description, and threat_persona from the first instance in each
  group. All other instances' data was silently dropped.

  This changes the precogly.org/threat-details extension to use a per-instance
  instance_details array, keyed by component/flow symbolic name, so every
  instance's fields are preserved through export and re-import.

  The import side handles both the new per-instance format and the previous
  flat format for backward compatibility with older exports.