### PR TITLE
fix: show Data Store sensitivity labels in both DFD styles

### DIFF
--- a/frontend/src/features/dfd-editor/components/nodes/DataStoreNode.tsx
+++ b/frontend/src/features/dfd-editor/components/nodes/DataStoreNode.tsx
@@ -88,6 +88,17 @@ export const DataStoreNode = memo(function DataStoreNode({
                     {technologyDisplayName}
                   </span>
                 )}
+                {data.dataSensitivity && DATA_SENSITIVITY_CONFIG[data.dataSensitivity] && (
+                  <span
+                    className="text-[10px] px-1 rounded truncate mt-0.5"
+                    style={{
+                      backgroundColor: `${DATA_SENSITIVITY_CONFIG[data.dataSensitivity].color}20`,
+                      color: DATA_SENSITIVITY_CONFIG[data.dataSensitivity].color,
+                    }}
+                  >
+                    {DATA_SENSITIVITY_CONFIG[data.dataSensitivity].label}
+                  </span>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/features/dfd-editor/types/notation.ts
+++ b/frontend/src/features/dfd-editor/types/notation.ts
@@ -4,7 +4,7 @@ export const DEFAULT_NOTATION: DFDNotationStyle = 'dfd3'
 export const NOTATION_NODE_SIZES: Record<DFDNotationStyle, Record<string, { width: number; height: number }>> = {
   dfd3: {
     process: { width: 150, height: 70 },
-    datastore: { width: 170, height: 70 },
+    datastore: { width: 170, height: 90 },
     humanActor: { width: 100, height: 100 },
     systemActor: { width: 100, height: 90 },
     trustZone: { width: 300, height: 200 },
@@ -12,7 +12,7 @@ export const NOTATION_NODE_SIZES: Record<DFDNotationStyle, Record<string, { widt
   },
   yourdon: {
     process: { width: 100, height: 100 },
-    datastore: { width: 170, height: 40 },
+    datastore: { width: 170, height: 50 },
     humanActor: { width: 100, height: 100 },
     systemActor: { width: 100, height: 90 },
     trustZone: { width: 300, height: 200 },


### PR DESCRIPTION
## Summary
Render the configured Data Sensitivity label on Yourdon Data Store nodes.
Increase the default Data Store heights in DFD3 and Yourdon so the label is visible without manual resizing.

<img width="1743" height="1029" alt="Screenshot From 2026-08-29 00-49-31" src="https://github.com/user-attachments/assets/7c10ad2f-33d2-43f0-a1ee-47487a34dd4a" />

<img width="1743" height="1029" alt="Screenshot From 2026-08-29 00-49-39" src="https://github.com/user-attachments/assets/b0c46702-bc16-47e0-837b-c5f2b7e20af9" />


Closes #197