### PR TITLE
Embed rendered DFDs in Word reports

### DIFF
--- a/frontend/src/components/shared/ReadOnlyDFDViewer.tsx
+++ b/frontend/src/components/shared/ReadOnlyDFDViewer.tsx
@@ -3,17 +3,18 @@
  * Displays a Data Flow Diagram without editing capabilities.
  */
 
-import { ReactFlow, Background, Controls, ReactFlowProvider } from '@xyflow/react'
+import { forwardRef, useImperativeHandle, useRef } from 'react'
+import { ReactFlow, Background, Controls, ReactFlowProvider, useReactFlow, type Edge, type Node } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { nodeTypes, edgeTypes } from '@/features/dfd-editor/components'
 import { DFDNotationProvider } from '@/features/dfd-editor/context/DFDNotationContext'
 import { DEFAULT_NOTATION } from '@/features/dfd-editor/types/notation'
+import { captureDiagramImage } from '@/features/dfd-editor/lib/export-diagram-image'
 
 // Flexible canvas data type that accepts the API response format
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 interface CanvasData {
-  nodes?: any[]
-  edges?: any[]
+  nodes?: unknown[]
+  edges?: unknown[]
   notationStyle?: string
 }
 
@@ -22,13 +23,38 @@ interface ReadOnlyDFDViewerProps {
   className?: string
 }
 
-function DFDViewerContent({ canvasData, className }: ReadOnlyDFDViewerProps) {
-  const nodes = canvasData.nodes ?? []
-  const edges = canvasData.edges ?? []
+export interface ReadOnlyDFDViewerHandle {
+  captureImage: () => Promise<Uint8Array>
+}
+
+const DFDViewerContent = forwardRef<ReadOnlyDFDViewerHandle, ReadOnlyDFDViewerProps>(function DFDViewerContent(
+  { canvasData, className },
+  ref,
+) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const reactFlow = useReactFlow()
+  const nodes = (canvasData.nodes ?? []) as Node[]
+  const edges = (canvasData.edges ?? []) as Edge[]
   const notationStyle = (canvasData.notationStyle as 'dfd3' | 'yourdon') ?? DEFAULT_NOTATION
 
+  useImperativeHandle(ref, () => ({
+    captureImage: () => {
+      if (!wrapperRef.current) {
+        throw new Error('DFD viewer is not mounted')
+      }
+
+      return captureDiagramImage(
+        wrapperRef.current,
+        reactFlow.getNodes(),
+        reactFlow.getViewport,
+        reactFlow.setViewport,
+        reactFlow.getNodesBounds,
+      )
+    },
+  }), [reactFlow])
+
   return (
-    <div className={className}>
+    <div ref={wrapperRef} className={className}>
       <DFDNotationProvider notationStyle={notationStyle}>
         <ReactFlow
           nodes={nodes}
@@ -70,12 +96,12 @@ function DFDViewerContent({ canvasData, className }: ReadOnlyDFDViewerProps) {
       </DFDNotationProvider>
     </div>
   )
-}
+})
 
-export function ReadOnlyDFDViewer(props: ReadOnlyDFDViewerProps) {
+export const ReadOnlyDFDViewer = forwardRef<ReadOnlyDFDViewerHandle, ReadOnlyDFDViewerProps>(function ReadOnlyDFDViewer(props, ref) {
   return (
     <ReactFlowProvider>
-      <DFDViewerContent {...props} />
+      <DFDViewerContent {...props} ref={ref} />
     </ReactFlowProvider>
   )
-}
+})

--- a/frontend/src/features/reports/ReportView.tsx
+++ b/frontend/src/features/reports/ReportView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Card, CardContent } from '@/components/ui/card'
 import {
@@ -35,6 +35,7 @@ import {
   exportComplianceCSV,
 } from './utils/csvExport'
 import { exportWordDoc } from './utils/wordExport'
+import { ReadOnlyDFDViewer, type ReadOnlyDFDViewerHandle } from '@/components/shared/ReadOnlyDFDViewer'
 
 interface ReportViewProps {
   threatModelId: string
@@ -120,8 +121,34 @@ function renderSection(sectionId: string, depth: string, data: ReportData) {
 
 export function ReportView({ threatModelId }: ReportViewProps) {
   const [reportType, setReportType] = useState<ReportType>('executive')
+  const [isExportingWord, setIsExportingWord] = useState(false)
+  const dfdViewerRefs = useRef<Record<string, ReadOnlyDFDViewerHandle | null>>({})
   const { data, isLoading, error } = useReport(threatModelId)
   const sections = getSectionsForType(reportType)
+
+  const handleWordExport = async (reportData: ReportData) => {
+    setIsExportingWord(true)
+
+    // Give each off-screen React Flow viewer time to mount, measure its nodes,
+    // and apply fitView before capturing the actual rendered diagram.
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    })
+
+    try {
+      const dfdImages = new Map<string, Uint8Array>()
+      for (const dfd of reportData.architecture.dfds) {
+        const canvasData = dfd.canvasData
+        if (!canvasData?.nodes?.length) continue
+        const viewer = dfdViewerRefs.current[dfd.id]
+        if (!viewer) throw new Error(`DFD viewer is not ready: ${dfd.name}`)
+        dfdImages.set(dfd.id, await viewer.captureImage())
+      }
+      await exportWordDoc(reportData, reportData.metadata.name, dfdImages)
+    } finally {
+      setIsExportingWord(false)
+    }
+  }
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -204,7 +231,7 @@ export function ReportView({ threatModelId }: ReportViewProps) {
                   <DropdownMenuItem
                     onClick={async () => {
                       try {
-                        await exportWordDoc(data, data.metadata.name)
+                        await handleWordExport(data)
                       } catch (err) {
                         toast.error(
                           err instanceof Error
@@ -219,6 +246,30 @@ export function ReportView({ threatModelId }: ReportViewProps) {
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
+
+            {isExportingWord && (
+              <div
+                aria-hidden="true"
+                style={{
+                  position: 'fixed',
+                  left: '-100000px',
+                  top: 0,
+                  width: '1200px',
+                  pointerEvents: 'none',
+                }}
+              >
+                {data.architecture.dfds.map((dfd) => (
+                  dfd.canvasData?.nodes?.length ? (
+                    <ReadOnlyDFDViewer
+                      key={dfd.id}
+                      ref={(viewer) => { dfdViewerRefs.current[dfd.id] = viewer }}
+                      canvasData={dfd.canvasData}
+                      className="h-[700px] w-[1200px]"
+                    />
+                  ) : null
+                ))}
+              </div>
+            )}
 
             {sections.map((section) => (
               <div key={section.id}>

--- a/frontend/src/features/reports/sections/ArchitectureSection.tsx
+++ b/frontend/src/features/reports/sections/ArchitectureSection.tsx
@@ -72,7 +72,7 @@ export function ArchitectureSection({ architecture }: ArchitectureSectionProps) 
                           </Button>
                         </div>
                         <ReadOnlyDFDViewer
-                          canvasData={dfd.canvasData as { nodes?: unknown[]; edges?: unknown[] }}
+                          canvasData={dfd.canvasData}
                           className="h-[500px] w-full"
                         />
                       </div>

--- a/frontend/src/features/reports/types/report.ts
+++ b/frontend/src/features/reports/types/report.ts
@@ -45,7 +45,7 @@ export interface ReportArchitecture {
     isPrimary?: boolean
     nodeCount: number
     edgeCount: number
-    canvasData?: { nodes?: unknown[]; edges?: unknown[] }
+    canvasData?: { nodes?: unknown[]; edges?: unknown[]; notationStyle?: string }
   }>
   referenceImages: Array<{
     id: number

--- a/frontend/src/features/reports/utils/wordExport.ts
+++ b/frontend/src/features/reports/utils/wordExport.ts
@@ -53,78 +53,6 @@ function flattenThreats(data: ReportData): ThreatWithContext[] {
   return out
 }
 
-type CanvasNodeForExport = {
-  id: string
-  type?: string
-  position?: { x?: number; y?: number }
-  style?: { width?: number | string; height?: number | string }
-  data?: { label?: string }
-}
-
-type CanvasEdgeForExport = { source: string; target: string }
-
-function escapeXml(value: string): string {
-  return value.replace(/[<>&'\"]/g, (character) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', "'": '&apos;', '\"': '&quot;' }[character] || character))
-}
-
-async function renderDfdPng(canvasData: { nodes?: unknown[]; edges?: unknown[] }): Promise<Uint8Array | null> {
-  const nodes = (canvasData.nodes || []) as CanvasNodeForExport[]
-  if (nodes.length === 0) return null
-  const edges = (canvasData.edges || []) as CanvasEdgeForExport[]
-  const positions = nodes.map((node) => ({
-    node,
-    x: node.position?.x ?? 0,
-    y: node.position?.y ?? 0,
-    width: Number(node.style?.width) || 150,
-    height: Number(node.style?.height) || 70,
-  }))
-  const minX = Math.min(...positions.map((item) => item.x))
-  const minY = Math.min(...positions.map((item) => item.y))
-  const maxX = Math.max(...positions.map((item) => item.x + item.width))
-  const maxY = Math.max(...positions.map((item) => item.y + item.height))
-  const padding = 32
-  const width = Math.max(640, maxX - minX + padding * 2)
-  const height = Math.max(360, maxY - minY + padding * 2)
-  const byId = new Map(positions.map((item) => [item.node.id, item]))
-  const colors: Record<string, string> = { process: '#dbeafe', datastore: '#f3e8ff', humanActor: '#dcfce7', systemActor: '#e2e8f0', stickyNote: '#fef9c3' }
-  const strokes: Record<string, string> = { process: '#3b82f6', datastore: '#a855f7', humanActor: '#16a34a', systemActor: '#64748b', stickyNote: '#eab308' }
-  const edgeMarkup = edges.map((edge) => {
-    const source = byId.get(edge.source)
-    const target = byId.get(edge.target)
-    if (!source || !target) return ''
-    const x1 = source.x - minX + padding + source.width / 2
-    const y1 = source.y - minY + padding + source.height / 2
-    const x2 = target.x - minX + padding + target.width / 2
-    const y2 = target.y - minY + padding + target.height / 2
-    return `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>`
-  }).join('')
-  const nodeMarkup = positions.map(({ node, x, y, width: nodeWidth, height: nodeHeight }) => {
-    const left = x - minX + padding
-    const top = y - minY + padding
-    const type = node.type || 'process'
-    const label = escapeXml(node.data?.label || type)
-    return `<g><rect x="${left}" y="${top}" width="${nodeWidth}" height="${nodeHeight}" rx="8" fill="${colors[type] || '#f8fafc'}" stroke="${strokes[type] || '#64748b'}" stroke-width="2"/><text x="${left + nodeWidth / 2}" y="${top + nodeHeight / 2}" text-anchor="middle" dominant-baseline="middle" font-family="Arial" font-size="14" fill="#1e293b">${label}</text></g>`
-  }).join('')
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 z" fill="#94a3b8"/></marker></defs>${edgeMarkup}${nodeMarkup}</svg>`
-  const image = await new Promise<HTMLImageElement>((resolve, reject) => {
-    const imageElement = new Image()
-    imageElement.onload = () => resolve(imageElement)
-    imageElement.onerror = () => reject(new Error('Unable to decode generated DFD image'))
-    imageElement.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
-  })
-  const canvas = document.createElement('canvas')
-  const scale = Math.min(2, 1200 / width)
-  canvas.width = Math.round(width * scale)
-  canvas.height = Math.round(height * scale)
-  const context = canvas.getContext('2d')
-  if (!context) return null
-  context.fillStyle = '#ffffff'
-  context.fillRect(0, 0, canvas.width, canvas.height)
-  context.drawImage(image, 0, 0, canvas.width, canvas.height)
-  const png = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'))
-  return png ? new Uint8Array(await png.arrayBuffer()) : null
-}
-
 // ---------------------------------------------------------------------------
 // Section builders
 // ---------------------------------------------------------------------------
@@ -547,15 +475,11 @@ function buildComplianceSection(data: ReportData): (Paragraph | Table)[] {
 // Main export
 // ---------------------------------------------------------------------------
 
-export async function exportWordDoc(data: ReportData, modelName: string): Promise<void> {
-  const dfdImages = new Map<string, Uint8Array>()
-  for (const dfd of data.architecture.dfds) {
-    if (dfd.canvasData) {
-      const image = await renderDfdPng(dfd.canvasData)
-      if (image) dfdImages.set(dfd.id, image)
-    }
-  }
-
+export async function exportWordDoc(
+  data: ReportData,
+  modelName: string,
+  dfdImages: Map<string, Uint8Array>,
+): Promise<void> {
   const children: (Paragraph | Table)[] = [
     // Title page
     new Paragraph({

--- a/frontend/src/features/reports/utils/wordExport.ts
+++ b/frontend/src/features/reports/utils/wordExport.ts
@@ -4,6 +4,7 @@ import {
   Table,
   TextRun,
   HeadingLevel,
+  ImageRun,
 } from 'docx'
 import type { ReportData, ReportThreat } from '../types/report'
 import {
@@ -50,6 +51,76 @@ function flattenThreats(data: ReportData): ThreatWithContext[] {
     for (const threat of threats) out.push({ threat, context })
   }
   return out
+}
+
+type CanvasNodeForExport = {
+  id: string
+  type?: string
+  position?: { x?: number; y?: number }
+  style?: { width?: number | string; height?: number | string }
+  data?: { label?: string }
+}
+
+type CanvasEdgeForExport = { source: string; target: string }
+
+function escapeXml(value: string): string {
+  return value.replace(/[<>&'\"]/g, (character) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', "'": '&apos;', '\"': '&quot;' }[character] || character))
+}
+
+async function renderDfdPng(canvasData: { nodes?: unknown[]; edges?: unknown[] }): Promise<Uint8Array | null> {
+  const nodes = (canvasData.nodes || []) as CanvasNodeForExport[]
+  if (nodes.length === 0) return null
+  const edges = (canvasData.edges || []) as CanvasEdgeForExport[]
+  const positions = nodes.map((node) => ({
+    node,
+    x: node.position?.x ?? 0,
+    y: node.position?.y ?? 0,
+    width: Number(node.style?.width) || 150,
+    height: Number(node.style?.height) || 70,
+  }))
+  const minX = Math.min(...positions.map((item) => item.x))
+  const minY = Math.min(...positions.map((item) => item.y))
+  const maxX = Math.max(...positions.map((item) => item.x + item.width))
+  const maxY = Math.max(...positions.map((item) => item.y + item.height))
+  const padding = 32
+  const width = Math.max(640, maxX - minX + padding * 2)
+  const height = Math.max(360, maxY - minY + padding * 2)
+  const byId = new Map(positions.map((item) => [item.node.id, item]))
+  const colors: Record<string, string> = { process: '#dbeafe', datastore: '#f3e8ff', humanActor: '#dcfce7', systemActor: '#e2e8f0', stickyNote: '#fef9c3' }
+  const strokes: Record<string, string> = { process: '#3b82f6', datastore: '#a855f7', humanActor: '#16a34a', systemActor: '#64748b', stickyNote: '#eab308' }
+  const edgeMarkup = edges.map((edge) => {
+    const source = byId.get(edge.source)
+    const target = byId.get(edge.target)
+    if (!source || !target) return ''
+    const x1 = source.x - minX + padding + source.width / 2
+    const y1 = source.y - minY + padding + source.height / 2
+    const x2 = target.x - minX + padding + target.width / 2
+    const y2 = target.y - minY + padding + target.height / 2
+    return `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>`
+  }).join('')
+  const nodeMarkup = positions.map(({ node, x, y, width: nodeWidth, height: nodeHeight }) => {
+    const left = x - minX + padding
+    const top = y - minY + padding
+    const type = node.type || 'process'
+    const label = escapeXml(node.data?.label || type)
+    return `<g><rect x="${left}" y="${top}" width="${nodeWidth}" height="${nodeHeight}" rx="8" fill="${colors[type] || '#f8fafc'}" stroke="${strokes[type] || '#64748b'}" stroke-width="2"/><text x="${left + nodeWidth / 2}" y="${top + nodeHeight / 2}" text-anchor="middle" dominant-baseline="middle" font-family="Arial" font-size="14" fill="#1e293b">${label}</text></g>`
+  }).join('')
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 z" fill="#94a3b8"/></marker></defs>${edgeMarkup}${nodeMarkup}</svg>`
+  const response = await fetch(`data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`)
+  const blob = await response.blob()
+  const image = await createImageBitmap(blob)
+  const canvas = document.createElement('canvas')
+  const scale = Math.min(2, 1200 / width)
+  canvas.width = Math.round(width * scale)
+  canvas.height = Math.round(height * scale)
+  const context = canvas.getContext('2d')
+  if (!context) return null
+  context.fillStyle = '#ffffff'
+  context.fillRect(0, 0, canvas.width, canvas.height)
+  context.drawImage(image, 0, 0, canvas.width, canvas.height)
+  image.close()
+  const png = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'))
+  return png ? new Uint8Array(await png.arrayBuffer()) : null
 }
 
 // ---------------------------------------------------------------------------
@@ -172,7 +243,7 @@ function buildScopeSection(data: ReportData): (Paragraph | Table)[] {
   return children
 }
 
-function buildArchitectureSection(data: ReportData): (Paragraph | Table)[] {
+function buildArchitectureSection(data: ReportData, dfdImages: Map<string, Uint8Array>): (Paragraph | Table)[] {
   const arch = data.architecture
   const children: (Paragraph | Table)[] = [h1('4. System Architecture'), spacer()]
 
@@ -199,7 +270,9 @@ function buildArchitectureSection(data: ReportData): (Paragraph | Table)[] {
     arch.dfds.forEach((dfd, idx) => {
       children.push(
         h3(`Figure ${idx + 1}: ${dfd.name}${dfd.isPrimary ? ' (Primary)' : ''}`),
-        placeholder(`Insert DFD diagram screenshot here — ${dfd.name}`),
+        ...(dfdImages.get(dfd.id)
+          ? [new Paragraph({ children: [new ImageRun({ data: dfdImages.get(dfd.id)!, transformation: { width: 600, height: 360 } })] })]
+          : [placeholder(`DFD diagram unavailable — ${dfd.name}`)]),
         spacer(),
       )
 
@@ -473,6 +546,14 @@ function buildComplianceSection(data: ReportData): (Paragraph | Table)[] {
 // ---------------------------------------------------------------------------
 
 export async function exportWordDoc(data: ReportData, modelName: string): Promise<void> {
+  const dfdImages = new Map<string, Uint8Array>()
+  for (const dfd of data.architecture.dfds) {
+    if (dfd.canvasData) {
+      const image = await renderDfdPng(dfd.canvasData)
+      if (image) dfdImages.set(dfd.id, image)
+    }
+  }
+
   const children: (Paragraph | Table)[] = [
     // Title page
     new Paragraph({
@@ -498,7 +579,7 @@ export async function exportWordDoc(data: ReportData, modelName: string): Promis
       ],
     }),
     spacer(),
-    placeholder('This document is auto-generated. Review all sections and insert DFD diagrams before submission.'),
+    placeholder('This document is auto-generated. Review all sections before submission.'),
     pageBreak(),
 
     // Sections
@@ -508,7 +589,7 @@ export async function exportWordDoc(data: ReportData, modelName: string): Promis
     pageBreak(),
     ...buildScopeSection(data),
     pageBreak(),
-    ...buildArchitectureSection(data),
+    ...buildArchitectureSection(data, dfdImages),
     pageBreak(),
     ...buildDataAssetsSection(data),
     pageBreak(),

--- a/frontend/src/features/reports/utils/wordExport.ts
+++ b/frontend/src/features/reports/utils/wordExport.ts
@@ -106,9 +106,12 @@ async function renderDfdPng(canvasData: { nodes?: unknown[]; edges?: unknown[] }
     return `<g><rect x="${left}" y="${top}" width="${nodeWidth}" height="${nodeHeight}" rx="8" fill="${colors[type] || '#f8fafc'}" stroke="${strokes[type] || '#64748b'}" stroke-width="2"/><text x="${left + nodeWidth / 2}" y="${top + nodeHeight / 2}" text-anchor="middle" dominant-baseline="middle" font-family="Arial" font-size="14" fill="#1e293b">${label}</text></g>`
   }).join('')
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 z" fill="#94a3b8"/></marker></defs>${edgeMarkup}${nodeMarkup}</svg>`
-  const response = await fetch(`data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`)
-  const blob = await response.blob()
-  const image = await createImageBitmap(blob)
+  const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const imageElement = new Image()
+    imageElement.onload = () => resolve(imageElement)
+    imageElement.onerror = () => reject(new Error('Unable to decode generated DFD image'))
+    imageElement.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+  })
   const canvas = document.createElement('canvas')
   const scale = Math.min(2, 1200 / width)
   canvas.width = Math.round(width * scale)
@@ -118,7 +121,6 @@ async function renderDfdPng(canvasData: { nodes?: unknown[]; edges?: unknown[] }
   context.fillStyle = '#ffffff'
   context.fillRect(0, 0, canvas.width, canvas.height)
   context.drawImage(image, 0, 0, canvas.width, canvas.height)
-  image.close()
   const png = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'))
   return png ? new Uint8Array(await png.arrayBuffer()) : null
 }
@@ -271,7 +273,7 @@ function buildArchitectureSection(data: ReportData, dfdImages: Map<string, Uint8
       children.push(
         h3(`Figure ${idx + 1}: ${dfd.name}${dfd.isPrimary ? ' (Primary)' : ''}`),
         ...(dfdImages.get(dfd.id)
-          ? [new Paragraph({ children: [new ImageRun({ data: dfdImages.get(dfd.id)!, transformation: { width: 600, height: 360 } })] })]
+          ? [new Paragraph({ children: [new ImageRun({ data: dfdImages.get(dfd.id)!, type: 'png', transformation: { width: 600, height: 360 } })] })]
           : [placeholder(`DFD diagram unavailable — ${dfd.name}`)]),
         spacer(),
       )


### PR DESCRIPTION
## Summary

- Capture each saved DFD through the existing React Flow renderer.
- Embed the rendered PNG in the Word report instead of generating a simplified outline.
- Preserve the existing fallback for diagrams without nodes.

[Screencast From 2026-08-29 01-34-45.webm](https://github.com/user-attachments/assets/d58d0244-fd5b-475f-b471-093c5684ae08)


Closes #206
