### PR TITLE
Add DFD keyboard shortcut help

### DIFF
--- a/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
+++ b/frontend/src/features/dfd-editor/components/DiagramToolbar.tsx
@@ -1,7 +1,7 @@
-import { memo, useCallback, useState } from 'react'
+import { memo, useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { XYPosition } from '@xyflow/react'
-import { User, Server, Cog, Database, Shield, Box, ArrowUp, LayoutTemplate, ShieldAlert, ShieldCheck, ImageDown } from 'lucide-react'
+import { User, Server, Cog, Database, Shield, Box, ArrowUp, LayoutTemplate, ShieldAlert, ShieldCheck, ImageDown, HelpCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import {
@@ -25,6 +25,13 @@ import type { DFDNotationStyle } from '../types/notation'
 import { useCreateNode } from '../hooks/useCreateNode'
 import { ExportImageDialog } from './ExportImageDialog'
 import type { ExportImageOptions } from '../lib/export-diagram-image'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 
 interface DiagramToolbarProps {
   connectionMode: boolean
@@ -97,6 +104,18 @@ const nodeButtons: ToolbarButtonConfig[] = [
   },
 ]
 
+const KEYBOARD_SHORTCUTS = [
+  ['Ctrl/Cmd + S', 'Save the diagram'],
+  ['Ctrl/Cmd + Z', 'Undo the last change'],
+  ['Ctrl/Cmd + Shift + Z or Ctrl/Cmd + Y', 'Redo the last undone change'],
+  ['Ctrl/Cmd + A', 'Select all nodes and edges'],
+  ['Ctrl/Cmd + C', 'Copy selected nodes'],
+  ['Ctrl/Cmd + V', 'Paste copied nodes or clipboard text into a selected node'],
+  ['Ctrl/Cmd + D', 'Duplicate selected nodes'],
+  ['Delete / Backspace', 'Delete selected nodes or edges'],
+  ['Escape', 'Deselect and cancel the active interaction'],
+]
+
 export const DiagramToolbar = memo(function DiagramToolbar({
   connectionMode,
   onConnectionModeChange,
@@ -117,6 +136,20 @@ export const DiagramToolbar = memo(function DiagramToolbar({
   const navigate = useNavigate()
   const { createNode } = useCreateNode(notationStyle)
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
+
+  useEffect(() => {
+    const handleShortcutHelp = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return
+      if (event.key === '?') {
+        event.preventDefault()
+        setShortcutsOpen(true)
+      }
+    }
+    window.addEventListener('keydown', handleShortcutHelp)
+    return () => window.removeEventListener('keydown', handleShortcutHelp)
+  }, [])
 
   const handleAddNode = useCallback(
     (type: DiagramNodeType) => {
@@ -203,7 +236,7 @@ export const DiagramToolbar = memo(function DiagramToolbar({
           <TooltipContent side="bottom">
             <p className="font-medium">Draw Connection</p>
             <p className="text-xs text-muted-foreground">
-              Click and drag from one node to another to create a data flow
+              Click and drag from one node to another to create a data flow. Press ? for shortcuts.
             </p>
           </TooltipContent>
         </Tooltip>
@@ -225,6 +258,24 @@ export const DiagramToolbar = memo(function DiagramToolbar({
             </Select>
           </>
         )}
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              aria-label="Keyboard shortcuts"
+              onClick={() => setShortcutsOpen(true)}
+            >
+              <HelpCircle className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p className="font-medium">Keyboard shortcuts (?)</p>
+            <p className="text-xs text-muted-foreground">Show the DFD editor shortcut reference</p>
+          </TooltipContent>
+        </Tooltip>
 
         {!hideTemplates && (
           <>
@@ -337,6 +388,22 @@ export const DiagramToolbar = memo(function DiagramToolbar({
           </div>
         )}
       </div>
+      <Dialog open={shortcutsOpen} onOpenChange={setShortcutsOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Keyboard shortcuts</DialogTitle>
+            <DialogDescription>Shortcuts are active when the canvas is focused and a form field is not being edited.</DialogDescription>
+          </DialogHeader>
+          <div className="divide-y rounded-md border">
+            {KEYBOARD_SHORTCUTS.map(([shortcut, description]) => (
+              <div key={shortcut} className="flex items-center justify-between gap-4 px-3 py-2 text-sm">
+                <kbd className="rounded border bg-muted px-2 py-1 font-mono text-xs whitespace-nowrap">{shortcut}</kbd>
+                <span className="text-right text-muted-foreground">{description}</span>
+              </div>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
     </TooltipProvider>
   )
 })


### PR DESCRIPTION
## Summary

- Add a keyboard-shortcuts help button to the DFD toolbar.
- Open the shortcuts reference with `?` when a form field is not focused.
- Document the editor shortcuts without interfering with label or form editing.

[Screencast From 2026-08-29 01-47-07.webm](https://github.com/user-attachments/assets/b1f28965-5f31-4812-acac-828288d61b25)

<img width="1743" height="1029" alt="Screenshot From 2026-08-29 01-47-40" src="https://github.com/user-attachments/assets/fdb6b4c3-4f98-47bd-b7e1-97c1cc91fb72" />

<img width="1743" height="1029" alt="Screenshot From 2026-08-29 01-47-46" src="https://github.com/user-attachments/assets/8a5464bf-06b4-4555-8a5b-3e6852193a77" />


Closes #252
