### PR TITLE
Rename selected components by typing or pasting

### DIFF
--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -373,6 +373,22 @@ function DFDEditorContent() {
     }
   }, [boundaryMode, cancelBoundaryMode])
 
+  const startNodeEditing = useCallback((initialText: string) => {
+    setNodes((currentNodes) => currentNodes.map((node) =>
+      node.selected
+        ? { ...node, data: { ...node.data, label: initialText, isInlineEditing: true } }
+        : node
+    ))
+  }, [setNodes])
+
+  const pasteNodeLabel = useCallback((text: string) => {
+    setNodes((currentNodes) => currentNodes.map((node) =>
+      node.selected
+        ? { ...node, data: { ...node.data, label: text, isInlineEditing: true } }
+        : node
+    ))
+  }, [setNodes])
+
   // Wrap saveNow for keyboard shortcut to pass notation style
   const handleKeyboardSave = useCallback(async () => {
     await saveNow(notationStyle)
@@ -383,6 +399,8 @@ function DFDEditorContent() {
     onSave: handleKeyboardSave,
     onUndo: undo,
     onDeselect: handleDeselect,
+    onStartNodeEditing: startNodeEditing,
+    onPasteText: pasteNodeLabel,
     enabled: true,
   })
 

--- a/frontend/src/features/dfd-editor/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/features/dfd-editor/hooks/useKeyboardShortcuts.ts
@@ -11,6 +11,8 @@ interface UseKeyboardShortcutsOptions {
   onDelete?: () => void
   onCopy?: () => void
   onPaste?: () => void
+  onPasteText?: (text: string) => void
+  onStartNodeEditing?: (initialText: string) => void
   onDuplicate?: () => void
   enabled?: boolean
 }
@@ -32,6 +34,8 @@ export function useKeyboardShortcuts({
   onDelete,
   onCopy,
   onPaste,
+  onPasteText,
+  onStartNodeEditing,
   onDuplicate,
   enabled = true,
 }: UseKeyboardShortcutsOptions = {}) {
@@ -241,8 +245,27 @@ export function useKeyboardShortcuts({
       // Paste: Cmd/Ctrl + V
       if (isMod && key === 'v') {
         event.preventDefault()
-        ;(onPaste || handlePaste)()
+        const selectedNodes = (getNodes() as DiagramNode[]).filter((n) => n.selected)
+        const selectedEdges = (getEdges() as DiagramEdge[]).filter((e) => e.selected)
+        if (selectedNodes.length === 1 && selectedEdges.length === 0 && onPasteText) {
+          void navigator.clipboard?.readText().then((text) => {
+            if (text) onPasteText(text)
+          })
+        } else {
+          ;(onPaste || handlePaste)()
+        }
         return
+      }
+
+      // Replace a selected node label with the first typed character.
+      if (!isMod && event.key.length === 1) {
+        const selectedNodes = (getNodes() as DiagramNode[]).filter((n) => n.selected)
+        const selectedEdges = (getEdges() as DiagramEdge[]).filter((e) => e.selected)
+        if (selectedNodes.length === 1 && selectedEdges.length === 0 && onStartNodeEditing) {
+          event.preventDefault()
+          onStartNodeEditing(event.key)
+          return
+        }
       }
 
       // Duplicate: Cmd/Ctrl + D
@@ -272,6 +295,8 @@ export function useKeyboardShortcuts({
     onDelete,
     onCopy,
     onPaste,
+    onPasteText,
+    onStartNodeEditing,
     onDuplicate,
     handleSelectAll,
     handleDeselect,

--- a/frontend/src/features/dfd-editor/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/features/dfd-editor/hooks/useKeyboardShortcuts.ts
@@ -41,6 +41,18 @@ export function useKeyboardShortcuts({
 }: UseKeyboardShortcutsOptions = {}) {
   const { getNodes, getEdges, setNodes, setEdges } = useReactFlow()
 
+  const isEditingTarget = useCallback((target: EventTarget | null) => {
+    const element = target as HTMLElement | null
+    return Boolean(
+      element && (
+        element.tagName === 'INPUT' ||
+        element.tagName === 'TEXTAREA' ||
+        element.isContentEditable ||
+        element.closest?.('[role="dialog"], [role="alertdialog"]')
+      )
+    )
+  }, [])
+
   // Default delete handler
   const handleDelete = useCallback(() => {
     const nodes = getNodes() as DiagramNode[]
@@ -180,15 +192,7 @@ export function useKeyboardShortcuts({
     const handleKeyDown = (event: KeyboardEvent) => {
       // Don't handle shortcuts when typing in inputs or while focus is
       // inside a modal — canvas edits behind an open dialog are invisible
-      const target = event.target as HTMLElement
-      if (
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.isContentEditable ||
-        target.closest?.('[role="dialog"], [role="alertdialog"]')
-      ) {
-        return
-      }
+      if (isEditingTarget(event.target)) return
 
       const isMod = event.metaKey || event.ctrlKey
       const key = event.key.toLowerCase()
@@ -244,14 +248,14 @@ export function useKeyboardShortcuts({
 
       // Paste: Cmd/Ctrl + V
       if (isMod && key === 'v') {
-        event.preventDefault()
         const selectedNodes = (getNodes() as DiagramNode[]).filter((n) => n.selected)
         const selectedEdges = (getEdges() as DiagramEdge[]).filter((e) => e.selected)
         if (selectedNodes.length === 1 && selectedEdges.length === 0 && onPasteText) {
-          void navigator.clipboard?.readText().then((text) => {
-            if (text) onPasteText(text)
-          })
+          // Let the browser dispatch its trusted paste event. The clipboard
+          // payload is read there, avoiding a permissions prompt from
+          // navigator.clipboard.readText().
         } else {
+          event.preventDefault()
           ;(onPaste || handlePaste)()
         }
         return
@@ -283,8 +287,26 @@ export function useKeyboardShortcuts({
       }
     }
 
+    const handlePasteEvent = (event: ClipboardEvent) => {
+      if (isEditingTarget(event.target)) return
+
+      const selectedNodes = (getNodes() as DiagramNode[]).filter((n) => n.selected)
+      const selectedEdges = (getEdges() as DiagramEdge[]).filter((e) => e.selected)
+      if (selectedNodes.length !== 1 || selectedEdges.length > 0 || !onPasteText) return
+
+      const text = event.clipboardData?.getData('text/plain') ?? ''
+      if (!text) return
+
+      event.preventDefault()
+      onPasteText(text)
+    }
+
     document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
+    document.addEventListener('paste', handlePasteEvent)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('paste', handlePasteEvent)
+    }
   }, [
     enabled,
     onSave,
@@ -298,12 +320,15 @@ export function useKeyboardShortcuts({
     onPasteText,
     onStartNodeEditing,
     onDuplicate,
+    isEditingTarget,
     handleSelectAll,
     handleDeselect,
     handleDelete,
     handleCopy,
     handlePaste,
     handleDuplicate,
+    getNodes,
+    getEdges,
   ])
 
   return {

--- a/frontend/src/features/guest-editor/GuestDFDEditor.tsx
+++ b/frontend/src/features/guest-editor/GuestDFDEditor.tsx
@@ -287,10 +287,28 @@ function GuestDFDEditorContent() {
     }
   }, [boundaryMode, cancelBoundaryMode])
 
+  const startNodeEditing = useCallback((initialText: string) => {
+    setNodes((currentNodes) => currentNodes.map((node) =>
+      node.selected
+        ? { ...node, data: { ...node.data, label: initialText, isInlineEditing: true } }
+        : node
+    ))
+  }, [setNodes])
+
+  const pasteNodeLabel = useCallback((text: string) => {
+    setNodes((currentNodes) => currentNodes.map((node) =>
+      node.selected
+        ? { ...node, data: { ...node.data, label: text, isInlineEditing: true } }
+        : node
+    ))
+  }, [setNodes])
+
   // Keyboard shortcuts (save is a no-op in guest — handled by header download)
   useKeyboardShortcuts({
     onUndo: undo,
     onDeselect: handleDeselect,
+    onStartNodeEditing: startNodeEditing,
+    onPasteText: pasteNodeLabel,
     enabled: true,
   })
 


### PR DESCRIPTION
## Summary

- Start renaming a selected component by typing its replacement name.
- Paste clipboard text directly into a selected component with `Ctrl/Cmd + V`.
- Preserve normal node copy/paste behavior for multi-selection and edge selection.
- Use the trusted paste event to avoid browser clipboard permission prompts.

[Screencast From 2026-08-29 12-00-31.webm](https://github.com/user-attachments/assets/52ec2f9c-e320-42c3-9e92-704ddee318f4)


Closes #299
