### PR TITLE
Reconnect dataflow endpoints

### DIFF
--- a/frontend/src/features/dfd-editor/DFDEditor.tsx
+++ b/frontend/src/features/dfd-editor/DFDEditor.tsx
@@ -11,6 +11,7 @@ import {
   type Connection,
   type XYPosition,
   addEdge,
+  reconnectEdge,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { ArrowLeft, Save, Clock, Loader2, Pencil, Trash2, ShieldAlert } from 'lucide-react'
@@ -312,6 +313,13 @@ function DFDEditorContent() {
     [nodes, setEdges]
   )
 
+  const handleReconnect = useCallback(
+    (oldEdge: DiagramEdge, connection: Connection) => {
+      setEdges((currentEdges) => reconnectEdge(oldEdge, connection, currentEdges) as DiagramEdge[])
+    },
+    [setEdges]
+  )
+
   // Handle template insertion
   const handleInsertTemplate = useCallback(
     (templateNodes: DiagramNode[], templateEdges: DiagramEdge[]) => {
@@ -607,6 +615,8 @@ function DFDEditorContent() {
               onNodesChange={onNodesChange}
               onEdgesChange={onEdgesChange}
               onConnect={handleConnect}
+              onReconnect={handleReconnect}
+              edgesReconnectable
               onNodeClick={handleNodeClick}
               onNodeDoubleClick={handleNodeDoubleClick}
               onEdgeClick={handleEdgeClick}

--- a/frontend/src/features/guest-editor/GuestDFDEditor.tsx
+++ b/frontend/src/features/guest-editor/GuestDFDEditor.tsx
@@ -10,6 +10,7 @@ import {
   type Connection,
   type XYPosition,
   addEdge,
+  reconnectEdge,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { useOutletContext } from 'react-router-dom'
@@ -270,6 +271,13 @@ function GuestDFDEditorContent() {
     [nodes, setEdges]
   )
 
+  const handleReconnect = useCallback(
+    (oldEdge: DiagramEdge, connection: Connection) => {
+      setEdges((currentEdges) => reconnectEdge(oldEdge, connection, currentEdges) as DiagramEdge[])
+    },
+    [setEdges]
+  )
+
   // Sync selected node/edge with current data
   const currentSelectedNode = selectedNode
     ? (nodes.find((n) => n.id === selectedNode.id) as DiagramNode | undefined)
@@ -330,6 +338,8 @@ function GuestDFDEditorContent() {
               onNodesChange={onNodesChange}
               onEdgesChange={onEdgesChange}
               onConnect={handleConnect}
+              onReconnect={handleReconnect}
+              edgesReconnectable
               onNodeClick={handleNodeClick}
               onNodeDoubleClick={handleNodeDoubleClick}
               onEdgeClick={handleEdgeClick}


### PR DESCRIPTION
## Summary

- Allow existing dataflows to reconnect to a different source or destination component.
- Preserve the dataflow's existing properties during reconnection.
- Enable the behavior in both authenticated and guest editors.

[Screencast From 2026-08-29 18-45-07.webm](https://github.com/user-attachments/assets/cc4d6880-8606-4d01-ab89-950ff9674262)


## Testing

- Reconnected both source and target endpoints.
- Verified dataflow properties remained intact.
- Tested authenticated and guest editor flows.

Closes #305
