### PR TITLE
Refresh stale risk residual scores

### DIFF
--- a/frontend/src/features/threat-models/api/threats.ts
+++ b/frontend/src/features/threat-models/api/threats.ts
@@ -7,6 +7,7 @@ import { api } from '@/lib/api'
 import type { ComponentThreat, ComponentThreatCountermeasure, CountermeasureStatus } from '@/features/dfd-editor/types/threat-analysis'
 import type { TaxonomyEntry } from '@/types/domain'
 import { componentKeys } from './components'
+import { riskKeys } from './risks'
 
 // Backend countermeasure status (aligned with frontend CountermeasureStatus)
 type BackendCountermeasureStatus = 'platform' | 'gap' | 'planned' | 'verified' | 'waived'
@@ -317,6 +318,7 @@ export function useCreateCountermeasure() {
       queryClient.invalidateQueries({ queryKey: ['threat-model-threats'] })
       queryClient.invalidateQueries({ queryKey: ['threat-models'] })
       queryClient.invalidateQueries({ queryKey: ['countermeasures-in-use'] })
+      queryClient.invalidateQueries({ queryKey: riskKeys.all })
     },
   })
 }
@@ -357,6 +359,7 @@ export function useApplyCountermeasure() {
       queryClient.invalidateQueries({ queryKey: ['threat-model-threats'] })
       queryClient.invalidateQueries({ queryKey: ['threat-models'] })
       queryClient.invalidateQueries({ queryKey: ['countermeasures-in-use'] })
+      queryClient.invalidateQueries({ queryKey: riskKeys.all })
     },
   })
 }
@@ -534,6 +537,7 @@ export function useUpdateCountermeasure() {
       queryClient.invalidateQueries({ queryKey: threatKeys.all })
       queryClient.invalidateQueries({ queryKey: ['threat-model-threats'] })
       queryClient.invalidateQueries({ queryKey: ['threat-models'] })
+      queryClient.invalidateQueries({ queryKey: riskKeys.all })
     },
   })
 }
@@ -553,6 +557,7 @@ export function useDeleteCountermeasure() {
       queryClient.invalidateQueries({ queryKey: ['threat-model-threats'] })
       queryClient.invalidateQueries({ queryKey: ['threat-models'] })
       queryClient.invalidateQueries({ queryKey: ['countermeasures-in-use'] })
+      queryClient.invalidateQueries({ queryKey: riskKeys.all })
     },
   })
 }
@@ -843,6 +848,7 @@ export function useLinkCountermeasure() {
       queryClient.invalidateQueries({ queryKey: ['threat-model-threats'] })
       queryClient.invalidateQueries({ queryKey: ['countermeasures-in-use'] })
       queryClient.invalidateQueries({ queryKey: ['threat-models'] })
+      queryClient.invalidateQueries({ queryKey: riskKeys.all })
     },
   })
 }
@@ -872,6 +878,7 @@ export function useUnlinkCountermeasure() {
       queryClient.invalidateQueries({ queryKey: ['threat-model-threats'] })
       queryClient.invalidateQueries({ queryKey: ['countermeasures-in-use'] })
       queryClient.invalidateQueries({ queryKey: ['threat-models'] })
+      queryClient.invalidateQueries({ queryKey: riskKeys.all })
     },
   })
 }

--- a/frontend/src/features/threat-models/components/workspace/RiskAnalysisTab.tsx
+++ b/frontend/src/features/threat-models/components/workspace/RiskAnalysisTab.tsx
@@ -502,7 +502,6 @@ function RiskDetailPanel({
 }) {
   const { data: riskDetail } = useRisk(threatModelId, risk.id)
   const displayRisk = riskDetail ?? risk
-  const recalculate = useRecalculateRisk(threatModelId)
   const updateRisk = useUpdateRisk(threatModelId)
   const { data: scoringMethods } = useScoringMethods()
   const scoringMethodLabel =
@@ -550,9 +549,6 @@ function RiskDetailPanel({
                 ))}
               </SelectContent>
             </Select>
-            <Button variant="ghost" size="sm" onClick={() => recalculate.mutate(risk.id)} disabled={recalculate.isPending}>
-              <RefreshCw className={`h-3 w-3 ${recalculate.isPending ? 'animate-spin' : ''}`} />
-            </Button>
           </div>
         </div>
 
@@ -753,6 +749,8 @@ function TableView({
   onToggleSelect,
   onToggleSelectAll,
   onDeleteRisk,
+  onRecalculateRisk,
+  recalculatingRiskId,
 }: {
   risks: Risk[]
   selectedRiskId: number | null
@@ -761,6 +759,8 @@ function TableView({
   onToggleSelect: (id: number) => void
   onToggleSelectAll: () => void
   onDeleteRisk: (id: number) => void
+  onRecalculateRisk: (id: number) => void
+  recalculatingRiskId: number | null
 }) {
   const allSelected = risks.length > 0 && selectedIds.length === risks.length
 
@@ -783,7 +783,7 @@ function TableView({
             <TableHead className="w-[120px]">Response</TableHead>
             <TableHead className="w-[140px]">Owner</TableHead>
             <TableHead className="w-[80px]">Threats</TableHead>
-            <TableHead className="w-[60px]" />
+            <TableHead className="w-[100px]">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -820,7 +820,20 @@ function TableView({
               <TableCell className="text-center text-sm text-muted-foreground">
                 {risk.threatCount}
               </TableCell>
-              <TableCell>
+              <TableCell className="whitespace-nowrap">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  title="Recalculate residual risk"
+                  aria-label={`Recalculate residual risk for ${risk.name}`}
+                  disabled={recalculatingRiskId === risk.id}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onRecalculateRisk(risk.id)
+                  }}
+                >
+                  <RefreshCw className={`h-3.5 w-3.5 text-muted-foreground ${recalculatingRiskId === risk.id ? 'animate-spin' : ''}`} />
+                </Button>
                 <Button
                   variant="ghost"
                   size="sm"
@@ -854,6 +867,7 @@ export function RiskAnalysisTab({
   const { data: risks, isLoading } = useRisks(threatModelId)
   const { data: scoringMethods } = useScoringMethods()
   const deleteRisk = useDeleteRisk(threatModelId)
+  const recalculateRisk = useRecalculateRisk(threatModelId)
 
   const selectedRisk = risks?.find((r) => r.id === selectedRiskId)
   const activeScoringMethod = scoringMethods?.find((m) => m.key === riskScoringMethod)
@@ -974,6 +988,8 @@ export function RiskAnalysisTab({
                 onToggleSelect={handleToggleSelect}
                 onToggleSelectAll={handleToggleSelectAll}
                 onDeleteRisk={setDeleteRiskId}
+                onRecalculateRisk={(riskId) => recalculateRisk.mutate(riskId)}
+                recalculatingRiskId={recalculateRisk.isPending ? recalculateRisk.variables ?? null : null}
               />
             ) : (
               <KanbanBoard


### PR DESCRIPTION
## Summary

- Refresh risk data after countermeasure create, apply, update, delete, link, and unlink operations.
- Add a clearly labeled recalculation action to each risk row in the Actions column.
- Show a loading state while a row is being recalculated.
- Keep recalculation out of the expanded risk detail panel.

[Screencast From 2026-08-30 00-47-58.webm](https://github.com/user-attachments/assets/f6b60bcf-99bc-4b3c-a248-113c6016f614)


## Issue

Closes #388