### PR TITLE
fix(systems): close the trust zone leaks, and make every model declare its owner

### DIFF
--- a/backend/apps/ai/models.py
+++ b/backend/apps/ai/models.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.db import models
 
 from apps.core.models import TimestampedModel
+from apps.core.tenancy import Tenancy
 
 from .crypto import decrypt, encrypt
 from .providers.base import ResolvedConfig
@@ -21,6 +22,8 @@ from .providers.base import ResolvedConfig
 
 class AIProviderConfig(TimestampedModel):
     """An organization's configuration for one AI model endpoint."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class ProviderType(models.TextChoices):
         # Only OpenAI-compatible endpoints are supported today. New, non-
@@ -114,6 +117,8 @@ class AIUsageRecord(TimestampedModel):
     system. ``model``/``provider_type`` are snapshots so history stays correct
     when a config is later edited or deleted.
     """
+
+    tenancy = Tenancy.TENANT_OWNED
 
     organization = models.ForeignKey(
         "organizations.Organization",

--- a/backend/apps/compliance/models.py
+++ b/backend/apps/compliance/models.py
@@ -5,11 +5,16 @@ Compliance models - frameworks, standards.
 from django.db import models
 
 from apps.core.models import TimestampedModel
+from apps.core.tenancy import Tenancy
 from apps.threats.models import CountermeasureLibrary
 
 
 class StandardFramework(TimestampedModel):
     """Compliance framework (e.g., PCI-DSS, SOC2, NIST)."""
+
+    # The user-created internal standards are unscoped today: every tenant reads
+    # them — precogly/precogly#405.
+    tenancy = Tenancy.MIXED
 
     slug = models.SlugField(max_length=100, unique=True)
     source_pack = models.ForeignKey(
@@ -43,6 +48,10 @@ class StandardFramework(TimestampedModel):
 class StandardRequirement(TimestampedModel):
     """Requirement within a compliance framework."""
 
+    # No nullable key of its own; a requirement belongs to whoever its framework
+    # belongs to.
+    tenancy = Tenancy.MIXED
+
     framework = models.ForeignKey(
         StandardFramework,
         on_delete=models.CASCADE,
@@ -73,6 +82,10 @@ class StandardRequirement(TimestampedModel):
 
 class CountermeasureLibraryStandard(models.Model):
     """Association between countermeasure and compliance requirement."""
+
+    # Both ends are library rows, so the mapping ships with the packs rather than
+    # belonging to whoever happens to use it.
+    tenancy = Tenancy.SHARED_REFERENCE
 
     class Sufficiency(models.TextChoices):
         FULL = "full", "Full"
@@ -109,6 +122,9 @@ class StandardRequirementMapping(models.Model):
     Example: NIST CSF PR.AC-4 partially covers OWASP A01:2021.
     Used for gap analysis between compliance standards.
     """
+
+    # A statement about two published standards, true for every installation.
+    tenancy = Tenancy.SHARED_REFERENCE
 
     class Sufficiency(models.TextChoices):
         FULL = "full", "Full"

--- a/backend/apps/compliance/models.py
+++ b/backend/apps/compliance/models.py
@@ -98,7 +98,9 @@ class CountermeasureLibraryStandard(models.Model):
         unique_together = ["countermeasure_library", "requirement"]
 
     def __str__(self):
-        return f"{self.countermeasure_library} -> {self.requirement} ({self.sufficiency})"
+        return (
+            f"{self.countermeasure_library} -> {self.requirement} ({self.sufficiency})"
+        )
 
 
 class StandardRequirementMapping(models.Model):

--- a/backend/apps/core/apps.py
+++ b/backend/apps/core/apps.py
@@ -5,3 +5,7 @@ class CoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.core"
     verbose_name = "Core"
+
+    def ready(self):
+        # Importing registers the checks; nothing else uses the module.
+        from apps.core import checks  # noqa: F401

--- a/backend/apps/core/checks.py
+++ b/backend/apps/core/checks.py
@@ -1,0 +1,80 @@
+"""Startup checks that hold conventions the type system cannot.
+
+Registered from `CoreConfig.ready`.
+"""
+
+from django.apps import apps as django_apps
+from django.core.checks import Error, register
+
+from apps.core.tenancy import Tenancy
+
+# Only Precogly's own models are asked to declare. Django's own tables, allauth's, and
+# every other dependency's are outside the question — nothing here scopes them and
+# nothing here may change them.
+DECLARING_APPS = frozenset(
+    {
+        "ai",
+        "compliance",
+        "core",
+        "diagrams",
+        "organizations",
+        "packs",
+        "systems",
+        "threat_models",
+        "threats",
+    }
+)
+
+
+@register()
+def every_model_declares_its_tenancy(app_configs, **kwargs):
+    """Refuse to start if a model in `apps/` has not said who its rows belong to.
+
+    The point is the models that do not exist yet. A new model added without a
+    `tenancy` attribute fails here on the first `manage.py` command rather than
+    reaching review as an unscoped queryset nobody thought to ask about — which is how
+    #404 and #405 arrived.
+
+    Inheritance is checked deliberately with `vars()` rather than `getattr`: a concrete
+    model inheriting another concrete model would otherwise pick up its parent's answer
+    silently, and the parent's answer is not evidence about the child.
+
+    `app_configs` is honoured rather than ignored, so `manage.py check organizations`
+    reports on that app alone. It is also the seam the tests use: under `isolate_apps`
+    the models being checked are not in the global registry, and a check that only ever
+    read `django_apps` could not see them.
+    """
+    if app_configs is None:
+        models = django_apps.get_models()
+    else:
+        models = [model for config in app_configs for model in config.get_models()]
+
+    errors = []
+
+    for model in models:
+        if model._meta.app_label not in DECLARING_APPS:
+            continue
+
+        declared = vars(model).get("tenancy")
+        if isinstance(declared, Tenancy):
+            continue
+
+        if declared is None:
+            hint = (
+                "Add `tenancy = Tenancy.TENANT_OWNED` if every row belongs to one "
+                "organization, or `Tenancy.SHARED_REFERENCE` if every installation "
+                "holds the same rows. See apps/core/tenancy.py."
+            )
+        else:
+            hint = f"`tenancy` is {declared!r}; it must be a `Tenancy` member."
+
+        errors.append(
+            Error(
+                f"{model._meta.label} does not declare its tenancy.",
+                hint=hint,
+                obj=model,
+                id="precogly.E001",
+            )
+        )
+
+    return errors

--- a/backend/apps/core/tenancy.py
+++ b/backend/apps/core/tenancy.py
@@ -1,0 +1,102 @@
+"""Whether a model's rows belong to one organization or to every installation.
+
+Precogly serves several organizations from one database, and the rule keeping them
+apart has been written once per viewset — as a join from the caller's memberships to
+whatever the model happens to hang off. Measured across the 61 models in `apps/`, 38
+of the 43 that reach `Organization` do so by more than one path, all 38 through a
+nullable foreign key somewhere along the way, and three models that hold customer
+data — `TrustZone`, `TrustBoundary`, `VerificationTest` — reach it by no forward path
+at all. So each of those joins is a guess, nothing checks it, and
+six cross-tenant defects have been found by hand (#226, #227, #404, #405, #406, #258).
+
+The fact that no join can recover is which kind of row a table holds. That is what
+this module records, and `apps.core.checks` is what makes recording it compulsory.
+Declaring is all it does: no column moves and no query changes. Giving tenant-owned
+models a non-null `organization` column, and enforcing the boundary against it, are
+separate and later.
+
+Usage, as a plain class attribute beside the fields:
+
+```python
+class Orgsystem(TimestampedModel):
+    tenancy = Tenancy.TENANT_OWNED
+
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    ...
+```
+"""
+
+import enum
+
+
+class Tenancy(enum.Enum):
+    """Who a row belongs to.
+
+    A model declares exactly one of these. `apps.core.checks` refuses to start with a
+    model that declares none, so the question cannot be skipped by forgetting it.
+    """
+
+    TENANT_OWNED = "tenant-owned"
+    """Every row belongs to exactly one organization.
+
+    Reading a row as a member of another organization is a leak, and writing one is
+    worse. These are the models that gain a non-null `organization` column when the
+    boundary becomes a column; today it is still whatever join each viewset writes.
+    """
+
+    SHARED_REFERENCE = "shared-reference"
+    """Every installation holds the same rows, and every organization may read them.
+
+    Library packs, taxonomies, and the reference data imported from them. There is no
+    organization to scope by and no leak to prevent — an unscoped queryset here is
+    correct, which is why a check that only asks "is this queryset scoped" cannot be
+    the whole answer.
+    """
+
+    MIXED = "mixed"
+    """The table holds both kinds of row, and nothing in it says which is which.
+
+    A defect. It is recorded rather than fixed here only because fixing it is a
+    migration; `MIXED_MODELS` below pins the six that exist so the set can shrink and
+    cannot grow.
+
+    `StandardFramework` is the clearest case and says so in its own field:
+
+        help_text="Populated for user-created internal standards. "
+                  "NULL for global pack-sourced frameworks."
+
+    `ThreatLibrary`, `CountermeasureLibrary`, `ComponentLibrary`, and
+    `DFDTemplatesLibrary` repeat the shape with `source_pack` — "Pack this item came
+    from (null = custom or legacy)". Where the tenant-authored rows carry no owner,
+    every organization reads them; #405 is that bug on `StandardFramework`.
+
+    One table is not itself the defect, and there is a real reason these are shaped
+    this way: one table is one foreign-key target. `ThreatLibrary` has six incoming
+    foreign keys and `StandardRequirement` five, so splitting them turns each into a
+    nullable pair or a generic relation, and a `ComponentInstanceThreat` would have to
+    record which of two tables it points at.
+
+    The defect is that ownership is *inferred* from a key that exists for another
+    purpose. `source_pack` records provenance and `threat_model` records attachment;
+    reading either as "and therefore nobody owns this row" is the step nothing checks.
+    Removing that inference is what these six are owed — by splitting them, or by
+    giving them an explicit owner column that means only that. Which of the two is per
+    table, and the incoming-foreign-key counts above are the argument.
+    """
+
+
+# The models that hold both kinds of row today. A pinned list rather than a derived
+# one: `Tenancy.MIXED` is a defect being carried, and the point of naming it here is
+# that `apps.core.tests.test_tenancy_check` fails if the set grows. Removing an entry
+# means the table was split or given an explicit owner column, and that is the only
+# direction this list may move.
+MIXED_MODELS = frozenset(
+    {
+        "compliance.StandardFramework",
+        "compliance.StandardRequirement",
+        "diagrams.DFDTemplatesLibrary",
+        "systems.ComponentLibrary",
+        "threats.CountermeasureLibrary",
+        "threats.ThreatLibrary",
+    }
+)

--- a/backend/apps/core/tests/test_tenancy_check.py
+++ b/backend/apps/core/tests/test_tenancy_check.py
@@ -1,0 +1,128 @@
+"""What the tenancy check accepts, and what it refuses.
+
+The check exists for models that do not exist yet, so the case that matters is a new
+model added without an answer. `isolate_apps` is how that is written without adding a
+real model to the tree: models defined inside it are registered for the duration of the
+test and never reach a migration.
+
+Those models live in a registry of their own rather than the global one, which is why
+each test passes the isolated app config in as `app_configs` — reading
+`django.apps.apps` would report on the real tree and never see them.
+"""
+
+from django.apps import apps as django_apps
+from django.db import models
+from django.test import SimpleTestCase
+from django.test.utils import isolate_apps
+
+from apps.core.checks import DECLARING_APPS, every_model_declares_its_tenancy
+from apps.core.tenancy import MIXED_MODELS, Tenancy
+
+
+def _ids(errors):
+    return [error.id for error in errors]
+
+
+def _check(isolated_apps):
+    return every_model_declares_its_tenancy(
+        app_configs=[isolated_apps.get_app_config("core")]
+    )
+
+
+class TenancyCheckTests(SimpleTestCase):
+    def test_the_tree_as_it_stands_passes(self):
+        """Every model in `apps/` has answered. This is the check doing its job."""
+        self.assertEqual(every_model_declares_its_tenancy(app_configs=None), [])
+
+    @isolate_apps("apps.core", kwarg_name="isolated_apps")
+    def test_a_model_with_no_declaration_is_an_error(self, isolated_apps):
+        class Undeclared(models.Model):
+            name = models.CharField(max_length=10)
+
+        errors = _check(isolated_apps)
+        self.assertEqual(_ids(errors), ["precogly.E001"])
+        self.assertIs(errors[0].obj, Undeclared)
+
+    @isolate_apps("apps.core", kwarg_name="isolated_apps")
+    def test_either_value_satisfies_it(self, isolated_apps):
+        class OwnedByOneOrganization(models.Model):
+            tenancy = Tenancy.TENANT_OWNED
+
+        class ShippedWithEveryInstall(models.Model):
+            tenancy = Tenancy.SHARED_REFERENCE
+
+        self.assertEqual(_check(isolated_apps), [])
+
+    @isolate_apps("apps.core", kwarg_name="isolated_apps")
+    def test_a_value_that_is_not_a_tenancy_member_is_an_error(self, isolated_apps):
+        """A string that looks right is still not an answer.
+
+        `tenancy = "tenant-owned"` would otherwise pass a truthiness test and give
+        step 3 something it cannot dispatch on.
+        """
+
+        class DeclaredAsAString(models.Model):
+            tenancy = "tenant-owned"
+
+        errors = _check(isolated_apps)
+        self.assertEqual(_ids(errors), ["precogly.E001"])
+        self.assertIs(errors[0].obj, DeclaredAsAString)
+
+    @isolate_apps("apps.core", kwarg_name="isolated_apps")
+    def test_a_declaration_is_not_inherited_from_a_concrete_parent(self, isolated_apps):
+        """A subclass has to answer for itself.
+
+        Multi-table inheritance would otherwise let a child pick up its parent's answer
+        silently, and the parent's answer is not evidence about the child's — the child
+        may add exactly the foreign key that changes it.
+        """
+
+        class DeclaredParent(models.Model):
+            tenancy = Tenancy.SHARED_REFERENCE
+
+        class SilentChild(DeclaredParent):
+            pass
+
+        errors = _check(isolated_apps)
+        self.assertEqual(_ids(errors), ["precogly.E001"])
+        self.assertIs(errors[0].obj, SilentChild)
+
+
+class MixedModelsTests(SimpleTestCase):
+    """`Tenancy.MIXED` is a defect being carried, so the set of them may only shrink.
+
+    A table holding both shared and tenant-owned rows tells them apart by a key that
+    exists for another purpose — `source_pack` records provenance, `threat_model`
+    records attachment — and reading either as "therefore nobody owns this row" is the
+    inference that leaked in #405. A new one must not be added quietly; removing one
+    means it was split or given an explicit owner column.
+    """
+
+    def test_no_model_has_become_mixed(self):
+        declared = {
+            model._meta.label
+            for model in django_apps.get_models()
+            if model._meta.app_label in DECLARING_APPS
+            and vars(model).get("tenancy") is Tenancy.MIXED
+        }
+        self.assertEqual(
+            declared - MIXED_MODELS,
+            set(),
+            "A model has been declared MIXED without being added to MIXED_MODELS. "
+            "Splitting the table or giving it an explicit owner column is the fix; "
+            "see Tenancy.MIXED in apps/core/tenancy.py.",
+        )
+
+    def test_a_model_that_stopped_being_mixed_is_removed_from_the_list(self):
+        declared = {
+            model._meta.label
+            for model in django_apps.get_models()
+            if model._meta.app_label in DECLARING_APPS
+            and vars(model).get("tenancy") is Tenancy.MIXED
+        }
+        self.assertEqual(
+            MIXED_MODELS - declared,
+            set(),
+            "MIXED_MODELS names a model that no longer declares MIXED. Delete the "
+            "entry — the list is the record of what is still outstanding.",
+        )

--- a/backend/apps/diagrams/models.py
+++ b/backend/apps/diagrams/models.py
@@ -6,10 +6,13 @@ from django.conf import settings
 from django.db import models
 
 from apps.core.models import TimestampedModel
+from apps.core.tenancy import Tenancy
 
 
 class DFDTemplatesLibrary(TimestampedModel):
     """DFD template library."""
+
+    tenancy = Tenancy.MIXED
 
     class DiagramType(models.TextChoices):
         CONTEXT = "context", "Context"
@@ -100,6 +103,8 @@ class DFDTemplatesLibrary(TimestampedModel):
 
 class DFD(TimestampedModel):
     """Data Flow Diagram."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class DiagramType(models.TextChoices):
         CONTEXT = "context", "Context"

--- a/backend/apps/diagrams/models.py
+++ b/backend/apps/diagrams/models.py
@@ -34,7 +34,11 @@ class DFDTemplatesLibrary(TimestampedModel):
         blank=True,
         help_text="Unique identifier within pack, e.g., 'banking-webapp-l1'",
     )
-    qualified_slug = models.CharField(
+    # `null=True` is required by `unique_dfdtemplate_qualified_slug` below. Postgres
+    # treats NULLs as distinct under a unique index, so any number of rows may carry no
+    # qualified slug; `blank=True` with `""` would make the second such row collide
+    # with the first. DJ001 cannot see the constraint.
+    qualified_slug = models.CharField(  # noqa: DJ001
         max_length=200,
         null=True,
         blank=True,

--- a/backend/apps/diagrams/services.py
+++ b/backend/apps/diagrams/services.py
@@ -249,7 +249,7 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
 
     with transaction.atomic():
         # Sync trust zone nodes first (zones must exist before component assignment)
-        zone_result = _sync_nodes_to_trust_zones(dfd, nodes)
+        zone_result = _sync_nodes_to_trust_zones(dfd, nodes, threat_model)
         node_zone_map = zone_result["node_zone_map"]
 
         # Sync system scope nodes to Orgsystem records
@@ -518,7 +518,9 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
         flow_result = _sync_edges_to_dataflows(dfd, edges, node_component_map)
 
         # Sync trust boundary edges to TrustBoundary DB records
-        boundary_result = _sync_edges_to_trust_boundaries(dfd, edges, node_zone_map)
+        boundary_result = _sync_edges_to_trust_boundaries(
+            dfd, edges, node_zone_map, threat_model
+        )
 
         # Clean up orphaned records (nodes/edges removed since last save)
         if old_canvas_data:
@@ -1001,13 +1003,19 @@ def _generate_threats_for_dataflow(dataflow):
     return created_count
 
 
-def _sync_nodes_to_trust_zones(dfd, nodes):
+def _sync_nodes_to_trust_zones(dfd, nodes, threat_model):
     """Sync trust zone canvas nodes to TrustZone DB records."""
     trust_zone_nodes = [node for node in nodes if node.get("type") == "trustZone"]
 
     synced_count = 0
     created_count = 0
     node_zone_map = {}  # canvas node_id -> TrustZone DB id
+
+    # `trust_zone_id` below is caller-supplied canvas data, so the lookup is scoped
+    # to the diagram's own organization. Unscoped it renamed and reclassified another
+    # tenant's zone — precogly/precogly#406. Taken from the threat model rather than
+    # `dfd.threat_model`, which is nullable.
+    org_id = threat_model.organization_id
 
     for node in trust_zone_nodes:
         node_id = node.get("id")
@@ -1030,6 +1038,7 @@ def _sync_nodes_to_trust_zones(dfd, nodes):
                 synced_count += 1
             except TrustZone.DoesNotExist:
                 trust_zone = TrustZone.objects.create(
+                    organization_id=org_id,
                     name=label,
                     trust_level=trust_level,
                     description=description,
@@ -1037,6 +1046,7 @@ def _sync_nodes_to_trust_zones(dfd, nodes):
                 created_count += 1
         else:
             trust_zone = TrustZone.objects.create(
+                organization_id=org_id,
                 name=label,
                 trust_level=trust_level,
                 description=description,
@@ -1179,11 +1189,15 @@ def _update_canvas_with_orgsystem_ids(dfd, node_system_map):
         dfd.save(update_fields=["canvas_data"])
 
 
-def _sync_edges_to_trust_boundaries(dfd, edges, node_zone_map):
+def _sync_edges_to_trust_boundaries(dfd, edges, node_zone_map, threat_model):
     """Sync trust boundary edges to TrustBoundary DB records."""
     synced_count = 0
     created_count = 0
     edge_boundary_map = {}
+
+    # Same reason as `_sync_nodes_to_trust_zones`: `trust_boundary_id` arrives in the
+    # canvas payload, so the lookup is scoped rather than taken on trust.
+    org_id = threat_model.organization_id
 
     for edge in edges:
         if edge.get("type") != "trustBoundary":
@@ -1232,6 +1246,7 @@ def _sync_edges_to_trust_boundaries(dfd, edges, node_zone_map):
                 synced_count += 1
             except TrustBoundary.DoesNotExist:
                 boundary = TrustBoundary.objects.create(
+                    organization_id=org_id,
                     zone_a_id=zone_a_id,
                     zone_b_id=zone_b_id,
                     label=label,
@@ -1241,6 +1256,7 @@ def _sync_edges_to_trust_boundaries(dfd, edges, node_zone_map):
                 created_count += 1
         else:
             boundary = TrustBoundary.objects.create(
+                organization_id=org_id,
                 zone_a_id=zone_a_id,
                 zone_b_id=zone_b_id,
                 label=label,

--- a/backend/apps/diagrams/services.py
+++ b/backend/apps/diagrams/services.py
@@ -1030,7 +1030,9 @@ def _sync_nodes_to_trust_zones(dfd, nodes, threat_model):
 
         if existing_trust_zone_id:
             try:
-                trust_zone = TrustZone.objects.get(id=existing_trust_zone_id)
+                trust_zone = TrustZone.objects.get(
+                    id=existing_trust_zone_id, organization_id=org_id
+                )
                 trust_zone.name = label
                 trust_zone.trust_level = trust_level
                 trust_zone.description = description
@@ -1236,7 +1238,9 @@ def _sync_edges_to_trust_boundaries(dfd, edges, node_zone_map, threat_model):
 
         if existing_boundary_id:
             try:
-                boundary = TrustBoundary.objects.get(id=existing_boundary_id)
+                boundary = TrustBoundary.objects.get(
+                    id=existing_boundary_id, organization_id=org_id
+                )
                 boundary.zone_a_id = zone_a_id
                 boundary.zone_b_id = zone_b_id
                 boundary.label = label

--- a/backend/apps/diagrams/services.py
+++ b/backend/apps/diagrams/services.py
@@ -22,7 +22,6 @@ from apps.threats.models import (
     InstanceCountermeasure,
     Risk,
     RiskThreat,
-    ThreatLibrary,
     build_taxonomy_snapshot,
 )
 from apps.threats.services import recalculate_risk
@@ -99,15 +98,20 @@ def _cleanup_orphaned_records(old_canvas_data, new_canvas_data, threat_model):
     old_ids = _extract_backend_ids_from_canvas(old_canvas_data)
     new_ids = _extract_backend_ids_from_canvas(new_canvas_data)
 
-    orphaned_boundary_ids = old_ids["trust_boundary_ids"] - new_ids["trust_boundary_ids"]
+    orphaned_boundary_ids = (
+        old_ids["trust_boundary_ids"] - new_ids["trust_boundary_ids"]
+    )
     orphaned_dataflow_ids = old_ids["dataflow_ids"] - new_ids["dataflow_ids"]
     orphaned_component_ids = old_ids["component_ids"] - new_ids["component_ids"]
     orphaned_zone_ids = old_ids["trust_zone_ids"] - new_ids["trust_zone_ids"]
     orphaned_system_ids = old_ids["orgsystem_ids"] - new_ids["orgsystem_ids"]
 
     has_orphans = (
-        orphaned_boundary_ids or orphaned_dataflow_ids or orphaned_component_ids
-        or orphaned_zone_ids or orphaned_system_ids
+        orphaned_boundary_ids
+        or orphaned_dataflow_ids
+        or orphaned_component_ids
+        or orphaned_zone_ids
+        or orphaned_system_ids
     )
     if not has_orphans:
         return
@@ -125,7 +129,9 @@ def _cleanup_orphaned_records(old_canvas_data, new_canvas_data, threat_model):
         affected_risk_ids = list(
             RiskThreat.objects.filter(
                 flow_threat__data_flow_id__in=orphaned_dataflow_ids
-            ).values_list("risk_id", flat=True).distinct()
+            )
+            .values_list("risk_id", flat=True)
+            .distinct()
         )
 
         count, _ = DataFlow.objects.filter(id__in=orphaned_dataflow_ids).delete()
@@ -142,9 +148,15 @@ def _cleanup_orphaned_records(old_canvas_data, new_canvas_data, threat_model):
         affected_risk_ids = list(
             RiskThreat.objects.filter(
                 Q(component_threat__component_id__in=orphaned_component_ids)
-                | Q(flow_threat__data_flow__source_component_id__in=orphaned_component_ids)
-                | Q(flow_threat__data_flow__dest_component_id__in=orphaned_component_ids)
-            ).values_list("risk_id", flat=True).distinct()
+                | Q(
+                    flow_threat__data_flow__source_component_id__in=orphaned_component_ids
+                )
+                | Q(
+                    flow_threat__data_flow__dest_component_id__in=orphaned_component_ids
+                )
+            )
+            .values_list("risk_id", flat=True)
+            .distinct()
         )
 
         count, _ = OrgsystemComponent.objects.filter(
@@ -226,8 +238,7 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
     # Filter to analyzable nodes (process, datastore, humanActor, systemActor)
     # All of these can have associated threats and participate in data flows
     analyzable_nodes = [
-        node for node in nodes
-        if node.get("type") in ANALYZABLE_NODE_TYPES
+        node for node in nodes if node.get("type") in ANALYZABLE_NODE_TYPES
     ]
 
     synced_count = 0
@@ -262,13 +273,17 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
             # 1. Try component_library_id first (already resolved reference)
             component_library_id = node_data.get("component_library_id")
             if component_library_id:
-                component_library = ComponentLibrary.objects.filter(id=component_library_id).first()
+                component_library = ComponentLibrary.objects.filter(
+                    id=component_library_id
+                ).first()
 
             # 2. Try component_ref (slug reference from template)
             if not component_library:
                 component_ref = node_data.get("component_ref")
                 if component_ref:
-                    component_library = ComponentLibrary.objects.filter(slug=component_ref).first()
+                    component_library = ComponentLibrary.objects.filter(
+                        slug=component_ref
+                    ).first()
 
             # 3. Try technology field (legacy/manual assignment)
             if not component_library:
@@ -314,7 +329,9 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                                 Q(component_threat__component=component)
                                 | Q(flow_threat__data_flow__source_component=component)
                                 | Q(flow_threat__data_flow__dest_component=component)
-                            ).values_list("risk_id", flat=True).distinct()
+                            )
+                            .values_list("risk_id", flat=True)
+                            .distinct()
                         )
 
                         component.delete()
@@ -332,12 +349,18 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                             category=category,
                             description=node_data.get("description", ""),
                             actor_type=(
-                                node_data.get("actor_type", "") if node_type == "humanActor"
-                                else node_data.get("system_type", "") if node_type == "systemActor"
+                                node_data.get("actor_type", "")
+                                if node_type == "humanActor"
+                                else node_data.get("system_type", "")
+                                if node_type == "systemActor"
                                 else ""
                             ),
-                            data_store_type=node_data.get("data_store_type", "") if node_type == "datastore" else "",
-                            data_sensitivity_level=node_data.get("data_sensitivity", "") if node_type in ("process", "datastore") else "",
+                            data_store_type=node_data.get("data_store_type", "")
+                            if node_type == "datastore"
+                            else "",
+                            data_sensitivity_level=node_data.get("data_sensitivity", "")
+                            if node_type in ("process", "datastore")
+                            else "",
                         )
                         created_count += 1
                         all_synced_components.append(component)
@@ -352,9 +375,13 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                         elif node_type == "systemActor":
                             component.actor_type = node_data.get("system_type", "")
                         if node_type == "datastore":
-                            component.data_store_type = node_data.get("data_store_type", "")
+                            component.data_store_type = node_data.get(
+                                "data_store_type", ""
+                            )
                         if node_type in ("process", "datastore"):
-                            component.data_sensitivity_level = node_data.get("data_sensitivity", "")
+                            component.data_sensitivity_level = node_data.get(
+                                "data_sensitivity", ""
+                            )
                         # NOTE: Don't overwrite orgsystem - preserve user's system assignment
                         # Backfill threat_model if not set (for components created before this link existed)
                         if component.threat_model_id is None:
@@ -373,12 +400,18 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                         category=category,
                         description=node_data.get("description", ""),
                         actor_type=(
-                            node_data.get("actor_type", "") if node_type == "humanActor"
-                            else node_data.get("system_type", "") if node_type == "systemActor"
+                            node_data.get("actor_type", "")
+                            if node_type == "humanActor"
+                            else node_data.get("system_type", "")
+                            if node_type == "systemActor"
                             else ""
                         ),
-                        data_store_type=node_data.get("data_store_type", "") if node_type == "datastore" else "",
-                        data_sensitivity_level=node_data.get("data_sensitivity", "") if node_type in ("process", "datastore") else "",
+                        data_store_type=node_data.get("data_store_type", "")
+                        if node_type == "datastore"
+                        else "",
+                        data_sensitivity_level=node_data.get("data_sensitivity", "")
+                        if node_type in ("process", "datastore")
+                        else "",
                     )
                     created_count += 1
                     all_synced_components.append(component)
@@ -393,12 +426,18 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                     category=category,
                     description=node_data.get("description", ""),
                     actor_type=(
-                        node_data.get("actor_type", "") if node_type == "humanActor"
-                        else node_data.get("system_type", "") if node_type == "systemActor"
+                        node_data.get("actor_type", "")
+                        if node_type == "humanActor"
+                        else node_data.get("system_type", "")
+                        if node_type == "systemActor"
                         else ""
                     ),
-                    data_store_type=node_data.get("data_store_type", "") if node_type == "datastore" else "",
-                    data_sensitivity_level=node_data.get("data_sensitivity", "") if node_type in ("process", "datastore") else "",
+                    data_store_type=node_data.get("data_store_type", "")
+                    if node_type == "datastore"
+                    else "",
+                    data_sensitivity_level=node_data.get("data_sensitivity", "")
+                    if node_type in ("process", "datastore")
+                    else "",
                 )
                 created_count += 1
                 all_synced_components.append(component)
@@ -453,7 +492,11 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
                     system_id = node_system_map[walk_id]
 
                 # Stop early if all resolved
-                if zone_id and system_id and (parent_component_db_id or node.get("type") != "process"):
+                if (
+                    zone_id
+                    and system_id
+                    and (parent_component_db_id or node.get("type") != "process")
+                ):
                     break
 
                 ancestor_node = node_lookup.get(walk_id)
@@ -475,13 +518,13 @@ def sync_dfd_nodes_to_components(dfd, threat_model, old_canvas_data=None):
         flow_result = _sync_edges_to_dataflows(dfd, edges, node_component_map)
 
         # Sync trust boundary edges to TrustBoundary DB records
-        boundary_result = _sync_edges_to_trust_boundaries(
-            dfd, edges, node_zone_map
-        )
+        boundary_result = _sync_edges_to_trust_boundaries(dfd, edges, node_zone_map)
 
         # Clean up orphaned records (nodes/edges removed since last save)
         if old_canvas_data:
-            _cleanup_orphaned_records(old_canvas_data, dfd.canvas_data or {}, threat_model)
+            _cleanup_orphaned_records(
+                old_canvas_data, dfd.canvas_data or {}, threat_model
+            )
 
     return {
         "synced_count": synced_count,
@@ -571,8 +614,11 @@ def _generate_countermeasures_for_threat(threat_instance):
     Returns:
         Number of countermeasures created
     """
-    from apps.threats.models import CountermeasureLibrary, InstanceCountermeasureStandard
     from apps.compliance.models import CountermeasureLibraryStandard
+    from apps.threats.models import (
+        CountermeasureLibrary,
+        InstanceCountermeasureStandard,
+    )
 
     is_component_threat = isinstance(threat_instance, ComponentInstanceThreat)
 
@@ -583,13 +629,21 @@ def _generate_countermeasures_for_threat(threat_instance):
 
     # Resolve threat_model_id
     if is_component_threat:
-        threat_model_id = threat_instance.component.threat_model_id if threat_instance.component else None
+        threat_model_id = (
+            threat_instance.component.threat_model_id
+            if threat_instance.component
+            else None
+        )
     else:
         data_flow = threat_instance.data_flow
         threat_model_id = None
         if hasattr(data_flow, "source_component") and data_flow.source_component:
             threat_model_id = data_flow.source_component.threat_model_id
-        if not threat_model_id and hasattr(data_flow, "dest_component") and data_flow.dest_component:
+        if (
+            not threat_model_id
+            and hasattr(data_flow, "dest_component")
+            and data_flow.dest_component
+        ):
             threat_model_id = data_flow.dest_component.threat_model_id
 
     if not threat_model_id:
@@ -603,8 +657,7 @@ def _generate_countermeasures_for_threat(threat_instance):
         threat_model_id=threat_model_id
     ).values_list("library_pack_id", flat=True)
     applicable_countermeasures = applicable_countermeasures.filter(
-        Q(source_pack_id__in=connected_pack_ids)
-        | Q(source_pack__isnull=True)
+        Q(source_pack_id__in=connected_pack_ids) | Q(source_pack__isnull=True)
     )
 
     threat_model = ThreatModel.objects.get(id=threat_model_id)
@@ -619,9 +672,15 @@ def _generate_countermeasures_for_threat(threat_instance):
             countermeasure_library=countermeasure_library,
             defaults={
                 "status": countermeasure_status,
-                "countermeasure_name": countermeasure_library.name if countermeasure_library else "",
-                "countermeasure_description": countermeasure_library.description if countermeasure_library else "",
-                "control_type": countermeasure_library.control_type if countermeasure_library else "",
+                "countermeasure_name": countermeasure_library.name
+                if countermeasure_library
+                else "",
+                "countermeasure_description": countermeasure_library.description
+                if countermeasure_library
+                else "",
+                "control_type": countermeasure_library.control_type
+                if countermeasure_library
+                else "",
             },
         )
         # Always create the junction link (idempotent via unique constraint)
@@ -630,9 +689,7 @@ def _generate_countermeasures_for_threat(threat_instance):
             link_kwargs["component_threat"] = threat_instance
         else:
             link_kwargs["flow_threat"] = threat_instance
-        _link_created = CountermeasureThreatLink.objects.get_or_create(
-            **link_kwargs
-        )[1]
+        _link_created = CountermeasureThreatLink.objects.get_or_create(**link_kwargs)[1]
         if created or _link_created:
             created_count += 1
             if countermeasure_status == "platform":
@@ -660,6 +717,7 @@ def _generate_countermeasures_for_threat(threat_instance):
     # Recalculate threat status if any platform countermeasures were created
     if has_platform_countermeasure:
         from apps.threats.services import recalculate_threat_status
+
         recalculate_threat_status(threat_instance)
 
     return created_count
@@ -736,7 +794,6 @@ def _sync_edges_to_dataflows(dfd, edges, node_component_map):
     Returns:
         dict with synced_count, created_count, threats_generated
     """
-    from apps.threats.models import CountermeasureLibrary
 
     synced_count = 0
     created_count = 0
@@ -889,17 +946,23 @@ def _generate_threats_for_dataflow(dataflow):
     # If we have component libraries, get threats specific to those components
     if component_libraries:
         # Get threats that apply to data flows for these component types
-        library_threats = ComponentLibraryThreat.objects.filter(
-            component_library__in=component_libraries,
-            applies_to__in=[
-                ComponentLibraryThreat.AppliesTo.FLOW,
-                ComponentLibraryThreat.AppliesTo.BOTH,
-            ],
-        ).select_related("threat_library").distinct()
+        library_threats = (
+            ComponentLibraryThreat.objects.filter(
+                component_library__in=component_libraries,
+                applies_to__in=[
+                    ComponentLibraryThreat.AppliesTo.FLOW,
+                    ComponentLibraryThreat.AppliesTo.BOTH,
+                ],
+            )
+            .select_related("threat_library")
+            .distinct()
+        )
 
         # Filter by connected packs if dataflow has a threat model.
         # Allow threats with no source_pack (custom/legacy) to always pass through.
-        threat_model_id = getattr(source_component, "threat_model_id", None) or getattr(dest_component, "threat_model_id", None)
+        threat_model_id = getattr(source_component, "threat_model_id", None) or getattr(
+            dest_component, "threat_model_id", None
+        )
         if threat_model_id:
             from apps.threat_models.models import ThreatModelLibraryPack
 
@@ -940,9 +1003,7 @@ def _generate_threats_for_dataflow(dataflow):
 
 def _sync_nodes_to_trust_zones(dfd, nodes):
     """Sync trust zone canvas nodes to TrustZone DB records."""
-    trust_zone_nodes = [
-        node for node in nodes if node.get("type") == "trustZone"
-    ]
+    trust_zone_nodes = [node for node in nodes if node.get("type") == "trustZone"]
 
     synced_count = 0
     created_count = 0
@@ -1033,9 +1094,7 @@ def _update_canvas_with_trust_zone_ids(dfd, node_zone_map):
 
 def _sync_nodes_to_orgsystems(dfd, nodes, threat_model):
     """Sync system scope canvas nodes to Orgsystem DB records."""
-    system_scope_nodes = [
-        node for node in nodes if node.get("type") == "systemScope"
-    ]
+    system_scope_nodes = [node for node in nodes if node.get("type") == "systemScope"]
 
     synced_count = 0
     created_count = 0
@@ -1145,10 +1204,15 @@ def _sync_edges_to_trust_boundaries(dfd, edges, node_zone_map):
         # Extract security metadata into format_metadata dict
         # Keys are already snake_case (parser converted from frontend camelCase)
         metadata_keys = [
-            "access_control_methods", "authentication_methods",
-            "access_token_expires", "access_token_ttl",
-            "has_refresh_token", "refresh_token_expires", "refresh_token_ttl",
-            "can_user_logout", "can_system_logout",
+            "access_control_methods",
+            "authentication_methods",
+            "access_token_expires",
+            "access_token_ttl",
+            "has_refresh_token",
+            "refresh_token_expires",
+            "refresh_token_ttl",
+            "can_user_logout",
+            "can_system_logout",
         ]
         format_metadata = {
             key: edge_data[key] for key in metadata_keys if key in edge_data

--- a/backend/apps/diagrams/tests/test_canvas_trust_zone_adoption.py
+++ b/backend/apps/diagrams/tests/test_canvas_trust_zone_adoption.py
@@ -1,0 +1,83 @@
+"""Regression test for precogly/precogly#406.
+
+Canvas nodes carry the `trust_zone_id` of the zone they represent, and canvas data
+comes from the caller. The sync looked that id up unfiltered and wrote the node's
+label and trust level onto whatever row came back, so saving one organization's
+diagram renamed and reclassified another's zone. The trust level feeds threat
+analysis.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from apps.diagrams.models import DFD
+from apps.diagrams.services import _sync_nodes_to_trust_zones
+from apps.organizations.models import Organization
+from apps.systems.models import TrustZone
+from apps.threat_models.models import ThreatModel
+
+User = get_user_model()
+
+
+class CanvasTrustZoneAdoptionTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.attacker_org = Organization.objects.create(name="Kestrel")
+        cls.victim_org = Organization.objects.create(name="Contoso")
+        cls.user = User.objects.create_user(
+            username="kestrel", email="user@kestrel.test", password="pw"
+        )
+
+        cls.threat_model = ThreatModel.objects.create(
+            organization=cls.attacker_org,
+            created_by=cls.user,
+            name="Kestrel threat model",
+        )
+        cls.dfd = DFD.objects.create(
+            name="Kestrel DFD", threat_model=cls.threat_model, is_primary=True
+        )
+
+        cls.victim_zone = TrustZone.objects.create(
+            organization=cls.victim_org, name="Contoso DMZ", trust_level=20
+        )
+
+    def _sync(self, zone_id):
+        """One trust-zone node naming `zone_id`, synced against Kestrel's diagram."""
+        nodes = [
+            {
+                "id": "node-1",
+                "type": "trustZone",
+                "data": {
+                    "label": "Adopted by Kestrel",
+                    "trust_level": 99,
+                    "trust_zone_id": zone_id,
+                },
+            }
+        ]
+        return _sync_nodes_to_trust_zones(self.dfd, nodes, self.threat_model)
+
+    def test_another_tenants_zone_is_not_adopted(self):
+        self._sync(self.victim_zone.id)
+
+        self.victim_zone.refresh_from_db()
+        self.assertEqual(
+            (self.victim_zone.name, self.victim_zone.trust_level),
+            ("Contoso DMZ", 20),
+        )
+
+    def test_the_unreachable_id_produces_a_zone_in_the_callers_organization(self):
+        result = self._sync(self.victim_zone.id)
+
+        adopted = TrustZone.objects.get(id=result["node_zone_map"]["node-1"])
+        self.assertEqual(adopted.organization_id, self.attacker_org.id)
+        self.assertEqual(adopted.name, "Adopted by Kestrel")
+
+    def test_a_zone_the_caller_owns_is_still_updated(self):
+        own = TrustZone.objects.create(
+            organization=self.attacker_org, name="Kestrel DMZ", trust_level=50
+        )
+
+        self._sync(own.id)
+
+        own.refresh_from_db()
+        self.assertEqual((own.name, own.trust_level), ("Adopted by Kestrel", 99))

--- a/backend/apps/organizations/models.py
+++ b/backend/apps/organizations/models.py
@@ -9,10 +9,14 @@ from django.db import models
 from django.utils import timezone
 
 from apps.core.models import TimestampedModel
+from apps.core.tenancy import Tenancy
 
 
 class Organization(TimestampedModel):
     """Organization/tenant model."""
+
+    # The tenant itself: a row belongs to the organization it is.
+    tenancy = Tenancy.TENANT_OWNED
 
     class Plan(models.TextChoices):
         FREE = "free", "Free"
@@ -45,6 +49,8 @@ class Organization(TimestampedModel):
 
 class OrganizationMember(TimestampedModel):
     """Organization membership with roles."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class Role(models.TextChoices):
         SECURITY_TEAM = "security_team", "Security Team"
@@ -85,6 +91,8 @@ class BusinessUnit(TimestampedModel):
     Display label is configurable per organization.
     """
 
+    tenancy = Tenancy.TENANT_OWNED
+
     organization = models.ForeignKey(
         Organization,
         on_delete=models.CASCADE,
@@ -120,6 +128,8 @@ class Team(TimestampedModel):
     """
     The functional unit of work. Owns threat models.
     """
+
+    tenancy = Tenancy.TENANT_OWNED
 
     organization = models.ForeignKey(
         Organization,
@@ -158,6 +168,11 @@ class TeamMembership(TimestampedModel):
     Users can belong to multiple teams.
     """
 
+    # The team side carries the organization. A user may be in teams belonging to
+    # several organizations, so the membership row belongs to the team's, not the
+    # user's.
+    tenancy = Tenancy.TENANT_OWNED
+
     class Role(models.TextChoices):
         LEAD = "lead", "Team Lead"
         MEMBER = "member", "Member"
@@ -189,6 +204,8 @@ class TeamInvitation(TimestampedModel):
     Invitation for users who haven't signed up yet.
     Converted to TeamMembership when user registers.
     """
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class Status(models.TextChoices):
         PENDING = "pending", "Pending"
@@ -249,6 +266,10 @@ class MagicLink(TimestampedModel):
     Tokenized URL for read-only threat model sharing.
     """
 
+    # Owned by the shared threat model's organization, and readable without any
+    # membership: the token is the credential. Scoping reads to members breaks it.
+    tenancy = Tenancy.TENANT_OWNED
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     threat_model = models.ForeignKey(
         "threat_models.ThreatModel",
@@ -281,6 +302,10 @@ class SharedWithMe(TimestampedModel):
     Tracks threat models shared with a user via magic link.
     When a logged-in user accesses a magic link, the threat model is added here.
     """
+
+    # Owned by the shared threat model's organization, and readable by the user
+    # outside it that the row grants access to.
+    tenancy = Tenancy.TENANT_OWNED
 
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/backend/apps/organizations/models.py
+++ b/backend/apps/organizations/models.py
@@ -74,9 +74,8 @@ class OrganizationMember(TimestampedModel):
         """Return True when demoting/removing this member would leave zero security team members."""
         return (
             self.role == self.Role.SECURITY_TEAM
-            and self.organization.members.filter(
-                role=self.Role.SECURITY_TEAM
-            ).count() <= 1
+            and self.organization.members.filter(role=self.Role.SECURITY_TEAM).count()
+            <= 1
         )
 
 
@@ -234,7 +233,7 @@ class TeamInvitation(TimestampedModel):
 
     def accept(self, user):
         """Convert invitation to membership."""
-        membership, created = TeamMembership.objects.get_or_create(
+        membership, _created = TeamMembership.objects.get_or_create(
             team=self.team,
             user=user,
             defaults={"role": self.role},
@@ -311,5 +310,3 @@ class SharedWithMe(TimestampedModel):
 
     def __str__(self):
         return f"{self.threat_model} shared with {self.user}"
-
-

--- a/backend/apps/packs/models.py
+++ b/backend/apps/packs/models.py
@@ -41,7 +41,9 @@ class LibraryPack(TimestampedModel):
     pack_type = models.CharField(max_length=20, choices=PackType.choices)
 
     # Versioning
-    version = models.CharField(max_length=20, help_text="Semantic version, e.g., '1.2.0'")
+    version = models.CharField(
+        max_length=20, help_text="Semantic version, e.g., '1.2.0'"
+    )
 
     # Metadata
     author = models.CharField(max_length=255, help_text="Author or organization name")

--- a/backend/apps/packs/models.py
+++ b/backend/apps/packs/models.py
@@ -11,6 +11,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
 from apps.core.models import TimestampedModel
+from apps.core.tenancy import Tenancy
 
 
 class LibraryPack(TimestampedModel):
@@ -18,6 +19,11 @@ class LibraryPack(TimestampedModel):
     A bundle of library items (technologies, threats, countermeasures, templates)
     that can be installed together by an organization.
     """
+
+    # A pack is the unit of shipped content. "Installed by an organization" above
+    # describes a link recorded elsewhere (`ThreatModelLibraryPack`), not ownership of
+    # the pack row.
+    tenancy = Tenancy.SHARED_REFERENCE
 
     class PackType(models.TextChoices):
         TECHNOLOGY = "technology", "Technology Pack"
@@ -68,6 +74,8 @@ class LibraryPack(TimestampedModel):
 class LibraryPackDependency(TimestampedModel):
     """Explicit dependency between packs."""
 
+    tenancy = Tenancy.SHARED_REFERENCE
+
     pack = models.ForeignKey(
         LibraryPack,
         on_delete=models.CASCADE,
@@ -98,6 +106,10 @@ class PendingFrameworkOverlay(TimestampedModel):
     When a framework is later installed, pending overlays for that framework
     can be activated automatically.
     """
+
+    # Staging for a pack import, keyed only by pack and slug. No organization is
+    # involved on either side.
+    tenancy = Tenancy.SHARED_REFERENCE
 
     pack = models.ForeignKey(
         LibraryPack,
@@ -140,6 +152,8 @@ class PendingRequirementOverlay(TimestampedModel):
     When a framework is later installed, pending requirement overlays
     referencing that framework can be activated automatically.
     """
+
+    tenancy = Tenancy.SHARED_REFERENCE
 
     pack = models.ForeignKey(
         LibraryPack,
@@ -189,6 +203,8 @@ class PendingTaxonomyOverlay(TimestampedModel):
     When a taxonomy is later installed, pending overlays for that taxonomy
     can be activated automatically.
     """
+
+    tenancy = Tenancy.SHARED_REFERENCE
 
     pack = models.ForeignKey(
         LibraryPack,

--- a/backend/apps/systems/management/commands/trust_zone_owners.py
+++ b/backend/apps/systems/management/commands/trust_zone_owners.py
@@ -1,0 +1,65 @@
+"""List trust zones with no owner, or with more than one.
+
+`systems.0005_trust_zone_organization` derives each zone's organization through its
+components, where both hops are nullable. A zone reachable from two organizations is
+precogly/precogly#406; one reachable from none has nothing to record. The migration
+raises on either, and this shows which rows it means.
+
+Read-only: what to do with them is a decision about customer data.
+"""
+
+from django.core.management.base import BaseCommand
+
+from apps.systems.models import OrgsystemComponent, TrustZone
+
+
+class Command(BaseCommand):
+    help = "List trust zones with no owner, or more than one, before migrating."
+
+    def handle(self, *args, **options):
+        owners = self._owners()
+
+        ownerless, ambiguous = [], []
+        for zone in TrustZone.objects.all().order_by("id"):
+            found = owners.get(zone.id, set())
+            if not found:
+                ownerless.append((zone, found))
+            elif len(found) > 1:
+                ambiguous.append((zone, found))
+
+        total = TrustZone.objects.count()
+        self.stdout.write(f"{total} trust zones")
+
+        self._report(
+            "reachable from more than one organization", ambiguous, show_orgs=True
+        )
+        self._report("reachable from no organization", ownerless, show_orgs=False)
+
+        if total and not ownerless and not ambiguous:
+            self.stdout.write(self.style.SUCCESS("  every zone has exactly one owner"))
+
+    @staticmethod
+    def _owners():
+        """zone id -> organization ids reachable through its components.
+
+        The same derivation the migration uses. Both hops are nullable, which is how
+        a zone ends up with no owner.
+        """
+        linked = OrgsystemComponent.objects.filter(trust_zone__isnull=False)
+        owners = {}
+        for relation in ("orgsystem", "threat_model"):
+            rows = linked.exclude(**{relation: None}).values_list(
+                "trust_zone_id", f"{relation}__organization_id"
+            )
+            for zone_id, org_id in rows:
+                if org_id is not None:
+                    owners.setdefault(zone_id, set()).add(org_id)
+        return owners
+
+    def _report(self, label, rows, show_orgs):
+        if not rows:
+            return
+        self.stdout.write(self.style.ERROR(f"\n{len(rows)} {label}:"))
+        for zone, found in rows:
+            suffix = f"  organizations {sorted(found)}" if show_orgs else ""
+            self.stdout.write(f"  #{zone.id}  {zone.name!r}{suffix}")

--- a/backend/apps/systems/migrations/0005_trust_zone_organization.py
+++ b/backend/apps/systems/migrations/0005_trust_zone_organization.py
@@ -1,0 +1,135 @@
+"""Give TrustZone and TrustBoundary an organization column.
+
+Both tables held customer data with no forward path to an organization, so every
+query that scoped them re-derived the owner through `components`, across two
+nullable hops. precogly/precogly#404 read other tenants' zones that way and #406
+wrote through it.
+
+The backfill uses those same hops once more to set the column. A zone reachable from
+two organizations is #406's case and picking either would hand one tenant's row to
+another; a zone reachable from none has no owner to record. Both raise and name the
+rows. Nothing is deleted here — `manage.py trust_zone_owners` lists them.
+"""
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def _zone_owners(apps):
+    """zone id -> the set of organization ids reachable from its components.
+
+    Two queries rather than a walk per zone. Both hops are nullable, so a component
+    can contribute one owner, two, or none.
+    """
+    Component = apps.get_model("systems", "OrgsystemComponent")
+    linked = Component.objects.filter(trust_zone__isnull=False)
+
+    owners = {}
+    for field in ("orgsystem__organization_id", "threat_model__organization_id"):
+        rows = linked.exclude(**{field.split("__organization_id")[0]: None})
+        for zone_id, org_id in rows.values_list("trust_zone_id", field):
+            if org_id is not None:
+                owners.setdefault(zone_id, set()).add(org_id)
+    return owners
+
+
+def _refuse(kind, rows):
+    raise RuntimeError(
+        f"Cannot migrate: {len(rows)} trust {kind}.\n"
+        f"  {rows}\n"
+        "A zone reachable from two organizations is precogly/precogly#406 and this "
+        "migration will not choose between them; a zone reachable from none has no "
+        "owner to record. Resolve or remove these rows, then run migrate again. "
+        "`manage.py trust_zone_owners` reports them without changing anything."
+    )
+
+
+def set_owners(apps, schema_editor):
+    TrustZone = apps.get_model("systems", "TrustZone")
+    TrustBoundary = apps.get_model("systems", "TrustBoundary")
+
+    owners = _zone_owners(apps)
+    resolved, ambiguous, ownerless = {}, [], []
+
+    for zone_id in TrustZone.objects.values_list("id", flat=True):
+        found = owners.get(zone_id, set())
+        if len(found) == 1:
+            resolved[zone_id] = found.pop()
+        elif found:
+            ambiguous.append(zone_id)
+        else:
+            ownerless.append(zone_id)
+
+    if ambiguous:
+        _refuse("zones reachable from more than one organization", ambiguous)
+    if ownerless:
+        _refuse("zones reachable from no organization", ownerless)
+
+    for zone_id, org_id in resolved.items():
+        TrustZone.objects.filter(id=zone_id).update(organization_id=org_id)
+
+    # A boundary joins two zones that are separate rows, so they can disagree even
+    # once every zone is resolved.
+    split = []
+    for boundary_id, a, b in TrustBoundary.objects.values_list(
+        "id", "zone_a_id", "zone_b_id"
+    ):
+        ends = {resolved[a], resolved[b]}
+        if len(ends) != 1:
+            split.append(boundary_id)
+        else:
+            TrustBoundary.objects.filter(id=boundary_id).update(
+                organization_id=ends.pop()
+            )
+
+    if split:
+        _refuse("boundaries whose two zones belong to different organizations", split)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("organizations", "0001_initial"),
+        ("systems", "0004_cyclonedx_schema_enrichment"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="trustzone",
+            name="organization",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="trust_zones",
+                to="organizations.organization",
+            ),
+        ),
+        migrations.AddField(
+            model_name="trustboundary",
+            name="organization",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="trust_boundaries",
+                to="organizations.organization",
+            ),
+        ),
+        migrations.RunPython(set_owners, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="trustzone",
+            name="organization",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="trust_zones",
+                to="organizations.organization",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="trustboundary",
+            name="organization",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="trust_boundaries",
+                to="organizations.organization",
+            ),
+        ),
+    ]

--- a/backend/apps/systems/models.py
+++ b/backend/apps/systems/models.py
@@ -96,13 +96,16 @@ class IntegrationSource(TimestampedModel):
 class TrustZone(TimestampedModel):
     """Trust zone (named security region)."""
 
-    # Tenant-owned, and the only model here with no foreign key saying so — a zone is
-    # reached in reverse through `components`. Created per diagram sync and per import,
-    # never deduplicated by name, and deleted when it falls out of its diagram
-    # (apps/diagrams/services.py:161), so it belongs to one threat model in every path
-    # that touches it. The missing key is what #404 read and #406 wrote through.
     tenancy = Tenancy.TENANT_OWNED
 
+    # A zone used to be reached only in reverse, through `components`, and both hops
+    # to an organization were nullable. #404 read across tenants that way and #406
+    # wrote through it. This column is the boundary now; nothing should re-derive it.
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="trust_zones",
+    )
     name = models.CharField(max_length=255)
     trust_level = models.IntegerField(default=50, help_text="0-100 scale")
     description = models.TextField(blank=True)
@@ -126,9 +129,16 @@ class TrustZone(TimestampedModel):
 class TrustBoundary(TimestampedModel):
     """Security boundary between two trust zones."""
 
-    # Same position as TrustZone: customer data with no forward path to an organization.
     tenancy = Tenancy.TENANT_OWNED
 
+    # Carries its own owner rather than reading it off `zone_a`: the two zones are
+    # separate rows and nothing but this column stops a boundary being drawn between
+    # organizations. Lifecycle still comes from the zones, which cascade.
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="trust_boundaries",
+    )
     zone_a = models.ForeignKey(
         TrustZone,
         on_delete=models.CASCADE,

--- a/backend/apps/systems/models.py
+++ b/backend/apps/systems/models.py
@@ -7,11 +7,14 @@ from django.core.exceptions import ValidationError
 from django.db import models
 
 from apps.core.models import TimestampedModel
+from apps.core.tenancy import Tenancy
 from apps.organizations.models import Organization
 
 
 class Orgsystem(TimestampedModel):
     """Organizational system being modeled."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class Criticality(models.TextChoices):
         LOW = "low", "Low"
@@ -54,6 +57,8 @@ class Orgsystem(TimestampedModel):
 class IntegrationSource(TimestampedModel):
     """External integration source for component discovery."""
 
+    tenancy = Tenancy.TENANT_OWNED
+
     class SourceType(models.TextChoices):
         GITHUB = "github", "GitHub"
         CSPM = "cspm", "CSPM"
@@ -91,6 +96,13 @@ class IntegrationSource(TimestampedModel):
 class TrustZone(TimestampedModel):
     """Trust zone (named security region)."""
 
+    # Tenant-owned, and the only model here with no foreign key saying so — a zone is
+    # reached in reverse through `components`. Created per diagram sync and per import,
+    # never deduplicated by name, and deleted when it falls out of its diagram
+    # (apps/diagrams/services.py:161), so it belongs to one threat model in every path
+    # that touches it. The missing key is what #404 read and #406 wrote through.
+    tenancy = Tenancy.TENANT_OWNED
+
     name = models.CharField(max_length=255)
     trust_level = models.IntegerField(default=50, help_text="0-100 scale")
     description = models.TextField(blank=True)
@@ -113,6 +125,9 @@ class TrustZone(TimestampedModel):
 
 class TrustBoundary(TimestampedModel):
     """Security boundary between two trust zones."""
+
+    # Same position as TrustZone: customer data with no forward path to an organization.
+    tenancy = Tenancy.TENANT_OWNED
 
     zone_a = models.ForeignKey(
         TrustZone,
@@ -157,6 +172,10 @@ class TrustBoundary(TimestampedModel):
 
 class ComponentLibrary(TimestampedModel):
     """Reusable component templates."""
+
+    # `customization_status` records one tenant's edits to a shipped row, and every
+    # tenant then reads the edited row.
+    tenancy = Tenancy.MIXED
 
     class Category(models.TextChoices):
         PROCESS = "process", "Process"
@@ -315,6 +334,11 @@ class ComponentLibrary(TimestampedModel):
 class OrgsystemComponent(TimestampedModel):
     """Component instance, optionally linked to an orgsystem."""
 
+    # "Optionally linked" is the nullable `orgsystem` that made #227 possible: with it
+    # null the organization is reached through `threat_model` instead, and the queryset
+    # has to cover both.
+    tenancy = Tenancy.TENANT_OWNED
+
     orgsystem = models.ForeignKey(
         Orgsystem,
         on_delete=models.CASCADE,
@@ -405,6 +429,8 @@ class OrgsystemComponent(TimestampedModel):
 class DataAsset(TimestampedModel):
     """Data asset with classification."""
 
+    tenancy = Tenancy.TENANT_OWNED
+
     class Sensitivity(models.TextChoices):
         LOW = "low", "Low"
         MEDIUM = "medium", "Medium"
@@ -461,6 +487,8 @@ class DataAsset(TimestampedModel):
 class ComponentDataAsset(TimestampedModel):
     """Association between component and data asset."""
 
+    tenancy = Tenancy.TENANT_OWNED
+
     class DataState(models.TextChoices):
         AT_REST = "at_rest", "At Rest"
         PROCESSED = "processed", "Processed"
@@ -492,6 +520,8 @@ class ComponentDataAsset(TimestampedModel):
 
 class DataFlow(TimestampedModel):
     """Data flow between components."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     source_component = models.ForeignKey(
         OrgsystemComponent,
@@ -547,6 +577,8 @@ class DataFlow(TimestampedModel):
 
 class DataFlowAsset(TimestampedModel):
     """Data assets transported in a data flow."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class ProtectionMethod(models.TextChoices):
         ENCRYPTED = "encrypted", "Encrypted"

--- a/backend/apps/systems/models.py
+++ b/backend/apps/systems/models.py
@@ -182,7 +182,11 @@ class ComponentLibrary(TimestampedModel):
         blank=True,
         help_text="Unique identifier within pack, e.g., 'aws-s3'",
     )
-    qualified_slug = models.CharField(
+    # `null=True` is required by `unique_component_qualified_slug` below. Postgres
+    # treats NULLs as distinct under a unique index, so any number of rows may carry no
+    # qualified slug; `blank=True` with `""` would make the second such row collide
+    # with the first. DJ001 cannot see the constraint.
+    qualified_slug = models.CharField(  # noqa: DJ001
         max_length=200,
         null=True,
         blank=True,
@@ -264,9 +268,7 @@ class ComponentLibrary(TimestampedModel):
         current = self.parent
         while current is not None:
             if current.pk in visited:
-                raise ValidationError(
-                    {"parent": "Circular parent reference detected."}
-                )
+                raise ValidationError({"parent": "Circular parent reference detected."})
             visited.add(current.pk)
             current = current.parent
 
@@ -367,7 +369,16 @@ class OrgsystemComponent(TimestampedModel):
     format_metadata = models.JSONField(default=dict, blank=True)
 
     # Metadata copied from library on creation (for self-sufficiency if orphaned)
-    category = models.CharField(
+    # TODO: drop `null=True` and migrate existing NULLs to "". `component_type` and
+    # `provider` below are copied from the library the same way and both spell "not
+    # set" as `blank=True` alone, so this field is the odd one of the three.
+    #
+    # The migration changes .tm export output. `adapters/tm_library.py` exports a
+    # component as an actor when `comp.category is None` and its format_metadata
+    # carries an `original_type`; migrating the NULLs stops that branch firing, and
+    # relaxing it to `not comp.category` newly catches rows already holding "".
+    # No test covers either direction.
+    category = models.CharField(  # noqa: DJ001
         max_length=30,
         blank=True,
         null=True,

--- a/backend/apps/systems/tests/test_trust_zone_scoping.py
+++ b/backend/apps/systems/tests/test_trust_zone_scoping.py
@@ -1,0 +1,122 @@
+"""Regression tests for precogly/precogly#404.
+
+`?threat_model=` on the trust-zone list replaced the organization join instead of
+narrowing it, so any authenticated user could name any threat model and read that
+tenant's zones. Zones now carry an `organization` and the filter applies on top of
+it.
+
+The tests asserting that own zones are still returned exist because a queryset
+returning nothing would pass the leak assertions too.
+"""
+
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.organizations.models import Organization, OrganizationMember
+from apps.systems.models import OrgsystemComponent, TrustBoundary, TrustZone
+from apps.threat_models.models import ThreatModel
+
+User = get_user_model()
+
+
+class TrustZoneScopingTests(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = Organization.objects.create(name="Acme")
+        cls.other_organization = Organization.objects.create(name="Globex")
+        cls.member = User.objects.create_user(
+            username="member", email="member@acme.test", password="pw"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.organization, user=cls.member
+        )
+
+        cls.threat_model = ThreatModel.objects.create(
+            organization=cls.organization,
+            created_by=cls.member,
+            name="Acme threat model",
+        )
+        cls.other_threat_model = ThreatModel.objects.create(
+            organization=cls.other_organization,
+            created_by=cls.member,
+            name="Globex threat model",
+        )
+
+        cls.own_zone = cls._zone(cls.organization, cls.threat_model, "Acme DMZ")
+        cls.other_zone = cls._zone(
+            cls.other_organization, cls.other_threat_model, "Globex DMZ"
+        )
+
+    def setUp(self):
+        self.client.force_authenticate(self.member)
+
+    @classmethod
+    def _zone(cls, organization, threat_model, name):
+        """A zone with a component attached, so the ?threat_model= join can reach it."""
+        zone = TrustZone.objects.create(organization=organization, name=name)
+        OrgsystemComponent.objects.create(
+            name=f"{name} component", threat_model=threat_model, trust_zone=zone
+        )
+        return zone
+
+    def _names(self, response):
+        rows = response.data
+        if isinstance(rows, dict):
+            rows = rows["results"]
+        return {row["name"] for row in rows}
+
+    def test_naming_another_tenants_threat_model_returns_nothing(self):
+        response = self.client.get(
+            "/api/trust-zones/", {"threat_model": self.other_threat_model.id}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._names(response), set())
+
+    def test_the_filter_still_returns_own_zones(self):
+        response = self.client.get(
+            "/api/trust-zones/", {"threat_model": self.threat_model.id}
+        )
+
+        self.assertEqual(self._names(response), {"Acme DMZ"})
+
+    def test_unfiltered_list_is_scoped_to_the_callers_organization(self):
+        response = self.client.get("/api/trust-zones/")
+
+        self.assertEqual(self._names(response), {"Acme DMZ"})
+
+
+class TrustBoundaryScopingTests(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = Organization.objects.create(name="Acme")
+        cls.other_organization = Organization.objects.create(name="Globex")
+        cls.member = User.objects.create_user(
+            username="member", email="member@acme.test", password="pw"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.organization, user=cls.member
+        )
+
+        cls.own = cls._boundary(cls.organization, "Acme edge")
+        cls.other = cls._boundary(cls.other_organization, "Globex edge")
+
+    def setUp(self):
+        self.client.force_authenticate(self.member)
+
+    @classmethod
+    def _boundary(cls, organization, label):
+        zone_a = TrustZone.objects.create(organization=organization, name=f"{label} a")
+        zone_b = TrustZone.objects.create(organization=organization, name=f"{label} b")
+        return TrustBoundary.objects.create(
+            organization=organization, zone_a=zone_a, zone_b=zone_b, label=label
+        )
+
+    def test_list_is_scoped_to_the_callers_organization(self):
+        response = self.client.get("/api/trust-boundaries/")
+
+        rows = response.data
+        if isinstance(rows, dict):
+            rows = rows["results"]
+        self.assertEqual({row["label"] for row in rows}, {"Acme edge"})

--- a/backend/apps/systems/views.py
+++ b/backend/apps/systems/views.py
@@ -11,9 +11,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from apps.core.permissions import CanWrite, IsSecurityTeam
-
-from apps.threats.models import ComponentInstanceThreat, ComponentLibraryThreat, build_taxonomy_snapshot
-from apps.threats.serializers import ComponentInstanceThreatSerializer
+from apps.threats.models import (
+    ComponentInstanceThreat,
+)
 
 from .models import (
     ComponentDataAsset,
@@ -46,7 +46,11 @@ class OrgsystemViewSet(viewsets.ModelViewSet):
     """ViewSet for Orgsystem CRUD operations."""
 
     permission_classes = [IsAuthenticated, CanWrite]
-    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filter_backends = [
+        DjangoFilterBackend,
+        filters.SearchFilter,
+        filters.OrderingFilter,
+    ]
     filterset_fields = ["criticality", "lifecycle_state", "organization"]
     search_fields = ["name", "owner"]
     ordering_fields = ["name", "created_at", "criticality"]
@@ -55,7 +59,9 @@ class OrgsystemViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Filter by user's organizations."""
         user = self.request.user
-        org_ids = user.organization_memberships.values_list("organization_id", flat=True)
+        org_ids = user.organization_memberships.values_list(
+            "organization_id", flat=True
+        )
         return Orgsystem.objects.filter(organization_id__in=org_ids).select_related(
             "organization"
         )
@@ -130,7 +136,11 @@ class ComponentLibraryViewSet(viewsets.ModelViewSet):
         Returns all components that have been imported into the database.
         Optionally filtered by a threat model's connected packs.
         """
-        qs = ComponentLibrary.objects.all().select_related("source_pack").order_by("name")
+        qs = (
+            ComponentLibrary.objects.all()
+            .select_related("source_pack")
+            .order_by("name")
+        )
         threat_model_id = self.request.query_params.get("threat_model")
         if threat_model_id:
             from apps.threat_models.models import ThreatModelLibraryPack
@@ -139,8 +149,7 @@ class ComponentLibraryViewSet(viewsets.ModelViewSet):
                 threat_model_id=threat_model_id
             ).values_list("library_pack_id", flat=True)
             qs = qs.filter(
-                Q(source_pack_id__in=connected_pack_ids)
-                | Q(source_pack__isnull=True)
+                Q(source_pack_id__in=connected_pack_ids) | Q(source_pack__isnull=True)
             )
         return qs
 
@@ -159,9 +168,14 @@ class OrgsystemComponentViewSet(viewsets.ModelViewSet):
         instance = serializer.save()
         if instance.orgsystem_id is None and instance.threat_model_id:
             from apps.threat_models.models import ThreatModelOrgsystem
-            association = ThreatModelOrgsystem.objects.filter(
-                threat_model_id=instance.threat_model_id
-            ).select_related("orgsystem").first()
+
+            association = (
+                ThreatModelOrgsystem.objects.filter(
+                    threat_model_id=instance.threat_model_id
+                )
+                .select_related("orgsystem")
+                .first()
+            )
             if association:
                 instance.orgsystem = association.orgsystem
                 instance.save(update_fields=["orgsystem"])
@@ -169,7 +183,9 @@ class OrgsystemComponentViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Filter by organizations reachable through orgsystem or threat model."""
         user = self.request.user
-        org_ids = user.organization_memberships.values_list("organization_id", flat=True)
+        org_ids = user.organization_memberships.values_list(
+            "organization_id", flat=True
+        )
         return OrgsystemComponent.objects.filter(
             Q(orgsystem__organization_id__in=org_ids)
             | Q(
@@ -192,9 +208,13 @@ class OrgsystemComponentViewSet(viewsets.ModelViewSet):
         if orgsystem_id:
             # Validate system belongs to user's organization
             user = self.request.user
-            org_ids = list(user.organization_memberships.values_list("organization_id", flat=True))
+            org_ids = list(
+                user.organization_memberships.values_list("organization_id", flat=True)
+            )
             try:
-                system = Orgsystem.objects.get(id=orgsystem_id, organization_id__in=org_ids)
+                system = Orgsystem.objects.get(
+                    id=orgsystem_id, organization_id__in=org_ids
+                )
                 component.orgsystem = system
             except Orgsystem.DoesNotExist:
                 return Response(
@@ -234,12 +254,14 @@ class OrgsystemComponentViewSet(viewsets.ModelViewSet):
 
         total = ComponentInstanceThreat.objects.filter(component=component).count()
 
-        return Response({
-            "created_count": created_count,
-            "existing_count": total - created_count,
-            "total": total,
-            "message": f"Generated {created_count} new threats, {total - created_count} already existed",
-        })
+        return Response(
+            {
+                "created_count": created_count,
+                "existing_count": total - created_count,
+                "total": total,
+                "message": f"Generated {created_count} new threats, {total - created_count} already existed",
+            }
+        )
 
 
 class DataAssetViewSet(viewsets.ModelViewSet):
@@ -255,9 +277,7 @@ class DataAssetViewSet(viewsets.ModelViewSet):
         org_ids = self.request.user.organization_memberships.values_list(
             "organization_id", flat=True
         )
-        return DataAsset.objects.filter(
-            threat_model__organization_id__in=org_ids
-        )
+        return DataAsset.objects.filter(threat_model__organization_id__in=org_ids)
 
 
 class DataFlowViewSet(viewsets.ModelViewSet):
@@ -271,7 +291,9 @@ class DataFlowViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Filter by user's organizations."""
         user = self.request.user
-        org_ids = user.organization_memberships.values_list("organization_id", flat=True)
+        org_ids = user.organization_memberships.values_list(
+            "organization_id", flat=True
+        )
         return DataFlow.objects.filter(
             Q(source_component__orgsystem__organization_id__in=org_ids)
             | Q(
@@ -293,7 +315,9 @@ class IntegrationSourceViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Filter by user's organizations."""
         user = self.request.user
-        org_ids = user.organization_memberships.values_list("organization_id", flat=True)
+        org_ids = user.organization_memberships.values_list(
+            "organization_id", flat=True
+        )
         return IntegrationSource.objects.filter(
             orgsystem__organization_id__in=org_ids
         ).select_related("orgsystem")
@@ -311,7 +335,9 @@ class ComponentDataAssetViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Filter by user's organizations."""
         user = self.request.user
-        org_ids = user.organization_memberships.values_list("organization_id", flat=True)
+        org_ids = user.organization_memberships.values_list(
+            "organization_id", flat=True
+        )
         return ComponentDataAsset.objects.filter(
             Q(component__orgsystem__organization_id__in=org_ids)
             | Q(
@@ -332,13 +358,19 @@ class DataFlowAssetViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Filter by organizations reachable through the data flow's source."""
         user = self.request.user
-        org_ids = user.organization_memberships.values_list("organization_id", flat=True)
-        return DataFlowAsset.objects.filter(
-            Q(data_flow__source_component__orgsystem__organization_id__in=org_ids)
-            | Q(
-                data_flow__source_component__orgsystem__isnull=True,
-                data_flow__source_component__threat_model__organization_id__in=org_ids,
+        org_ids = user.organization_memberships.values_list(
+            "organization_id", flat=True
+        )
+        return (
+            DataFlowAsset.objects.filter(
+                Q(data_flow__source_component__orgsystem__organization_id__in=org_ids)
+                | Q(
+                    data_flow__source_component__orgsystem__isnull=True,
+                    data_flow__source_component__threat_model__organization_id__in=org_ids,
+                )
             )
-        ).select_related(
-            "data_flow__source_component", "data_flow__dest_component", "data_asset"
-        ).order_by("id")
+            .select_related(
+                "data_flow__source_component", "data_flow__dest_component", "data_asset"
+            )
+            .order_by("id")
+        )

--- a/backend/apps/systems/views.py
+++ b/backend/apps/systems/views.py
@@ -85,17 +85,17 @@ class TrustZoneViewSet(viewsets.ModelViewSet):
         org_ids = self.request.user.organization_memberships.values_list(
             "organization_id", flat=True
         )
+        # The organization filter applies before the threat_model narrowing, not
+        # instead of it. Passing `?threat_model=` used to replace the org join
+        # rather than add to it, which returned any tenant's zones to any
+        # authenticated caller — precogly/precogly#404.
+        queryset = TrustZone.objects.filter(organization_id__in=org_ids)
         threat_model_id = self.request.query_params.get("threat_model")
         if threat_model_id:
-            # Scoped: zones that have components belonging to this threat model
-            return TrustZone.objects.filter(
+            queryset = queryset.filter(
                 components__threat_model_id=threat_model_id
             ).distinct()
-        # Default: zones reachable through any component in user's org
-        return TrustZone.objects.filter(
-            Q(components__orgsystem__organization_id__in=org_ids)
-            | Q(components__threat_model__organization_id__in=org_ids)
-        ).distinct()
+        return queryset
 
 
 class TrustBoundaryViewSet(viewsets.ModelViewSet):
@@ -111,12 +111,7 @@ class TrustBoundaryViewSet(viewsets.ModelViewSet):
         org_ids = self.request.user.organization_memberships.values_list(
             "organization_id", flat=True
         )
-        return TrustBoundary.objects.filter(
-            Q(zone_a__components__orgsystem__organization_id__in=org_ids)
-            | Q(zone_a__components__threat_model__organization_id__in=org_ids)
-            | Q(zone_b__components__orgsystem__organization_id__in=org_ids)
-            | Q(zone_b__components__threat_model__organization_id__in=org_ids)
-        ).distinct()
+        return TrustBoundary.objects.filter(organization_id__in=org_ids)
 
 
 class ComponentLibraryViewSet(viewsets.ModelViewSet):

--- a/backend/apps/threat_models/adapters/cyclonedx.py
+++ b/backend/apps/threat_models/adapters/cyclonedx.py
@@ -17,11 +17,9 @@ from .cyclonedx_enum_maps import (
     ASSET_TYPE_TO_CATEGORY,
     CATEGORY_TO_ASSET_TYPE,
     CDX_STATUS_TO_CONTROL,
-    CDX_TO_DATA_STORE_TYPE,
     CDX_TO_LEVEL,
     CDX_TO_RESPONSE,
     CONTROL_STATUS_TO_CDX,
-    DATA_STORE_TYPE_TO_CDX,
     LEVEL_TO_CDX,
     RESPONSE_TO_CDX,
     SEVERITY_TO_CDX_RISK_LEVEL,
@@ -144,13 +142,9 @@ class CycloneDxAdapter(BaseAdapter):
         ).select_related("source_component", "dest_component")
 
         zone_ids = set(
-            components.exclude(trust_zone=None).values_list(
-                "trust_zone_id", flat=True
-            )
+            components.exclude(trust_zone=None).values_list("trust_zone_id", flat=True)
         )
-        trust_zones = TrustZone.objects.filter(id__in=zone_ids).select_related(
-            "parent"
-        )
+        trust_zones = TrustZone.objects.filter(id__in=zone_ids).select_related("parent")
 
         trust_boundaries = TrustBoundary.objects.filter(
             Q(zone_a_id__in=zone_ids) | Q(zone_b_id__in=zone_ids)
@@ -204,10 +198,9 @@ class CycloneDxAdapter(BaseAdapter):
 
         from apps.diagrams.models import DFD
 
-        primary_dfd = (
-            DFD.objects.filter(threat_model=threat_model, is_primary=True)
-            .first()
-        )
+        primary_dfd = DFD.objects.filter(
+            threat_model=threat_model, is_primary=True
+        ).first()
 
         return {
             "components": list(components),
@@ -321,9 +314,7 @@ class CycloneDxAdapter(BaseAdapter):
             data_stores = []
             for component in datastore_components:
                 data_stores.append(
-                    self._build_data_store(
-                        component, data_asset_map, resolver
-                    )
+                    self._build_data_store(component, data_asset_map, resolver)
                 )
             blueprint["dataStores"] = data_stores
 
@@ -363,12 +354,14 @@ class CycloneDxAdapter(BaseAdapter):
         visualizations = []
         primary_dfd = prefetch.get("primary_dfd")
         if primary_dfd and primary_dfd.canvas_data:
-            visualizations.append({
-                "type": "precogly-dfd",
-                "name": primary_dfd.name,
-                "diagramType": primary_dfd.diagram_type,
-                "data": primary_dfd.canvas_data,
-            })
+            visualizations.append(
+                {
+                    "type": "precogly-dfd",
+                    "name": primary_dfd.name,
+                    "diagramType": primary_dfd.diagram_type,
+                    "data": primary_dfd.canvas_data,
+                }
+            )
 
         # Re-emit Tier 3 blueprint-level passthrough data
         cyclonedx_meta = threat_model.format_metadata.get("cyclonedx", {})
@@ -532,9 +525,7 @@ class CycloneDxAdapter(BaseAdapter):
         result = []
         for i, assumption in enumerate(assumptions):
             if isinstance(assumption, str):
-                result.append(
-                    {"bom-ref": f"assumption-{i}", "description": assumption}
-                )
+                result.append({"bom-ref": f"assumption-{i}", "description": assumption})
             elif isinstance(assumption, dict):
                 entry = {"bom-ref": assumption.get("id", f"assumption-{i}")}
                 if "description" in assumption:
@@ -568,20 +559,14 @@ class CycloneDxAdapter(BaseAdapter):
         scenarios = []
 
         for _library_id, instances in threats_by_library.items():
-            first_type, first_instance = instances[0]
+            _first_type, first_instance = instances[0]
             threat_lib = first_instance.threat_library
 
             # Abstract threat
-            abstract_ref = resolver.register(
-                "threat", threat_lib or first_instance
-            )
+            abstract_ref = resolver.register("threat", threat_lib or first_instance)
             abstract_threat = {
                 "bom-ref": abstract_ref,
-                "name": (
-                    threat_lib.name
-                    if threat_lib
-                    else first_instance.threat_name
-                ),
+                "name": (threat_lib.name if threat_lib else first_instance.threat_name),
                 "description": (
                     threat_lib.description
                     if threat_lib
@@ -610,9 +595,7 @@ class CycloneDxAdapter(BaseAdapter):
             mitigation_refs = set()
             for _, inst in instances:
                 for link in inst.countermeasure_links.all():
-                    ctrl_ref = resolver.get_ref(
-                        "control", link.countermeasure
-                    )
+                    ctrl_ref = resolver.get_ref("control", link.countermeasure)
                     if ctrl_ref:
                         mitigation_refs.add(ctrl_ref)
             if mitigation_refs:
@@ -644,9 +627,7 @@ class CycloneDxAdapter(BaseAdapter):
                 # Actor
                 persona_links = list(inst.persona_links.all())
                 if persona_links:
-                    persona_ref = resolver.get_ref(
-                        "persona", persona_links[0].persona
-                    )
+                    persona_ref = resolver.get_ref("persona", persona_links[0].persona)
                     if persona_ref:
                         scenario["actor"] = persona_ref
 
@@ -732,13 +713,9 @@ class CycloneDxAdapter(BaseAdapter):
             # Related threats
             related_threats = set()
             for risk_threat in risk.risk_threats.all():
-                threat_inst = (
-                    risk_threat.component_threat or risk_threat.flow_threat
-                )
+                threat_inst = risk_threat.component_threat or risk_threat.flow_threat
                 if threat_inst and threat_inst.threat_library:
-                    ref = resolver.get_ref(
-                        "threat", threat_inst.threat_library
-                    )
+                    ref = resolver.get_ref("threat", threat_inst.threat_library)
                     if ref:
                         related_threats.add(ref)
             if related_threats:
@@ -769,9 +746,7 @@ class CycloneDxAdapter(BaseAdapter):
                 responses = []
                 for resp in risk_responses:
                     response_entry = {
-                        "strategy": RESPONSE_TO_CDX.get(
-                            resp.strategy, resp.strategy
-                        ),
+                        "strategy": RESPONSE_TO_CDX.get(resp.strategy, resp.strategy),
                     }
                     if resp.description:
                         response_entry["description"] = resp.description
@@ -788,9 +763,7 @@ class CycloneDxAdapter(BaseAdapter):
                     if resp.owner:
                         response_entry["owner"] = resp.owner.email
                     if resp.target_date:
-                        response_entry["targetDate"] = (
-                            resp.target_date.isoformat()
-                        )
+                        response_entry["targetDate"] = resp.target_date.isoformat()
                     responses.append(response_entry)
                 entry["responses"] = responses
 
@@ -834,9 +807,7 @@ class CycloneDxAdapter(BaseAdapter):
                 "bom-ref": ref,
                 "name": cm.countermeasure_name
                 or (
-                    cm.countermeasure_library.name
-                    if cm.countermeasure_library
-                    else ""
+                    cm.countermeasure_library.name if cm.countermeasure_library else ""
                 ),
                 "status": CONTROL_STATUS_TO_CDX.get(cm.status, cm.status),
             }
@@ -872,9 +843,7 @@ class CycloneDxAdapter(BaseAdapter):
                     if asset_ref:
                         applies_to.add(asset_ref)
                 elif link.flow_threat:
-                    flow_ref = resolver.get_ref(
-                        "flow", link.flow_threat.data_flow
-                    )
+                    flow_ref = resolver.get_ref("flow", link.flow_threat.data_flow)
                     if flow_ref:
                         applies_to.add(flow_ref)
             if applies_to:
@@ -884,9 +853,7 @@ class CycloneDxAdapter(BaseAdapter):
             satisfies = []
             for mapping in cm.instance_standard_mappings.all():
                 if mapping.requirement:
-                    req_ref = resolver.get_ref(
-                        "requirement", mapping.requirement
-                    )
+                    req_ref = resolver.get_ref("requirement", mapping.requirement)
                     if req_ref:
                         satisfies.append(req_ref)
             if satisfies:
@@ -917,9 +884,7 @@ class CycloneDxAdapter(BaseAdapter):
         summary["threat_model"] = 1
 
         # 2. Orgsystem
-        orgsystem = self._import_orgsystem(
-            blueprint, threat_model, organization
-        )
+        orgsystem = self._import_orgsystem(blueprint, threat_model, organization)
         summary["orgsystems"] = 1
 
         # 3. Zones
@@ -939,9 +904,7 @@ class CycloneDxAdapter(BaseAdapter):
 
         # 6. DataStores -> merge into components
         for store_data in blueprint.get("dataStores", []):
-            self._import_data_store(
-                store_data, orgsystem, threat_model, resolver
-            )
+            self._import_data_store(store_data, orgsystem, threat_model, resolver)
 
         # 7. DataSets -> DataAsset
         for dataset_data in blueprint.get("dataSets", []):
@@ -972,7 +935,10 @@ class CycloneDxAdapter(BaseAdapter):
         }
         for threat_data in threats_block.get("threats", []):
             self._import_threat(
-                threat_data, threat_model, resolver, scenario_threat_refs,
+                threat_data,
+                threat_model,
+                resolver,
+                scenario_threat_refs,
                 warnings,
             )
             summary["threats"] += 1
@@ -989,9 +955,7 @@ class CycloneDxAdapter(BaseAdapter):
             summary["risks"] += 1
 
         # 13. Resolve control → threat links from mitigations
-        self._resolve_control_threat_links(
-            threats_block, threat_model, resolver
-        )
+        self._resolve_control_threat_links(threats_block, threat_model, resolver)
 
         # 14. Tier 3 passthrough
         self._store_tier3_data(threat_model, json_data, blueprint, resolver)
@@ -1003,9 +967,7 @@ class CycloneDxAdapter(BaseAdapter):
 
     # --- Import helpers ---
 
-    def _import_threat_model(
-        self, blueprint, json_data, organization, created_by
-    ):
+    def _import_threat_model(self, blueprint, json_data, organization, created_by):
         from apps.threat_models.models import ThreatModel
 
         name = blueprint.get("name", "Imported CycloneDX Model")
@@ -1015,7 +977,9 @@ class CycloneDxAdapter(BaseAdapter):
             created_by=created_by,
             name=name,
             description=blueprint.get("description", ""),
-            format_metadata={"cyclonedx": {"spec_version": json_data.get("specVersion", "2.0")}},
+            format_metadata={
+                "cyclonedx": {"spec_version": json_data.get("specVersion", "2.0")}
+            },
         )
         return threat_model
 
@@ -1059,12 +1023,8 @@ class CycloneDxAdapter(BaseAdapter):
 
         bom_ref = boundary_data.get("bom-ref", "")
         zone_refs = boundary_data.get("zones", [])
-        zone_a = (
-            resolver.resolve("zone", zone_refs[0]) if len(zone_refs) > 0 else None
-        )
-        zone_b = (
-            resolver.resolve("zone", zone_refs[1]) if len(zone_refs) > 1 else None
-        )
+        zone_a = resolver.resolve("zone", zone_refs[0]) if len(zone_refs) > 0 else None
+        zone_b = resolver.resolve("zone", zone_refs[1]) if len(zone_refs) > 1 else None
 
         if not zone_a or not zone_b:
             logger.warning(
@@ -1089,15 +1049,11 @@ class CycloneDxAdapter(BaseAdapter):
             format_metadata={
                 "cyclonedx": {
                     "bom_ref": bom_ref,
-                    "session_management": boundary_data.get(
-                        "sessionManagement"
-                    ),
+                    "session_management": boundary_data.get("sessionManagement"),
                     "crossing_details": {
                         k: v
                         for k, v in {
-                            "dataTransformation": crossing.get(
-                                "dataTransformation"
-                            ),
+                            "dataTransformation": crossing.get("dataTransformation"),
                             "protocols": crossing.get("protocols"),
                         }.items()
                         if v is not None
@@ -1129,13 +1085,15 @@ class CycloneDxAdapter(BaseAdapter):
 
         # Build Tier 3 metadata
         cdx_meta = {"bom_ref": bom_ref}
-        if isinstance(asset_type, str) and asset_type not in (
-            "component",
-            "data-store",
-            "actor",
-        ):
-            cdx_meta["asset_type"] = asset_type
-        elif isinstance(asset_type, dict):
+        if (
+            isinstance(asset_type, str)
+            and asset_type
+            not in (
+                "component",
+                "data-store",
+                "actor",
+            )
+        ) or isinstance(asset_type, dict):
             cdx_meta["asset_type"] = asset_type
         for key in ("interfaces", "classification", "authentication", "authorization"):
             if asset_data.get(key):
@@ -1153,9 +1111,7 @@ class CycloneDxAdapter(BaseAdapter):
         resolver.register("asset", bom_ref, component)
         return component
 
-    def _import_data_store(
-        self, store_data, orgsystem, threat_model, resolver
-    ):
+    def _import_data_store(self, store_data, orgsystem, threat_model, resolver):
         """Import a dataStore — merge into existing asset or create new component."""
         from apps.systems.models import OrgsystemComponent
 
@@ -1164,11 +1120,14 @@ class CycloneDxAdapter(BaseAdapter):
 
         # Try to merge with existing component of same name
         existing = None
-        for ref_key, (entity_type, obj) in resolver._ref_to_obj.items():
-            if entity_type == "asset" and isinstance(obj, OrgsystemComponent):
-                if obj.name == name:
-                    existing = obj
-                    break
+        for entity_type, obj in resolver._ref_to_obj.values():
+            if (
+                entity_type == "asset"
+                and isinstance(obj, OrgsystemComponent)
+                and obj.name == name
+            ):
+                existing = obj
+                break
 
         if existing:
             # Merge: update store type if available
@@ -1320,7 +1279,11 @@ class CycloneDxAdapter(BaseAdapter):
         return cm
 
     def _import_threat(
-        self, threat_data, threat_model, resolver, scenario_threat_refs,
+        self,
+        threat_data,
+        threat_model,
+        resolver,
+        scenario_threat_refs,
         warnings,
     ):
         from apps.threats.models import ThreatLibrary
@@ -1343,12 +1306,21 @@ class CycloneDxAdapter(BaseAdapter):
         if bom_ref not in scenario_threat_refs:
             for asset_ref in threat_data.get("affectedAssets", []):
                 self._create_instance_threat_from_abstract(
-                    threat_lib, asset_ref, threat_data, threat_model, resolver,
+                    threat_lib,
+                    asset_ref,
+                    threat_data,
+                    threat_model,
+                    resolver,
                     warnings,
                 )
 
     def _create_instance_threat_from_abstract(
-        self, threat_lib, asset_ref, threat_data, threat_model, resolver,
+        self,
+        threat_lib,
+        asset_ref,
+        threat_data,
+        threat_model,
+        resolver,
         warnings,
     ):
         from apps.systems.models import DataFlow, OrgsystemComponent
@@ -1393,7 +1365,7 @@ class CycloneDxAdapter(BaseAdapter):
         if not created and target:
             msg = (
                 f"Duplicate threat-asset link skipped: "
-                f"threat '{threat_lib.name}' × asset '{target.name}'."
+                f"threat '{threat_lib.name}' x asset '{target.name}'."
             )
             logger.warning(msg)
             warnings.append(msg)
@@ -1407,9 +1379,7 @@ class CycloneDxAdapter(BaseAdapter):
 
         bom_ref = scenario_data.get("bom-ref", "")
         threat_ref = scenario_data.get("threat")
-        threat_lib = (
-            resolver.resolve("threat", threat_ref) if threat_ref else None
-        )
+        threat_lib = resolver.resolve("threat", threat_ref) if threat_ref else None
 
         severity = "medium"
         risk_score = scenario_data.get("riskScore", {})
@@ -1426,9 +1396,9 @@ class CycloneDxAdapter(BaseAdapter):
                 scenario_meta[key] = scenario_data[key]
 
         for asset_ref in scenario_data.get("affectedAssets", []):
-            target = resolver.resolve(
-                "asset", asset_ref
-            ) or resolver.resolve("flow", asset_ref)
+            target = resolver.resolve("asset", asset_ref) or resolver.resolve(
+                "flow", asset_ref
+            )
             if not target:
                 logger.warning(
                     "Scenario '%s' references unknown asset '%s'.",
@@ -1446,9 +1416,7 @@ class CycloneDxAdapter(BaseAdapter):
                     component=target,
                     threat_library=threat_lib,
                     threat_name=threat_lib.name if threat_lib else "",
-                    threat_description=(
-                        threat_lib.description if threat_lib else ""
-                    ),
+                    threat_description=(threat_lib.description if threat_lib else ""),
                     inherent_severity=severity,
                     intent=intent,
                     access_level=access_level,
@@ -1460,9 +1428,7 @@ class CycloneDxAdapter(BaseAdapter):
                     data_flow=target,
                     threat_library=threat_lib,
                     threat_name=threat_lib.name if threat_lib else "",
-                    threat_description=(
-                        threat_lib.description if threat_lib else ""
-                    ),
+                    threat_description=(threat_lib.description if threat_lib else ""),
                     inherent_severity=severity,
                     intent=intent,
                     access_level=access_level,
@@ -1499,9 +1465,7 @@ class CycloneDxAdapter(BaseAdapter):
         risk = Risk.objects.create(
             threat_model=threat_model,
             name=name,
-            description=risk_data.get(
-                "statement", risk_data.get("description", "")
-            ),
+            description=risk_data.get("statement", risk_data.get("description", "")),
             inherent_score=inherent_score,
             inherent_level=inherent_level,
             residual_score=residual_score if residual_score else None,
@@ -1538,15 +1502,11 @@ class CycloneDxAdapter(BaseAdapter):
                 "priority",
                 "targetDate",
             }
-            extra_meta = {
-                k: v for k, v in resp_data.items() if k not in known_keys
-            }
+            extra_meta = {k: v for k, v in resp_data.items() if k not in known_keys}
 
             eff_data = resp_data.get("effectiveness", {})
             effectiveness = (
-                eff_data.get("percentage")
-                if isinstance(eff_data, dict)
-                else None
+                eff_data.get("percentage") if isinstance(eff_data, dict) else None
             )
 
             RiskResponse.objects.create(
@@ -1558,9 +1518,7 @@ class CycloneDxAdapter(BaseAdapter):
                 cost=resp_data.get("cost", ""),
                 priority=resp_data.get("priority", ""),
                 target_date=target_date,
-                format_metadata=(
-                    {"cyclonedx": extra_meta} if extra_meta else {}
-                ),
+                format_metadata=({"cyclonedx": extra_meta} if extra_meta else {}),
             )
 
         # Link to threats via relatedThreats
@@ -1571,16 +1529,12 @@ class CycloneDxAdapter(BaseAdapter):
                     threat_library=threat_lib,
                     component__threat_model=threat_model,
                 ):
-                    RiskThreat.objects.get_or_create(
-                        risk=risk, component_threat=ct
-                    )
+                    RiskThreat.objects.get_or_create(risk=risk, component_threat=ct)
                 for ft in DataFlowInstanceThreat.objects.filter(
                     threat_library=threat_lib,
                     data_flow__source_component__threat_model=threat_model,
                 ):
-                    RiskThreat.objects.get_or_create(
-                        risk=risk, flow_threat=ft
-                    )
+                    RiskThreat.objects.get_or_create(risk=risk, flow_threat=ft)
 
     def _extract_risk_score(self, rating):
         """Extract (score, level) from a CycloneDX risk rating."""
@@ -1594,16 +1548,12 @@ class CycloneDxAdapter(BaseAdapter):
         if score is not None:
             score = min(100, max(0, int(score)))
         else:
-            score = {"low": 20, "medium": 45, "high": 70, "critical": 90}.get(
-                level, 45
-            )
+            score = {"low": 20, "medium": 45, "high": 70, "critical": 90}.get(level, 45)
 
         precogly_level = CDX_TO_LEVEL.get(level, "medium")
         return score, precogly_level
 
-    def _resolve_control_threat_links(
-        self, threats_block, threat_model, resolver
-    ):
+    def _resolve_control_threat_links(self, threats_block, threat_model, resolver):
         """Create CountermeasureThreatLink records from threat mitigations."""
         from apps.threats.models import (
             ComponentInstanceThreat,
@@ -1694,9 +1644,7 @@ class CycloneDxAdapter(BaseAdapter):
             tier3["visualizations"] = passthrough_visualizations
 
         if tier3:
-            threat_model.format_metadata.setdefault("cyclonedx", {}).update(
-                tier3
-            )
+            threat_model.format_metadata.setdefault("cyclonedx", {}).update(tier3)
             threat_model.save(update_fields=["format_metadata"])
 
     def _import_dfd(self, vis_data, threat_model, resolver):

--- a/backend/apps/threat_models/adapters/cyclonedx.py
+++ b/backend/apps/threat_models/adapters/cyclonedx.py
@@ -889,12 +889,12 @@ class CycloneDxAdapter(BaseAdapter):
 
         # 3. Zones
         for zone_data in blueprint.get("zones", []):
-            self._import_zone(zone_data, resolver)
+            self._import_zone(zone_data, resolver, organization)
             summary["zones"] += 1
 
         # 4. Boundaries (depends on zones)
         for boundary_data in blueprint.get("boundaries", []):
-            self._import_boundary(boundary_data, resolver)
+            self._import_boundary(boundary_data, resolver, organization)
             summary["boundaries"] += 1
 
         # 5. Assets -> OrgsystemComponent
@@ -998,7 +998,7 @@ class CycloneDxAdapter(BaseAdapter):
         )
         return orgsystem
 
-    def _import_zone(self, zone_data, resolver):
+    def _import_zone(self, zone_data, resolver, organization):
         from apps.systems.models import TrustZone
 
         bom_ref = zone_data.get("bom-ref", "")
@@ -1010,6 +1010,7 @@ class CycloneDxAdapter(BaseAdapter):
             parent = resolver.resolve("zone", parent_ref)
 
         zone = TrustZone.objects.create(
+            organization=organization,
             name=name,
             description=zone_data.get("description", ""),
             trust_level=zone_data.get("trustLevel"),
@@ -1018,7 +1019,7 @@ class CycloneDxAdapter(BaseAdapter):
         resolver.register("zone", bom_ref, zone)
         return zone
 
-    def _import_boundary(self, boundary_data, resolver):
+    def _import_boundary(self, boundary_data, resolver, organization):
         from apps.systems.models import TrustBoundary
 
         bom_ref = boundary_data.get("bom-ref", "")
@@ -1036,6 +1037,7 @@ class CycloneDxAdapter(BaseAdapter):
         crossing = boundary_data.get("crossingRequirements", {})
 
         boundary = TrustBoundary.objects.create(
+            organization=organization,
             zone_a=zone_a,
             zone_b=zone_b,
             label=boundary_data.get("name", ""),

--- a/backend/apps/threat_models/adapters/tm_library.py
+++ b/backend/apps/threat_models/adapters/tm_library.py
@@ -483,6 +483,7 @@ class TmLibraryAdapter(BaseAdapter):
             # 2. Trust Zones
             for tz_data in json_data.get("trust_zones", []):
                 tz = TrustZone.objects.create(
+                    organization=organization,
                     name=tz_data.get("title", tz_data["symbolic_name"]),
                     description=tz_data.get("description", ""),
                     format_metadata={
@@ -507,6 +508,7 @@ class TmLibraryAdapter(BaseAdapter):
                 zone_b = resolver.resolve("trust_zone", tb_data.get("trust_zone_b", ""))
                 if zone_a and zone_b:
                     TrustBoundary.objects.create(
+                        organization=organization,
                         zone_a=zone_a,
                         zone_b=zone_b,
                         format_metadata={

--- a/backend/apps/threat_models/models.py
+++ b/backend/apps/threat_models/models.py
@@ -9,6 +9,7 @@ from django.dispatch import receiver
 
 from apps.compliance.models import StandardFramework
 from apps.core.models import TimestampedModel
+from apps.core.tenancy import Tenancy
 from apps.organizations.models import Organization
 from apps.systems.models import Orgsystem
 
@@ -50,6 +51,10 @@ class ThreatModelQuerySet(models.QuerySet):
 
 class ThreatModel(TimestampedModel):
     """Threat model."""
+
+    # One of the seven models carrying `organization` directly, and the anchor most of
+    # the rest of the schema reaches an organization through.
+    tenancy = Tenancy.TENANT_OWNED
 
     objects = ThreatModelQuerySet.as_manager()
 
@@ -114,6 +119,8 @@ class ThreatModel(TimestampedModel):
 class ThreatModelOrgsystem(models.Model):
     """Association between threat model and orgsystem."""
 
+    tenancy = Tenancy.TENANT_OWNED
+
     threat_model = models.ForeignKey(
         ThreatModel,
         on_delete=models.CASCADE,
@@ -135,6 +142,10 @@ class ThreatModelOrgsystem(models.Model):
 class ThreatModelLibraryPack(models.Model):
     """Association between threat model and library pack."""
 
+    # The link is tenant-owned even though the pack it names is not: which packs a
+    # threat model has connected is that organization's business.
+    tenancy = Tenancy.TENANT_OWNED
+
     threat_model = models.ForeignKey(
         ThreatModel,
         on_delete=models.CASCADE,
@@ -155,6 +166,8 @@ class ThreatModelLibraryPack(models.Model):
 
 class ThreatModelRelationship(TimestampedModel):
     """Relationship between threat models."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class RelationType(models.TextChoices):
         DEPENDS_ON = "depends_on", "Depends On"
@@ -188,6 +201,8 @@ class ThreatModelRelationship(TimestampedModel):
 class ThreatModelFramework(models.Model):
     """Association between threat model and compliance framework."""
 
+    tenancy = Tenancy.TENANT_OWNED
+
     threat_model = models.ForeignKey(
         ThreatModel,
         on_delete=models.CASCADE,
@@ -208,6 +223,8 @@ class ThreatModelFramework(models.Model):
 
 class ThreatModelReferenceImage(TimestampedModel):
     """Reference image for threat model (whiteboard photos, architecture diagrams, etc.)."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     threat_model = models.ForeignKey(
         ThreatModel,
@@ -247,6 +264,8 @@ class ThreatModelReferenceImage(TimestampedModel):
 class OutOfScopeItem(TimestampedModel):
     """Out-of-scope item for a threat model."""
 
+    tenancy = Tenancy.TENANT_OWNED
+
     threat_model = models.ForeignKey(
         ThreatModel,
         on_delete=models.CASCADE,
@@ -264,6 +283,8 @@ class OutOfScopeItem(TimestampedModel):
 
 class UseCase(TimestampedModel):
     """Use case associated with a threat model (CycloneDX 2.0 TM-BOM)."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     threat_model = models.ForeignKey(
         ThreatModel,

--- a/backend/apps/threats/models.py
+++ b/backend/apps/threats/models.py
@@ -902,10 +902,10 @@ class Risk(TimestampedModel):
     # fields up is the same shape and spells "not set" as `blank=True` alone, so this
     # model carries two spellings for it.
     #
-    # Backend and frontend have to land together. `RiskAssessmentViewSet.bulk_update`
-    # writes NULL deliberately — `request.data["response"] or None` — and the risk
-    # board filters with `r.response === col.response` against a column whose key is
-    # `null`, so a stored "" would drop every cleared risk off the board.
+    # Backend and frontend have to land together. `RiskViewSet.bulk_update` writes
+    # NULL deliberately — `request.data["response"] or None` — and the risk board
+    # filters with `r.response === col.response` against a column whose key is `null`,
+    # so a stored "" would drop every cleared risk off the board.
     response = models.CharField(  # noqa: DJ001
         max_length=20,
         choices=Response.choices,

--- a/backend/apps/threats/models.py
+++ b/backend/apps/threats/models.py
@@ -8,11 +8,14 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
 from apps.core.models import TimestampedModel
+from apps.core.tenancy import Tenancy
 from apps.systems.models import ComponentLibrary, DataFlow, OrgsystemComponent
 
 
 class ThreatLibrary(TimestampedModel):
     """Threat template/definition."""
+
+    tenancy = Tenancy.MIXED
 
     class CustomizationStatus(models.TextChoices):
         ORIGINAL = "original", "Original (from pack)"
@@ -93,6 +96,8 @@ class ThreatLibrary(TimestampedModel):
 class ExternalTaxonomy(TimestampedModel):
     """External threat classification taxonomy (STRIDE, CAPEC, CWE, etc.)."""
 
+    tenancy = Tenancy.SHARED_REFERENCE
+
     source_pack = models.ForeignKey(
         "packs.LibraryPack",
         on_delete=models.SET_NULL,
@@ -116,6 +121,8 @@ class ExternalTaxonomy(TimestampedModel):
 
 class TaxonomyEntry(TimestampedModel):
     """Single entry within a taxonomy (e.g., STRIDE:tampering, CAPEC:66)."""
+
+    tenancy = Tenancy.SHARED_REFERENCE
 
     taxonomy = models.ForeignKey(
         ExternalTaxonomy,
@@ -141,6 +148,8 @@ class TaxonomyEntry(TimestampedModel):
 class ThreatLibraryTaxonomyEntry(TimestampedModel):
     """M2M join: links a ThreatLibrary to one or more TaxonomyEntry records."""
 
+    tenancy = Tenancy.SHARED_REFERENCE
+
     threat_library = models.ForeignKey(
         ThreatLibrary,
         on_delete=models.CASCADE,
@@ -161,6 +170,8 @@ class ThreatLibraryTaxonomyEntry(TimestampedModel):
 
 class ComponentLibraryThreat(TimestampedModel):
     """Association between component library and threats."""
+
+    tenancy = Tenancy.SHARED_REFERENCE
 
     class AppliesTo(models.TextChoices):
         COMPONENT = "component", "Component"
@@ -193,6 +204,8 @@ class ComponentLibraryThreat(TimestampedModel):
 
 class CountermeasureLibrary(TimestampedModel):
     """Countermeasure/control template."""
+
+    tenancy = Tenancy.MIXED
 
     class Cost(models.TextChoices):
         LOW = "low", "Low"
@@ -308,6 +321,8 @@ class ThreatAccessLevel(models.TextChoices):
 class ComponentInstanceThreat(TimestampedModel):
     """Threat instance for a specific component."""
 
+    tenancy = Tenancy.TENANT_OWNED
+
     class Severity(models.TextChoices):
         LOW = "low", "Low"
         MEDIUM = "medium", "Medium"
@@ -411,6 +426,8 @@ class ComponentInstanceThreat(TimestampedModel):
 
 class DataFlowInstanceThreat(TimestampedModel):
     """Threat instance for a specific data flow."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class Severity(models.TextChoices):
         LOW = "low", "Low"
@@ -516,6 +533,8 @@ class DataFlowInstanceThreat(TimestampedModel):
 class InstanceCountermeasure(TimestampedModel):
     """Unified countermeasure instance scoped to a threat model, linked to threats via junction table."""
 
+    tenancy = Tenancy.TENANT_OWNED
+
     class Status(models.TextChoices):
         GAP = "gap", "Gap"
         PLANNED = "planned", "Planned"
@@ -602,6 +621,8 @@ class InstanceCountermeasure(TimestampedModel):
 class CountermeasureThreatLink(TimestampedModel):
     """Polymorphic junction table linking a countermeasure to component and/or flow threats."""
 
+    tenancy = Tenancy.TENANT_OWNED
+
     countermeasure = models.ForeignKey(
         InstanceCountermeasure,
         on_delete=models.CASCADE,
@@ -653,6 +674,13 @@ class CountermeasureThreatLink(TimestampedModel):
 class VerificationTest(TimestampedModel):
     """Verification test for countermeasures."""
 
+    # Tenant-owned despite reading like a template: `last_run_at`, `passed`, and
+    # `evidence` are one organization's test result, not a definition. Like TrustZone it
+    # carries no foreign key saying so — it is reached only through
+    # `InstanceCountermeasureTest` — and `/api/verification-tests/` serves it. Suspected
+    # to leak the same way #404 does; unverified.
+    tenancy = Tenancy.TENANT_OWNED
+
     class Method(models.TextChoices):
         PENTEST = "pentest", "Penetration Test"
         AUTO = "auto", "Automated Scan"
@@ -673,6 +701,8 @@ class VerificationTest(TimestampedModel):
 
 class InstanceCountermeasureTest(TimestampedModel):
     """Association between countermeasure and verification test."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     countermeasure = models.ForeignKey(
         InstanceCountermeasure,
@@ -696,6 +726,8 @@ class InstanceCountermeasureTest(TimestampedModel):
 
 class CountermeasureComment(TimestampedModel):
     """Comment/history log entry for a countermeasure instance."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -722,6 +754,8 @@ class CountermeasureComment(TimestampedModel):
 
 class PentestFinding(TimestampedModel):
     """Pentest finding for reconciliation."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class ReconciliationStatus(models.TextChoices):
         MATCHED = "matched", "Matched"
@@ -768,6 +802,10 @@ class InstanceCountermeasureStandard(TimestampedModel):
     Allows overriding library-level compliance mappings for specific countermeasure instances.
     Instance mappings take precedence over library mappings for the same requirement.
     """
+
+    # The override belongs to whoever made it, even though both things it names —
+    # a library countermeasure and a published requirement — are shared.
+    tenancy = Tenancy.TENANT_OWNED
 
     class Sufficiency(models.TextChoices):
         FULL = "full", "Full"
@@ -823,6 +861,8 @@ def build_taxonomy_snapshot(threat_library):
 
 class Risk(TimestampedModel):
     """Business-level risk that aggregates multiple threat instances."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class Level(models.TextChoices):
         LOW = "low", "Low"
@@ -922,6 +962,8 @@ class Risk(TimestampedModel):
 class ThreatPersona(TimestampedModel):
     """Threat persona scoped to a specific threat model."""
 
+    tenancy = Tenancy.TENANT_OWNED
+
     threat_model = models.ForeignKey(
         "threat_models.ThreatModel",
         on_delete=models.CASCADE,
@@ -960,6 +1002,8 @@ class ThreatPersona(TimestampedModel):
 
 class ThreatPersonaLink(TimestampedModel):
     """Links a ThreatPersona to a threat instance (dual-FK pattern)."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     persona = models.ForeignKey(
         ThreatPersona,
@@ -1010,6 +1054,8 @@ class ThreatPersonaLink(TimestampedModel):
 class ThreatSource(TimestampedModel):
     """Global reference table for threat sources (e.g., NIST SP 800-30r1)."""
 
+    tenancy = Tenancy.SHARED_REFERENCE
+
     slug = models.SlugField(max_length=50, unique=True)
     name = models.CharField(max_length=100)
     description = models.TextField(blank=True, default="")
@@ -1023,6 +1069,9 @@ class ThreatSource(TimestampedModel):
 
 class ThreatSourceLink(TimestampedModel):
     """Links a ThreatSource to a threat instance (dual-FK pattern)."""
+
+    # The source is shared; which threat instance cites it is not.
+    tenancy = Tenancy.TENANT_OWNED
 
     source = models.ForeignKey(
         ThreatSource,
@@ -1072,6 +1121,8 @@ class ThreatSourceLink(TimestampedModel):
 
 class RiskResponse(TimestampedModel):
     """Structured risk response (CycloneDX 2.0 TM-BOM)."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     class Strategy(models.TextChoices):
         AVOID = "avoid", "Avoid"
@@ -1123,6 +1174,8 @@ class RiskResponse(TimestampedModel):
 
 class RiskThreat(TimestampedModel):
     """Junction table linking a Risk to threat instances."""
+
+    tenancy = Tenancy.TENANT_OWNED
 
     risk = models.ForeignKey(
         Risk,

--- a/backend/apps/threats/models.py
+++ b/backend/apps/threats/models.py
@@ -32,7 +32,11 @@ class ThreatLibrary(TimestampedModel):
         blank=True,
         help_text="Unique identifier within pack, e.g., 'sql-injection'",
     )
-    qualified_slug = models.CharField(
+    # `null=True` is required by `unique_threat_qualified_slug` below. Postgres treats
+    # NULLs as distinct under a unique index, so any number of rows may carry no
+    # qualified slug; `blank=True` with `""` would make the second such row collide
+    # with the first. DJ001 cannot see the constraint.
+    qualified_slug = models.CharField(  # noqa: DJ001
         max_length=200,
         null=True,
         blank=True,
@@ -84,7 +88,6 @@ class ThreatLibrary(TimestampedModel):
             else:
                 self.qualified_slug = f"custom/{self.slug}"
         super().save(*args, **kwargs)
-
 
 
 class ExternalTaxonomy(TimestampedModel):
@@ -214,7 +217,9 @@ class CountermeasureLibrary(TimestampedModel):
         blank=True,
         help_text="Unique identifier within pack, e.g., 'encryption-at-rest'",
     )
-    qualified_slug = models.CharField(
+    # `null=True` is required by `unique_countermeasure_qualified_slug` below, for the
+    # same reason as `ThreatLibrary.qualified_slug`.
+    qualified_slug = models.CharField(  # noqa: DJ001
         max_length=200,
         null=True,
         blank=True,
@@ -574,7 +579,9 @@ class InstanceCountermeasure(TimestampedModel):
         help_text="User-assessed control effectiveness (0.0-1.0). Null = not yet assessed.",
     )
     priority = models.CharField(max_length=10, default="none", blank=True)
-    due_date = models.DateField(null=True, blank=True, help_text="Target completion date")
+    due_date = models.DateField(
+        null=True, blank=True, help_text="Target completion date"
+    )
     external_ticket_url = models.URLField(
         blank=True, help_text="Link to Jira/GitHub/etc. ticket"
     )
@@ -851,7 +858,15 @@ class Risk(TimestampedModel):
         choices=Level.choices,
         blank=True,
     )
-    response = models.CharField(
+    # TODO: drop `null=True` and migrate existing NULLs to "". `residual_level` two
+    # fields up is the same shape and spells "not set" as `blank=True` alone, so this
+    # model carries two spellings for it.
+    #
+    # Backend and frontend have to land together. `RiskAssessmentViewSet.bulk_update`
+    # writes NULL deliberately — `request.data["response"] or None` — and the risk
+    # board filters with `r.response === col.response` against a column whose key is
+    # `null`, so a stored "" would drop every cleared risk off the board.
+    response = models.CharField(  # noqa: DJ001
         max_length=20,
         choices=Response.choices,
         null=True,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -159,8 +159,13 @@ known-first-party = ["apps", "config"]
 # it does not run under -O. The Django-style tests here use `self.assertEqual`
 # and never tripped it; the pytest-style ones added with the MCP work do, 51
 # times in three files.
-"**/tests/**" = ["S101", "S105", "S106"]
-"**/tests.py" = ["S101", "S105", "S106"]
+#
+# DJ008 wants `__str__` on every model. The models in
+# apps/core/tests/test_tenancy_check.py exist for the length of one test, under
+# `isolate_apps`, and are never rendered anywhere — the rule has nothing to protect
+# there.
+"**/tests/**" = ["DJ008", "S101", "S105", "S106"]
+"**/tests.py" = ["DJ008", "S101", "S105", "S106"]
 
 [tool.pytest.ini_options]
 # Wire pytest-django to the same settings manage.py uses by default. The


### PR DESCRIPTION
Closes #404. Closes #406.

## The problem

Six cross-tenant defects are open — #226, #227, #404, #405, #406, #258, each
found by hand. e82e480 swept four viewsets for exactly this bug class and still
missed #404.

They keep happening because the boundary is re-derived in every viewset, as a join
from the caller's memberships to whatever the model hangs off. Nothing in the
schema lets anyone check the join. Of the 61 models in `apps/`, 43 reach
`Organization`, 38 of those by more than one path and every one through a nullable
foreign key. `TrustZone`, `TrustBoundary` and `VerificationTest` hold customer data
and reach it by no forward path at all.

## What this does

**Every model in `apps/` declares who its rows belong to** — `TENANT_OWNED`,
`SHARED_REFERENCE` or `MIXED`. 

This PR also adds a Django system check that fails on any model that
doesn't declare its tenancy.
43 are tenant-owned, 12 are shared reference, and 6 are mixed.

**`TrustZone` and `TrustBoundary` are a bit of a special case and get a non-null `organization`.**
Trust zones had no column saying which organization they belong to. Anything that needed to know walked out through the zone's components to a threat model or a system, and from there to an organization — several hops, more than one route, and a nullable link on most of them. Each viewset picked its own route, and nothing checked the choice.

Two bugs came out of that:

- `GET /api/trust-zones/?threat_model=` returned other organizations' zones (#404). The viewset joined through two of the available paths and they were the wrong two.
- `PATCH /api/diagrams/<your own dfd>/` overwrote another organization's zone (#406). The canvas sync reads a `trust_zone_id` out of the request body, looks it up with no filter, and writes the node's name and trust level onto whatever comes back. Trust level feeds threat analysis, so the row is left wrong, not just renamed. There was no queryset to fix here — the lookup was unfiltered because there was nothing to filter on.

This adds a non-null `organization` to `TrustZone` and `TrustBoundary`. It duplicates nothing on these two: `TrustZone` had no foreign key reaching an organization at all.

The migration derives each existing zone's owner once, through its components. 
**There are two edge cases we still need to handle in the future:**
1. A zone reachable from two organizations (which is #406 having already happened) 
2. A zone reachable from none. 
For right now, both raise and name the rows, and nothing is deleted. `manage.py trust_zone_owners` prints the same list so we can look before you migrate.

## Verification

Run on the branch at `dd09b5e` on 2026-08-30:

```
uv run pytest -q                                       ->  242 passed
manage.py check                                        ->  no issues (0 silenced)
manage.py makemigrations --check --dry-run             ->  No changes detected
pre-commit run --from-ref upstream/main --to-ref HEAD  ->  passed
```

Run with uv against a local Postgres; this branch predates the compose rework in
#322 and the cached image no longer matches its mounts. All six CI checks are green
on `dd09b5e`, which includes `docker compose run --rm backend python -m pytest`.

Both regression tests were checked against the unfixed code. The #404 pair fails
without the viewset change; #406 reproduces as
`('Adopted by Kestrel', 99) != ('Contoso DMZ', 20)`.

## Not done here

- **Six `# noqa: DJ001` on the branch; two of them are deferrals.** The four on
  `qualified_slug` are permanent — `null=True` is required by the unique constraint,
  since Postgres treats NULLs as distinct and `""` would collide. The two that are
  debt are `Risk.response` and `OrgsystemComponent.category`. Both need a data
  migration, and neither is only that: `category` feeds a `.tm` export branch no test
  covers (`tm_library.py:1362` exports a component as an actor when the category is
  NULL), and `response` is what the risk board filters on with `null` as a column
  key, so backend and frontend have to land together. No issue filed for either.