### PR TITLE
Sync frontend CountermeasureStatus with the backend's 8 values (fixes #328)

### DIFF
--- a/frontend/src/features/dfd-editor/types/threat-analysis.ts
+++ b/frontend/src/features/dfd-editor/types/threat-analysis.ts
@@ -18,7 +18,7 @@ export interface ComplianceStandardMapping {
 /**
  * Status of a countermeasure for a specific component-threat
  */
-export type CountermeasureStatus = 'platform' | 'gap' | 'planned' | 'verified' | 'waived'
+export type CountermeasureStatus = 'platform' | 'gap' | 'planned' | 'in_progress' | 'implemented' | 'verified' | 'waived' | 'decommissioned'
 
 export const COUNTERMEASURE_STATUS_CONFIG: Record<
   CountermeasureStatus,
@@ -53,6 +53,24 @@ export const COUNTERMEASURE_STATUS_CONFIG: Record<
     color: '#3b82f6', // blue
     bgColor: 'bg-blue-500',
     description: 'Risk accepted, not implementing',
+  },
+  in_progress: {
+    label: 'In Progress',
+    color: '#eab308', // yellow
+    bgColor: 'bg-yellow-500',
+    description: 'Implementation actively underway',
+  },
+  implemented: {
+    label: 'Implemented',
+    color: '#10b981', // teal-green, distinct from verified
+    bgColor: 'bg-emerald-500',
+    description: 'Implemented, not yet independently verified by the security team',
+  },
+  decommissioned: {
+    label: 'Decommissioned',
+    color: '#6b7280', // gray
+    bgColor: 'bg-gray-400',
+    description: 'Control formally retired, no longer tracked as active',
   },
 }
 
@@ -220,9 +238,11 @@ export function deriveThreatStatus(countermeasures: ComponentThreatCountermeasur
 
   const hasPlanned = countermeasures.some((cm) => cm.status === 'planned')
   const hasWaived = countermeasures.some((cm) => cm.status === 'waived')
-  if (hasPlanned || hasWaived) return 'addressable'
+  const hasInProgress = countermeasures.some((cm) => cm.status === 'in_progress')
+  if (hasPlanned || hasWaived || hasInProgress) return 'addressable'
 
-  // All are 'platform' or 'verified' (no gaps, no planned, no waived)
+  // All are 'platform', 'verified', 'implemented', or 'decommissioned'
+  // (no gaps, no planned, no waived, no in_progress)
   return 'mitigated'
 }
 

--- a/frontend/src/features/threat-models/api/threats.ts
+++ b/frontend/src/features/threat-models/api/threats.ts
@@ -9,8 +9,10 @@ import type { TaxonomyEntry } from '@/types/domain'
 import { componentKeys } from './components'
 import { riskKeys } from './risks'
 
-// Backend countermeasure status (aligned with frontend CountermeasureStatus)
-type BackendCountermeasureStatus = 'platform' | 'gap' | 'planned' | 'verified' | 'waived'
+// Backend countermeasure status. Aliased directly to the frontend CountermeasureStatus
+// type (rather than duplicated as a literal union) so the two can no longer drift --
+// this duplication is what caused precogly/precogly#328.
+type BackendCountermeasureStatus = CountermeasureStatus
 
 // Types
 export interface ComponentInstanceThreat {


### PR DESCRIPTION
`InstanceCountermeasure.Status` on the backend has carried 8 values — `gap`, `planned`, `in_progress`, `implemented`, `verified`, `waived`, `platform`, `decommissioned` — since `0012_cyclonedx_schema_enrichment` (2026-07-11). The frontend never caught up: `CountermeasureStatus` in `dfd-editor/types/threat-analysis.ts` still had only 5, so `COUNTERMEASURE_STATUS_CONFIG[status]` returned `undefined` for any countermeasure the backend had marked `in_progress`, `implemented` or `decommissioned`. That is the crash reported in #328.

This widens `CountermeasureStatus` to the full 8-value union, adds display config (label/color/description) for the 3 missing statuses, and updates `deriveThreatStatus()` so `in_progress` counts toward *addressable* alongside `planned`/`waived`, and `implemented`/`decommissioned` join `platform`/`verified` under *mitigated*.

It also fixes a second, independent copy of the same drift: `threat-models/api/threats.ts` declared its own local `BackendCountermeasureStatus` as a 5-value literal union, commented "aligned with frontend CountermeasureStatus" but kept in sync only by hand. That is now a direct type alias to the imported type, so the two can no longer diverge.

Verified with a full `tsc -b --noEmit` in the frontend container: 0 errors after both changes. The first change alone fails the build (TS2322 in `useWorkspaceThreatAnalysis.ts`, `in_progress` not assignable to the stale union), which is what shows the second copy was load-bearing.

Fixes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
