### PR TITLE
fix(threat-models): paginate the Risk Register

### DIFF
--- a/backend/apps/core/management/commands/seed.py
+++ b/backend/apps/core/management/commands/seed.py
@@ -2,7 +2,8 @@
 Seed the database with demo data for new contributors.
 
 Creates a superuser, demo organization, imports library packs,
-and creates sample threat models with DFD templates.
+and creates sample threat models with DFD templates. Fills the first sample
+model's Risk Register.
 
 Also creates a second organization and a member who is not on the security team, so
 that the demo database can exhibit multi-tenancy. See _create_second_org for why that
@@ -27,6 +28,8 @@ from apps.organizations.models import (
 from apps.packs.models import LibraryPack
 from apps.packs.services import get_libraries_path, import_pack_from_path, validate_pack
 from apps.threat_models.models import ThreatModel, ThreatModelLibraryPack
+from apps.threats.models import Risk
+from apps.threats.services import calculate_inherent_score
 
 User = get_user_model()
 
@@ -94,6 +97,52 @@ SECOND_ORG_THREAT_MODELS = [
     },
 ]
 
+# Risks for the Risk Register, on the first sample threat model.
+#
+# Scores are not written here. `calculate_inherent_score` derives them from these
+# pairs the same way the application does, so demo risks cannot drift from what
+# the scoring engine would produce.
+SAMPLE_RISKS = {
+    None: [
+        ("Unauthenticated internal Lambda invoke URL", "certain", "severe"),
+        ("Public S3 bucket exposes customer documents", "likely", "severe"),
+        ("No request throttling on the auth endpoint", "likely", "major"),
+        ("Lambda role grants wildcard S3 permissions", "possible", "severe"),
+        ("Secrets in plaintext Lambda env variables", "possible", "major"),
+        ("Request bodies with PII retained in logs", "unlikely", "major"),
+    ],
+    "mitigate": [
+        ("SQL injection in the order lookup handler", "likely", "severe"),
+        ("WAF rules miss newer OWASP categories", "certain", "major"),
+        ("JWT signature unchecked on the internal path", "likely", "major"),
+        ("Cross-tenant read via unvalidated bucket key", "certain", "moderate"),
+        ("Known RCE in a bundled Lambda dependency", "likely", "moderate"),
+        ("No rate limit on credential stuffing", "certain", "minor"),
+        ("Stack traces disclosed in API errors", "possible", "moderate"),
+    ],
+    # Carried by a provider contract or an insurer.
+    "transfer": [
+        ("Payment processor outage halts settlement", "unlikely", "severe"),
+        ("OpenSearch cluster loses an availability zone", "unlikely", "major"),
+        ("CDN mis-routes traffic on a config push", "possible", "minor"),
+        ("Identity provider certificate expires", "unlikely", "moderate"),
+    ],
+    # The activity is dropped rather than controlled.
+    "avoid": [
+        ("Shared root credentials in the deploy pipeline", "likely", "severe"),
+        ("Customer data copied to the analytics sandbox", "possible", "severe"),
+        ("Direct database access from developer laptops", "possible", "major"),
+    ],
+    # Raising either value on any of these lifts it onto the first page, so the
+    # Accept column stops being empty there.
+    "accept": [
+        ("Internal status page exposes service names", "rare", "negligible"),
+        ("Staging bucket keeps unversioned objects", "rare", "negligible"),
+        ("Admin console lacks a session idle timeout", "rare", "negligible"),
+        ("Developer docs list internal hostnames", "rare", "negligible"),
+    ],
+}
+
 
 class Command(BaseCommand):
     help = "Seed database with demo data for development"
@@ -118,6 +167,7 @@ class Command(BaseCommand):
         # imported packs on the same run rather than on the next one.
         self._create_second_org()
         self._connect_packs_to_threat_models()
+        self._seed_risks(org)
         self._report_accounts()
 
     def _create_org(self):
@@ -378,6 +428,61 @@ class Command(BaseCommand):
                     f"({components_count} components, {threats_count} threats)"
                 )
             )
+
+    def _seed_risks(self, org):
+        """Fill the first sample threat model's Risk Register.
+
+        Keyed on whether that model already has risks, not on whether this run
+        created it. `_create_sample_threat_models` skips a model that exists, so
+        a step hung off model creation would never run on a database that has
+        been seeded before — which is every database that needs this.
+        """
+        threat_model = ThreatModel.objects.filter(
+            name=SAMPLE_THREAT_MODELS[0]["name"], organization=org
+        ).first()
+        if not threat_model:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"No threat model named {SAMPLE_THREAT_MODELS[0]['name']}. "
+                    "Risk Register left empty."
+                )
+            )
+            return
+
+        if threat_model.risks.exists():
+            self.stdout.write(f"Risks already exist: {threat_model.name}")
+            return
+
+        owner = User.objects.filter(username=DEMO_EMAIL).first()
+        assignee = User.objects.filter(username=ANALYST_EMAIL).first()
+
+        risks = []
+        for response, entries in SAMPLE_RISKS.items():
+            for name, likelihood, impact in entries:
+                scoring_metadata = {"likelihood": likelihood, "impact": impact}
+                score, level = calculate_inherent_score(
+                    threat_model.risk_scoring_method, scoring_metadata
+                )
+                position = len(risks)
+                risks.append(
+                    Risk(
+                        threat_model=threat_model,
+                        name=name,
+                        scoring_metadata=scoring_metadata,
+                        inherent_score=score,
+                        inherent_level=level,
+                        response=response,
+                        # Leave every third risk unowned. An owner column filled
+                        # on every row never renders its empty state.
+                        owner=owner if position % 3 else None,
+                        assigned_to=assignee if position % 4 == 0 else None,
+                    )
+                )
+
+        Risk.objects.bulk_create(risks)
+        self.stdout.write(
+            self.style.SUCCESS(f"Created {len(risks)} risks on {threat_model.name}")
+        )
 
     def _connect_packs_to_threat_models(self):
         """Ensure all imported packs are connected to all threat models."""

--- a/backend/apps/core/pagination.py
+++ b/backend/apps/core/pagination.py
@@ -1,0 +1,23 @@
+"""Project-wide pagination."""
+
+from rest_framework.pagination import PageNumberPagination
+
+
+class ClientSizedPagination(PageNumberPagination):
+    """Page-number pagination whose page size the client may choose.
+
+    Stock ``PageNumberPagination`` leaves ``page_size_query_param`` unset, so
+    ``PAGE_SIZE`` is the only page size any client can get. The Risk Register's
+    board groups a page into columns, so a column count describes the register
+    only when the page holds it. A caller that asks for no size still gets
+    ``PAGE_SIZE``.
+
+    Without ``max_page_size``, ``?page_size=999999`` is a request to serialize
+    an entire table.
+    """
+
+    page_size_query_param = "page_size"
+    # Arbitrary: a round bound, and the largest size the Risk Register offers.
+    # Nothing was measured. Raise it alongside a figure for the payload that
+    # produces.
+    max_page_size = 200

--- a/backend/apps/threats/tests/test_risk_pagination.py
+++ b/backend/apps/threats/tests/test_risk_pagination.py
@@ -1,0 +1,90 @@
+"""Regression test for precogly/precogly#484.
+
+The page-size tests fail without `ClientSizedPagination`. The rest pass against
+stock `PageNumberPagination` too — they pin DRF behavior the frontend depends on
+rather than anything this change introduced.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.core.pagination import ClientSizedPagination
+from apps.organizations.models import Organization, OrganizationMember
+from apps.threat_models.models import ThreatModel
+from apps.threats.models import Risk
+
+User = get_user_model()
+
+# The count from #484. Any number above PAGE_SIZE would do.
+RISK_COUNT = 24
+
+
+class RiskRegisterPaginationTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.org = Organization.objects.create(name="Contoso")
+        cls.user = User.objects.create_user(
+            username="analyst", email="analyst@contoso.test", password="pw"
+        )
+        OrganizationMember.objects.create(
+            organization=cls.org, user=cls.user, role="security_team"
+        )
+        cls.threat_model = ThreatModel.objects.create(
+            organization=cls.org, created_by=cls.user, name="Contoso threat model"
+        )
+        for i in range(RISK_COUNT):
+            Risk.objects.create(
+                threat_model=cls.threat_model,
+                name=f"Risk {i:02d}",
+                inherent_score=i,
+                inherent_level="medium",
+            )
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {RefreshToken.for_user(self.user).access_token}"
+        )
+        self.url = f"/api/threat-models/{self.threat_model.pk}/risks/"
+
+    def test_first_page_reports_the_whole_register(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], RISK_COUNT)
+        self.assertEqual(len(response.data["results"]), 20)
+        self.assertIsNotNone(response.data["next"])
+
+    def test_pages_together_cover_the_register_without_overlap(self):
+        page_one = self.client.get(self.url, {"page": 1}).data["results"]
+        page_two = self.client.get(self.url, {"page": 2}).data["results"]
+
+        ids = [risk["id"] for risk in page_one + page_two]
+        self.assertEqual(len(ids), RISK_COUNT)
+        self.assertEqual(len(set(ids)), RISK_COUNT)
+
+    def test_client_may_choose_the_page_size(self):
+        """Without `page_size_query_param` this returns 20, so the register's
+        board could never group more than a default page into its columns."""
+        response = self.client.get(self.url, {"page_size": 100})
+
+        self.assertEqual(len(response.data["results"]), RISK_COUNT)
+        self.assertIsNone(response.data["next"])
+
+    def test_page_size_is_capped(self):
+        """An unbounded page size is a request to serialize the whole table."""
+        response = self.client.get(self.url, {"page_size": 100000})
+
+        self.assertEqual(
+            len(response.data["results"]),
+            min(RISK_COUNT, ClientSizedPagination.max_page_size),
+        )
+
+    def test_page_past_the_end_is_rejected(self):
+        """Why the register steps back a page after deleting a page's last row:
+        an out-of-range page is a 404, not an empty page."""
+        response = self.client.get(self.url, {"page": 99})
+
+        self.assertEqual(response.status_code, 404)

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -202,7 +202,7 @@ REST_FRAMEWORK = {
         "rest_framework.filters.SearchFilter",
         "rest_framework.filters.OrderingFilter",
     ],
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "DEFAULT_PAGINATION_CLASS": "apps.core.pagination.ClientSizedPagination",
     "PAGE_SIZE": 20,
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     # Auto-convert snake_case <-> camelCase at API boundary

--- a/frontend/src/components/ui/pagination.tsx
+++ b/frontend/src/components/ui/pagination.tsx
@@ -1,0 +1,127 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react"
+
+import { buttonVariants, type Button } from "@/components/ui/button"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/frontend/src/features/threat-models/api/risks.ts
+++ b/frontend/src/features/threat-models/api/risks.ts
@@ -2,8 +2,14 @@
  * API hooks for risk endpoints.
  */
 
-import { useQuery, useMutation, useQueryClient, skipToken } from '@tanstack/react-query'
-import { api } from '@/lib/api'
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  skipToken,
+  keepPreviousData,
+} from '@tanstack/react-query'
+import { api, getPage } from '@/lib/api'
 import type {
   Risk,
   ScoringMethod,
@@ -17,26 +23,44 @@ import type {
 // Query keys
 export const riskKeys = {
   all: ['risks'] as const,
+  // Every page's key extends `list`, so the mutations below can keep
+  // invalidating `list` alone and still reach whichever pages are cached.
   list: (threatModelId: string) => [...riskKeys.all, 'list', threatModelId] as const,
+  page: (threatModelId: string, page: number, pageSize: number) =>
+    [...riskKeys.list(threatModelId), { page, pageSize }] as const,
   detail: (threatModelId: string, riskId: number) =>
     [...riskKeys.all, 'detail', threatModelId, riskId] as const,
   scoringMethods: ['scoring-methods'] as const,
 }
 
 /**
- * Fetch all risks for a threat model.
+ * Page sizes the register offers.
+ *
+ * The largest must not exceed `ClientSizedPagination.max_page_size` (200). The
+ * server clamps a larger request rather than rejecting it, so the page controls
+ * would compute a page count from a size they never got.
  */
-export function useRisks(threatModelId: string | null | undefined) {
+export const RISK_PAGE_SIZES = [20, 50, 100, 200] as const
+export const DEFAULT_RISK_PAGE_SIZE = RISK_PAGE_SIZES[0]
+
+/**
+ * Fetch one page of a threat model's risks.
+ *
+ * Returns the whole `Page`. Returning `results` alone is what made the header
+ * report 20 risks for a register of 24: the total lives in `count`.
+ */
+export function useRisks(
+  threatModelId: string | null | undefined,
+  { page = 1, pageSize = DEFAULT_RISK_PAGE_SIZE }: { page?: number; pageSize?: number } = {}
+) {
   return useQuery({
-    queryKey: riskKeys.list(threatModelId!),
+    queryKey: riskKeys.page(threatModelId!, page, pageSize),
     queryFn: threatModelId
-      ? async () => {
-          const response = await api.get<{ results: Risk[] } | Risk[]>(
-            `/threat-models/${threatModelId}/risks/`
-          )
-          return Array.isArray(response) ? response : response.results
-        }
+      ? () => getPage<Risk>(`/threat-models/${threatModelId}/risks/`, { page, pageSize })
       : skipToken,
+    // Hold the previous page on screen while the next one loads. Without this
+    // every page step unmounts the table and shows the tab-wide spinner.
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/frontend/src/features/threat-models/components/workspace/RiskAnalysisTab.tsx
+++ b/frontend/src/features/threat-models/components/workspace/RiskAnalysisTab.tsx
@@ -53,6 +53,13 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination'
+import {
   useRisks,
   useRisk,
   useCreateRisk,
@@ -61,6 +68,8 @@ import {
   useRecalculateRisk,
   useScoringMethods,
   useBulkUpdateRisks,
+  RISK_PAGE_SIZES,
+  DEFAULT_RISK_PAGE_SIZE,
 } from '@/features/threat-models/api/risks'
 import type {
   Risk,
@@ -698,10 +707,14 @@ function BulkActionBar({
   selectedIds,
   threatModelId,
   onClear,
+  isPaginated,
 }: {
   selectedIds: number[]
   threatModelId: string
   onClear: () => void
+  /** Select-all ticks the loaded rows, which is every row only when the register
+      fits on one page. Past that the label has to say so. */
+  isPaginated: boolean
 }) {
   const bulkUpdate = useBulkUpdateRisks(threatModelId)
   const [bulkResponse, setBulkResponse] = useState<RiskResponse | ''>('')
@@ -719,7 +732,9 @@ function BulkActionBar({
 
   return (
     <div className="flex items-center gap-3 p-3 bg-muted/60 border rounded-lg">
-      <span className="text-sm font-medium">{selectedIds.length} selected</span>
+      <span className="text-sm font-medium">
+        {selectedIds.length} selected{isPaginated && ' on this page'}
+      </span>
       <Select value={bulkResponse} onValueChange={(v) => setBulkResponse(v as RiskResponse)}>
         <SelectTrigger className="h-8 w-[150px]">
           <SelectValue placeholder="Set response…" />
@@ -850,6 +865,81 @@ function TableView({
   )
 }
 
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+/**
+ * Props that make a `PaginationPrevious`/`PaginationNext` unusable at a boundary.
+ *
+ * Those render an `<a>`, which has no `disabled`: the component is built for
+ * href-based paging, while this register drives state from `onClick`. Kept here
+ * rather than patched into `components/ui/pagination.tsx` so that file stays a
+ * verbatim copy of upstream.
+ */
+function boundaryProps(atBoundary: boolean) {
+  return atBoundary
+    ? {
+        'aria-disabled': true,
+        tabIndex: -1,
+        className: 'pointer-events-none opacity-50',
+      }
+    : {}
+}
+
+function RegisterPagination({
+  page,
+  pageCount,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+}: {
+  page: number
+  pageCount: number
+  pageSize: number
+  onPageChange: (page: number) => void
+  onPageSizeChange: (pageSize: number) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 flex-wrap">
+      <div className="flex items-center gap-2">
+        <Label className="text-sm text-muted-foreground whitespace-nowrap">Per page:</Label>
+        <Select value={String(pageSize)} onValueChange={(v) => onPageSizeChange(Number(v))}>
+          <SelectTrigger className="h-8 w-[80px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RISK_PAGE_SIZES.map((size) => (
+              <SelectItem key={size} value={String(size)}>{size}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Pagination className="mx-0 w-auto justify-end">
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              href="#"
+              onClick={(e) => { e.preventDefault(); onPageChange(page - 1) }}
+              {...boundaryProps(page <= 1)}
+            />
+          </PaginationItem>
+          <PaginationItem>
+            <span className="px-3 text-sm text-muted-foreground tabular-nums">
+              Page {page} of {pageCount}
+            </span>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext
+              href="#"
+              onClick={(e) => { e.preventDefault(); onPageChange(page + 1) }}
+              {...boundaryProps(page >= pageCount)}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  )
+}
+
 // ─── Main component ───────────────────────────────────────────────────────────
 
 export function RiskAnalysisTab({
@@ -863,14 +953,38 @@ export function RiskAnalysisTab({
   const [selectedRiskId, setSelectedRiskId] = useState<number | null>(null)
   const [deleteRiskId, setDeleteRiskId] = useState<number | null>(null)
   const [selectedIds, setSelectedIds] = useState<number[]>([])
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState<number>(DEFAULT_RISK_PAGE_SIZE)
 
-  const { data: risks, isLoading } = useRisks(threatModelId)
+  const { data: riskPage, isLoading } = useRisks(threatModelId, { page, pageSize })
   const { data: scoringMethods } = useScoringMethods()
   const deleteRisk = useDeleteRisk(threatModelId)
   const recalculateRisk = useRecalculateRisk(threatModelId)
 
+  // `risks` is one page; `totalRisks` is the register. Everything the user can
+  // act on — select, bulk-update, drag between board columns — is scoped to the
+  // page, because that is all the client has.
+  const risks = riskPage?.results
+  const totalRisks = riskPage?.count ?? 0
+  const pageCount = Math.max(1, Math.ceil(totalRisks / pageSize))
+  const firstRowNumber = (page - 1) * pageSize + 1
+  const lastRowNumber = firstRowNumber + (risks?.length ?? 0) - 1
+
   const selectedRisk = risks?.find((r) => r.id === selectedRiskId)
   const activeScoringMethod = scoringMethods?.find((m) => m.key === riskScoringMethod)
+
+  // Selection can only refer to rows that are loaded, so leaving the page drops
+  // it rather than silently carrying ids the user can no longer see.
+  const goToPage = (next: number) => {
+    setPage(next)
+    setSelectedIds([])
+    setSelectedRiskId(null)
+  }
+
+  const changePageSize = (next: number) => {
+    setPageSize(next)
+    goToPage(1)
+  }
 
   const handleDelete = () => {
     if (deleteRiskId === null) return
@@ -879,6 +993,10 @@ export function RiskAnalysisTab({
         setDeleteRiskId(null)
         if (selectedRiskId === deleteRiskId) setSelectedRiskId(null)
         setSelectedIds((prev) => prev.filter((id) => id !== deleteRiskId))
+        // Deleting a page's last row leaves `page` past the end. DRF answers an
+        // out-of-range page with a 404 rather than an empty one, so step back
+        // before the refetch asks for it.
+        if (page > 1 && risks?.length === 1) goToPage(page - 1)
       },
     })
   }
@@ -907,7 +1025,8 @@ export function RiskAnalysisTab({
         <div>
           <h2 className="text-lg font-semibold">Risk Register</h2>
           <p className="text-sm text-muted-foreground">
-            {risks?.length ?? 0} risk{(risks?.length ?? 0) !== 1 ? 's' : ''}
+            {totalRisks} risk{totalRisks !== 1 ? 's' : ''}
+            {pageCount > 1 && ` — showing ${firstRowNumber}–${lastRowNumber}`}
           </p>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
@@ -959,7 +1078,17 @@ export function RiskAnalysisTab({
           selectedIds={selectedIds}
           threatModelId={threatModelId}
           onClear={() => setSelectedIds([])}
+          isPaginated={pageCount > 1}
         />
+      )}
+
+      {/* An empty column does not mean no risks carry that response — they may
+          be on another page. Nothing on the board itself shows that. */}
+      {viewMode === 'kanban' && pageCount > 1 && (
+        <p className="text-sm text-muted-foreground">
+          Board shows risks {firstRowNumber}–{lastRowNumber} of {totalRisks}. Column counts
+          are for this page — raise the page size to see more of the register at once.
+        </p>
       )}
 
       {/* Empty state */}
@@ -976,6 +1105,7 @@ export function RiskAnalysisTab({
           </div>
         </Card>
       ) : (
+        <>
         <div className="flex gap-6">
           {/* Main content */}
           <div className={`flex-1 min-w-0 ${selectedRisk && viewMode === 'table' ? 'max-w-[60%]' : ''}`}>
@@ -1013,6 +1143,19 @@ export function RiskAnalysisTab({
             </div>
           )}
         </div>
+
+        {/* Kept visible at one page too, once the size has been changed, so the
+            control that got the user there can also take them back. */}
+        {(pageCount > 1 || pageSize !== DEFAULT_RISK_PAGE_SIZE) && (
+          <RegisterPagination
+            page={page}
+            pageCount={pageCount}
+            pageSize={pageSize}
+            onPageChange={goToPage}
+            onPageSizeChange={changePageSize}
+          />
+        )}
+        </>
       )}
 
       {/* Detail panel for kanban (below board) */}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -218,6 +218,47 @@ export const api = {
   },
 }
 
+// Paginated list endpoints
+
+/** One page of a DRF `PageNumberPagination` response. */
+export interface Page<T> {
+  count: number
+  next: string | null
+  previous: string | null
+  results: T[]
+}
+
+/**
+ * Fetch one page of a list endpoint.
+ *
+ * List endpoints are paginated by default, but a viewset may set
+ * `pagination_class = None` and return a bare array — many do. Both shapes come
+ * back as a `Page` so callers never branch: a bare array is reported as a single
+ * page holding everything.
+ *
+ * `pageSize` is capped server-side by `ClientSizedPagination.max_page_size`;
+ * asking for more silently yields the cap rather than erroring.
+ */
+export async function getPage<T>(
+  endpoint: string,
+  params: { page?: number; pageSize?: number } = {}
+): Promise<Page<T>> {
+  const query = new URLSearchParams()
+  if (params.page !== undefined) query.set('page', String(params.page))
+  // Snake case deliberately. The camelCase parser rewrites request bodies and
+  // leaves query strings alone, so DRF reads this key verbatim as `page_size`.
+  if (params.pageSize !== undefined) query.set('page_size', String(params.pageSize))
+
+  const separator = endpoint.includes('?') ? '&' : '?'
+  const url = query.size > 0 ? `${endpoint}${separator}${query}` : endpoint
+
+  const response = await apiFetch<Page<T> | T[]>(url)
+  if (Array.isArray(response)) {
+    return { count: response.length, next: null, previous: null, results: response }
+  }
+  return response
+}
+
 // Auth API
 export interface LoginCredentials {
   email: string


### PR DESCRIPTION
## The problem

`useRisks` extracted `results` from the paginated response and discarded `count` and `next`. A register of 24 risks loaded 20 and reported 20 in the header. The remaining four were unreachable, and selection and bulk actions operated on the first page without saying so.

Closes #484.

## What changed

**Backend.** `ClientSizedPagination` sets `page_size_query_param` and `max_page_size = 200`, and becomes the project default. Stock `PageNumberPagination` leaves `page_size_query_param` unset, so `PAGE_SIZE` was the only page size any client could get, and subclassing is the only way DRF offers to change that. A caller that asks for no size still gets `PAGE_SIZE`, so no existing endpoint changes shape.

**Frontend.** `getPage<T>()` in `lib/api.ts` returns the whole `Page` and reports a bare array as a single complete page, so callers never branch on which shape came back. `useRisks` takes `{ page, pageSize }`, keys the query on both, and uses `placeholderData: keepPreviousData`. Page keys extend the existing `list` key, so every mutation's `invalidateQueries` still reaches all cached pages unchanged. The header reports `count`.

**Seeds.** No seeded threat model carried any risks, so the register was empty in every development database and its pagination could not be exercised at all. `_seed_risks` adds 24 to the first sample model, keyed on whether that model already has risks rather than on whether this run created it — `_create_sample_threat_models` skips a model that exists, so a step hung off model creation would never run on a database that had been seeded before.

## The trade-off to look at hardest

The board paginates with the table rather than fetching every page. A Kanban column therefore counts only the current page, so an empty column does not mean no risks carry that response. A banner says as much and the page-size selector goes to 200, but the caveat is real and was chosen deliberately over two alternatives:

- **Fetch every page.** Keeps the board, select-all and the counts correct by construction, at the cost of unbounded rows in the DOM. The CycloneDX and tm_library importers create risks in a loop, so a register can be large.
- **Per-column server queries.** Correct and bounded, but needs `response` added to `filterset_fields` plus an `isnull` escape for the untriaged column, and five queries per board load.

Selection is page-scoped, which the bulk bar now states outright. Deleting a page's last row steps back a page first, because DRF answers an out-of-range page with a 404 rather than an empty one.

## Verification

```
$ uv run pytest -q
323 passed, 7 subtests passed

$ uv run pytest apps/threats/tests/test_risk_pagination.py -q
5 passed
```

Reverting the settings line to stock `PageNumberPagination` fails two of the five (`AssertionError: 20 != 24`), so those two gate the change rather than only describing it. The other three pass either way and pin the DRF behavior the frontend now depends on.

Against the seeded database:

```
default        -> count=24 rows=20 next=yes
?page=2        -> count=24 rows=4  next=no
?page_size=50  -> count=24 rows=24 next=no
```

That first line is the reproduction in #484 verbatim.

```
$ npm run build
✓ 2619 modules transformed
✓ built in 3.46s
```

**The UI itself is not verified.** This repo has no frontend tests and I have not clicked through the register in a browser. `tsc -b` and the bundle are clean; whether the page renders correctly is unchecked.

## Left out

`components/ui/pagination.tsx` is upstream shadcn v4 with its two import paths rewritten. `npx shadcn add pagination` was not used: it resolves upstream's `cn` import as an npm package and installs an unrelated `cn@0.2.6`, and prompts to overwrite `button.tsx`.

Thirteen other API modules share the `results`-and-discard shape. Nine viewsets set `pagination_class = None`, so every library, taxonomy and pack list is unaffected by it. The rest are follow-ups rather than scope here, tracked in #514.

No breaking changes.
